### PR TITLE
Fix card image surface fallbacks

### DIFF
--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -1019,9 +1019,10 @@ export default async function CardPage({
               const relatedCardImageSrc =
                 normalizeCardImageUrl(relatedCard.display_image_url ?? relatedCard.image_url) ?? undefined;
               const relatedCardImageFallback =
-                relatedCard.display_image_kind === "exact"
+                normalizeCardImageUrl(relatedCard.display_image_fallback_url) ??
+                (relatedCard.display_image_kind === "exact"
                   ? buildTcgDexImageUrl(relatedCard.tcgdex_external_id)
-                  : null;
+                  : null);
               return (
                 <Link
                   key={relatedCard.gv_id}

--- a/apps/web/src/components/compare/CompareWorkspace.tsx
+++ b/apps/web/src/components/compare/CompareWorkspace.tsx
@@ -289,7 +289,7 @@ export default function CompareWorkspace({
                 <div className="relative rounded-[12px] bg-slate-50 p-4">
                   <CardZoomModal
                     src={card.display_image_url ?? card.image_url}
-                    fallbackSrc={card.representative_image_url}
+                    fallbackSrc={card.display_image_fallback_url ?? card.representative_image_url}
                     alt={displayIdentity.display_name}
                     imageClassName="aspect-[3/4] w-full rounded-[12px] object-contain"
                     fallbackClassName="flex aspect-[3/4] items-center justify-center rounded-[12px] bg-slate-100 px-4 text-center text-sm text-slate-500"

--- a/apps/web/src/components/explore/ExploreDiscoverySections.tsx
+++ b/apps/web/src/components/explore/ExploreDiscoverySections.tsx
@@ -133,6 +133,7 @@ export default function ExploreDiscoverySections({
                       <div className="space-y-2 p-0">
                         <PublicCardImage
                           src={spotlightCard.display_image_url ?? spotlightCard.image_url}
+                          fallbackSrc={spotlightCard.display_image_fallback_url}
                           alt={getCardImageAltText(spotlightCard.display_name, spotlightCard)}
                           imageClassName="aspect-[3/4] w-full object-contain bg-[linear-gradient(180deg,_#ffffff_0%,_#f8fafc_100%)] p-3"
                           fallbackClassName="flex aspect-[3/4] items-center justify-center rounded-[1rem] bg-slate-100 px-4 text-center text-sm text-slate-500"
@@ -187,6 +188,7 @@ export default function ExploreDiscoverySections({
                             <div className="space-y-2">
                               <PublicCardImage
                                 src={card.display_image_url ?? card.image_url}
+                                fallbackSrc={card.display_image_fallback_url}
                                 alt={getCardImageAltText(card.display_name, card)}
                                 imageClassName="aspect-[3/4] w-full object-contain"
                                 fallbackClassName="flex aspect-[3/4] items-center justify-center rounded-[0.9rem] bg-slate-100 px-3 text-center text-xs text-slate-500"

--- a/apps/web/src/lib/cards/childDisplayImageFallbacks.ts
+++ b/apps/web/src/lib/cards/childDisplayImageFallbacks.ts
@@ -1,0 +1,158 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  resolveCardImageFieldsV1,
+  type CardDisplayImageKind,
+} from "@/lib/canon/resolveCardImageFieldsV1";
+
+export type ChildDisplayImageFallbackLookupRow = {
+  id?: string | null;
+  selected_printing_gv_id?: string | null;
+  search_card_printing_id?: string | null;
+  printing_gv_id?: string | null;
+  finish_key?: string | null;
+};
+
+type CardPrintingImageLookupRow = {
+  id: string;
+  card_print_id: string | null;
+  printing_gv_id: string | null;
+  finish_key: string | null;
+  image_url: string | null;
+  image_alt_url: string | null;
+  image_source?: string | null;
+  image_path?: string | null;
+  image_status?: string | null;
+  image_note?: string | null;
+};
+
+export type ChildDisplayImageFallback = {
+  display_image_url: string;
+  display_image_kind: CardDisplayImageKind;
+  image_status: string;
+  image_note: string;
+};
+
+const CHILD_FALLBACK_STATUS = "representative_missing_variant_visual";
+const CHILD_FALLBACK_NOTE =
+  "Correct card identity. Displaying the best reviewed child printing image until the parent identity image is available.";
+
+function uniqueValues(values: Array<string | null | undefined>) {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => value?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+}
+
+function hasChildImageEvidence(row: CardPrintingImageLookupRow) {
+  return Boolean(
+    row.image_path?.trim() ||
+      row.image_url?.trim() ||
+      row.image_alt_url?.trim(),
+  );
+}
+
+function imageKindScore(kind: string | null | undefined) {
+  if (kind === "exact") return 40;
+  if (kind === "representative" || kind === "missing_variant_visual") return 25;
+  return 10;
+}
+
+export async function getChildDisplayImageFallbacks(
+  supabase: Pick<SupabaseClient, "from">,
+  lookupRows: ChildDisplayImageFallbackLookupRow[],
+) {
+  const cardPrintIds = uniqueValues(lookupRows.map((row) => row.id));
+  const fallbackByCardPrintId = new Map<string, ChildDisplayImageFallback>();
+  if (cardPrintIds.length === 0) {
+    return fallbackByCardPrintId;
+  }
+
+  const { data, error } = await supabase
+    .from("card_printings")
+    .select(
+      "id,card_print_id,printing_gv_id,finish_key,image_source,image_path,image_url,image_alt_url,image_status,image_note",
+    )
+    .in("card_print_id", cardPrintIds);
+
+  if (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[image-fallback] child image lookup failed closed", {
+        message: error.message,
+      });
+    }
+    return fallbackByCardPrintId;
+  }
+
+  const childrenByParentId = new Map<string, CardPrintingImageLookupRow[]>();
+  for (const child of ((data ?? []) as CardPrintingImageLookupRow[]).filter(
+    hasChildImageEvidence,
+  )) {
+    if (!child.card_print_id) continue;
+    const existing = childrenByParentId.get(child.card_print_id) ?? [];
+    existing.push(child);
+    childrenByParentId.set(child.card_print_id, existing);
+  }
+
+  await Promise.all(
+    lookupRows.map(async (row) => {
+      const parentId = row.id?.trim();
+      if (!parentId) return;
+
+      const children = childrenByParentId.get(parentId) ?? [];
+      if (children.length === 0) return;
+
+      const selectedPrintingGvId =
+        row.selected_printing_gv_id?.trim() ||
+        row.search_card_printing_id?.trim() ||
+        row.printing_gv_id?.trim() ||
+        null;
+      const targetFinishKey = row.finish_key?.trim().toLowerCase() || null;
+      const resolved = await Promise.all(
+        children.map(async (child) => ({
+          child,
+          imageFields: await resolveCardImageFieldsV1(child),
+        })),
+      );
+
+      const best = resolved
+        .filter((entry) => Boolean(entry.imageFields.display_image_url))
+        .sort((left, right) => {
+          const leftSelected =
+            selectedPrintingGvId && left.child.printing_gv_id === selectedPrintingGvId ? 100 : 0;
+          const rightSelected =
+            selectedPrintingGvId && right.child.printing_gv_id === selectedPrintingGvId ? 100 : 0;
+          if (leftSelected !== rightSelected) return rightSelected - leftSelected;
+
+          const leftFinish =
+            targetFinishKey && left.child.finish_key?.toLowerCase() === targetFinishKey ? 20 : 0;
+          const rightFinish =
+            targetFinishKey && right.child.finish_key?.toLowerCase() === targetFinishKey ? 20 : 0;
+          if (leftFinish !== rightFinish) return rightFinish - leftFinish;
+
+          const leftKind = imageKindScore(left.imageFields.display_image_kind);
+          const rightKind = imageKindScore(right.imageFields.display_image_kind);
+          if (leftKind !== rightKind) return rightKind - leftKind;
+
+          return String(left.child.printing_gv_id ?? "").localeCompare(
+            String(right.child.printing_gv_id ?? ""),
+          );
+        })[0];
+
+      if (!best?.imageFields.display_image_url) return;
+
+      fallbackByCardPrintId.set(parentId, {
+        display_image_url: best.imageFields.display_image_url,
+        display_image_kind: "missing_variant_visual",
+        image_status: CHILD_FALLBACK_STATUS,
+        image_note: CHILD_FALLBACK_NOTE,
+      });
+    }),
+  );
+
+  return fallbackByCardPrintId;
+}

--- a/apps/web/src/lib/cards/getFeaturedExploreCards.ts
+++ b/apps/web/src/lib/cards/getFeaturedExploreCards.ts
@@ -3,10 +3,15 @@ import "server-only";
 import { cache } from "react";
 import { createPublicServerClient } from "@/lib/supabase/publicServer";
 import { resolveCardImageFieldsV1 } from "@/lib/canon/resolveCardImageFieldsV1";
+import {
+  getChildDisplayImageFallbacks,
+  type ChildDisplayImageFallback,
+} from "@/lib/cards/childDisplayImageFallbacks";
 import { getRotationOffset } from "@/lib/cards/getFeaturedCardRotation";
 import { resolveDisplayIdentity } from "@/lib/cards/resolveDisplayIdentity";
 
 type FeaturedExploreCardRow = {
+  id: string | null;
   gv_id: string | null;
   name: string | null;
   number: string | null;
@@ -50,19 +55,29 @@ export type FeaturedExploreCard = {
   image_note?: string;
   image_source?: string;
   display_image_url?: string;
+  display_image_fallback_url?: string;
   display_image_kind?: "exact" | "representative" | "missing_variant_visual" | "missing" | "blocked";
 };
 
 const FEATURED_EXPLORE_CARD_COUNT = 10;
 const FEATURED_EXPLORE_CANDIDATE_WINDOW = 48;
 
-async function normalizeFeaturedExploreCard(row: FeaturedExploreCardRow | null | undefined): Promise<FeaturedExploreCard | null> {
+async function normalizeFeaturedExploreCard(
+  row: FeaturedExploreCardRow | null | undefined,
+  childDisplayImageFallbacks = new Map<string, ChildDisplayImageFallback>(),
+): Promise<FeaturedExploreCard | null> {
   if (!row?.gv_id) {
     return null;
   }
 
   const setRecord = Array.isArray(row.sets) ? row.sets[0] : row.sets;
   const imageFields = await resolveCardImageFieldsV1(row);
+  const childDisplayImageFallback = row.id
+    ? childDisplayImageFallbacks.get(row.id)
+    : undefined;
+  const fallbackDisplayImage = !imageFields.display_image_url
+    ? childDisplayImageFallback
+    : undefined;
   const name = row.name?.trim() || "Unknown";
   const displayIdentity = resolveDisplayIdentity({
     name,
@@ -86,11 +101,22 @@ async function normalizeFeaturedExploreCard(row: FeaturedExploreCardRow | null |
     set_identity_model: setRecord?.identity_model?.trim() || undefined,
     image_url: imageFields.image_url ?? undefined,
     representative_image_url: imageFields.representative_image_url ?? undefined,
-    image_status: imageFields.image_status ?? undefined,
-    image_note: imageFields.image_note ?? undefined,
     image_source: imageFields.image_source ?? undefined,
-    display_image_url: imageFields.display_image_url ?? undefined,
-    display_image_kind: imageFields.display_image_kind,
+    display_image_url:
+      imageFields.display_image_url ??
+      fallbackDisplayImage?.display_image_url ??
+      undefined,
+    display_image_fallback_url:
+      childDisplayImageFallback?.display_image_url ?? undefined,
+    display_image_kind: fallbackDisplayImage
+      ? fallbackDisplayImage.display_image_kind
+      : imageFields.display_image_kind,
+    image_status: fallbackDisplayImage
+      ? fallbackDisplayImage.image_status
+      : imageFields.image_status ?? undefined,
+    image_note: fallbackDisplayImage
+      ? fallbackDisplayImage.image_note
+      : imageFields.image_note ?? undefined,
   } satisfies FeaturedExploreCard;
 }
 
@@ -115,7 +141,7 @@ async function getFeaturedExploreCardsFromWindow(offset: number, windowSize: num
   const supabase = createPublicServerClient();
   const { data, error } = await supabase
     .from("card_prints")
-    .select("gv_id,name,number,rarity,set_code,variant_key,printed_identity_modifier,image_url,image_alt_url,image_source,image_path,representative_image_url,image_status,image_note,sets(name,identity_model)")
+    .select("id,gv_id,name,number,rarity,set_code,variant_key,printed_identity_modifier,image_url,image_alt_url,image_source,image_path,representative_image_url,image_status,image_note,sets(name,identity_model)")
     .ilike("rarity", "%Special Illustration Rare%")
     .order("gv_id", { ascending: true })
     .range(offset, offset + windowSize - 1);
@@ -124,8 +150,15 @@ async function getFeaturedExploreCardsFromWindow(offset: number, windowSize: num
     throw error;
   }
 
+  const rows = (data ?? []) as FeaturedExploreCardRow[];
+  const childDisplayImageFallbacks = await getChildDisplayImageFallbacks(
+    supabase,
+    rows,
+  );
   const normalizedRows = await Promise.all(
-    ((data ?? []) as FeaturedExploreCardRow[]).map((row) => normalizeFeaturedExploreCard(row)),
+    rows.map((row) =>
+      normalizeFeaturedExploreCard(row, childDisplayImageFallbacks),
+    ),
   );
 
   return normalizedRows.filter((row): row is FeaturedExploreCard => Boolean(row?.gv_id));

--- a/apps/web/src/lib/cards/getPublicCardsByGvIds.ts
+++ b/apps/web/src/lib/cards/getPublicCardsByGvIds.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { getCompatiblePublicGvIdCandidates, pickResolvedPublicGvIdRow } from "@/lib/gvIdAlias";
 import { resolveCardImageFieldsV1 } from "@/lib/canon/resolveCardImageFieldsV1";
+import { getChildDisplayImageFallbacks } from "@/lib/cards/childDisplayImageFallbacks";
 import { getPublicPricingByCardIds } from "@/lib/pricing/getPublicPricingByCardIds";
 import { createPublicServerClient } from "@/lib/supabase/publicServer";
 import { normalizeCompareCardsParam } from "@/lib/compareCards";
@@ -25,6 +26,7 @@ export type ComparePublicCard = {
   image_note?: string;
   image_source?: string;
   display_image_url?: string;
+  display_image_fallback_url?: string;
   display_image_kind?: "exact" | "representative" | "missing_variant_visual" | "missing" | "blocked";
   raw_price?: number;
   raw_price_source?: string;
@@ -128,7 +130,10 @@ export async function getPublicCardsByGvIds(gvIds: string[]) {
 
   const rows = (data ?? []) as PublicCompareCardRow[];
   const cardIds = rows.map((row) => row.id).filter((value): value is string => Boolean(value));
-  const pricesByCardId = await getPublicPricingByCardIds(supabase, cardIds);
+  const [pricesByCardId, childDisplayImageFallbacks] = await Promise.all([
+    getPublicPricingByCardIds(supabase, cardIds),
+    getChildDisplayImageFallbacks(supabase, rows),
+  ]);
 
   const cards: ComparePublicCard[] = [];
 
@@ -143,6 +148,12 @@ export async function getPublicCardsByGvIds(gvIds: string[]) {
 
     const setRecord = Array.isArray(row.sets) ? row.sets[0] : row.sets;
     const imageFields = await resolveCardImageFieldsV1(row);
+    const childDisplayImageFallback = row.id
+      ? childDisplayImageFallbacks.get(row.id)
+      : undefined;
+    const fallbackDisplayImage = !imageFields.display_image_url
+      ? childDisplayImageFallback
+      : undefined;
 
     cards.push({
       id: row.id ?? row.gv_id,
@@ -158,11 +169,22 @@ export async function getPublicCardsByGvIds(gvIds: string[]) {
       artist: row.artist?.trim() || undefined,
       image_url: imageFields.image_url ?? undefined,
       representative_image_url: imageFields.representative_image_url ?? undefined,
-      image_status: imageFields.image_status ?? undefined,
-      image_note: imageFields.image_note ?? undefined,
       image_source: imageFields.image_source ?? undefined,
-      display_image_url: imageFields.display_image_url ?? undefined,
-      display_image_kind: imageFields.display_image_kind,
+      display_image_url:
+        imageFields.display_image_url ??
+        fallbackDisplayImage?.display_image_url ??
+        undefined,
+      display_image_fallback_url:
+        childDisplayImageFallback?.display_image_url ?? undefined,
+      display_image_kind: fallbackDisplayImage
+        ? fallbackDisplayImage.display_image_kind
+        : imageFields.display_image_kind,
+      image_status: fallbackDisplayImage
+        ? fallbackDisplayImage.image_status
+        : imageFields.image_status ?? undefined,
+      image_note: fallbackDisplayImage
+        ? fallbackDisplayImage.image_note
+        : imageFields.image_note ?? undefined,
       raw_price: row.id ? pricesByCardId.get(row.id)?.raw_price : undefined,
       raw_price_source: row.id ? pricesByCardId.get(row.id)?.raw_price_source : undefined,
       raw_price_ts: row.id ? pricesByCardId.get(row.id)?.raw_price_ts : undefined,

--- a/apps/web/src/lib/explore/getExploreRows.ts
+++ b/apps/web/src/lib/explore/getExploreRows.ts
@@ -13,6 +13,7 @@ import {
   getPublicPricingByCardIds,
   type PublicPricingRecord,
 } from "@/lib/pricing/getPublicPricingByCardIds";
+import { getChildDisplayImageFallbacks } from "@/lib/cards/childDisplayImageFallbacks";
 import {
   STRUCTURED_CARD_SET_ALIAS_MAP,
   normalizeSetQuery,
@@ -643,104 +644,6 @@ function extractTcgdexSetId(tcgdexCardId?: string) {
   return separatorIndex > 0 ? tcgdexCardId.slice(0, separatorIndex) : undefined;
 }
 
-function hasChildImageEvidence(row: CardPrintingImageLookupRow) {
-  return Boolean(
-    row.image_path?.trim() ||
-      row.image_url?.trim() ||
-      row.image_alt_url?.trim(),
-  );
-}
-
-function imageKindScore(kind: string | null | undefined) {
-  if (kind === "exact") return 40;
-  if (kind === "representative" || kind === "missing_variant_visual") return 25;
-  return 10;
-}
-
-async function fetchChildDisplayImageFallbacks(lookupRows: CardPrintLookupRow[]) {
-  const cardPrintIds = uniqueValues(lookupRows.map((row) => row.id).filter(Boolean));
-  const fallbackByCardPrintId = new Map<string, string>();
-  if (cardPrintIds.length === 0) {
-    return fallbackByCardPrintId;
-  }
-
-  const supabase = createServerComponentClient();
-  const { data, error } = await supabase
-    .from("card_printings")
-    .select(
-      "id,card_print_id,printing_gv_id,finish_key,image_source,image_path,image_url,image_alt_url,image_status,image_note",
-    )
-    .in("card_print_id", cardPrintIds);
-
-  if (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[explore] child image fallback lookup failed closed", {
-        message: error.message,
-      });
-    }
-    return fallbackByCardPrintId;
-  }
-
-  const childrenByParentId = new Map<string, CardPrintingImageLookupRow[]>();
-  for (const child of ((data ?? []) as CardPrintingImageLookupRow[]).filter(hasChildImageEvidence)) {
-    if (!child.card_print_id) continue;
-    const existing = childrenByParentId.get(child.card_print_id) ?? [];
-    existing.push(child);
-    childrenByParentId.set(child.card_print_id, existing);
-  }
-
-  await Promise.all(
-    lookupRows.map(async (row) => {
-      const children = childrenByParentId.get(row.id) ?? [];
-      if (children.length === 0) {
-        return;
-      }
-
-      const selectedPrintingGvId =
-        row.selected_printing_gv_id?.trim() ||
-        row.search_card_printing_id?.trim() ||
-        row.printing_gv_id?.trim() ||
-        null;
-      const targetFinishKey = row.finish_key?.trim().toLowerCase() || null;
-
-      const resolved = await Promise.all(
-        children.map(async (child) => ({
-          child,
-          imageFields: await resolveCardImageFieldsV1(child),
-        })),
-      );
-
-      const best = resolved
-        .filter((entry) => Boolean(entry.imageFields.display_image_url))
-        .sort((left, right) => {
-          const leftSelected =
-            selectedPrintingGvId && left.child.printing_gv_id === selectedPrintingGvId ? 100 : 0;
-          const rightSelected =
-            selectedPrintingGvId && right.child.printing_gv_id === selectedPrintingGvId ? 100 : 0;
-          if (leftSelected !== rightSelected) return rightSelected - leftSelected;
-
-          const leftFinish =
-            targetFinishKey && left.child.finish_key?.toLowerCase() === targetFinishKey ? 20 : 0;
-          const rightFinish =
-            targetFinishKey && right.child.finish_key?.toLowerCase() === targetFinishKey ? 20 : 0;
-          if (leftFinish !== rightFinish) return rightFinish - leftFinish;
-
-          const leftKind = imageKindScore(left.imageFields.display_image_kind);
-          const rightKind = imageKindScore(right.imageFields.display_image_kind);
-          if (leftKind !== rightKind) return rightKind - leftKind;
-
-          return String(left.child.printing_gv_id ?? "").localeCompare(String(right.child.printing_gv_id ?? ""));
-        })[0];
-
-      if (best?.imageFields.display_image_url) {
-        fallbackByCardPrintId.set(row.id, best.imageFields.display_image_url);
-      }
-    }),
-  );
-
-  return fallbackByCardPrintId;
-}
-
 function toNumberDigits(value?: string | null) {
   const digits = (value ?? "").replace(/\D/g, "");
   return digits || undefined;
@@ -854,7 +757,10 @@ async function buildExploreRows(
   const rows = lookupRows.filter(
     (row): row is CardPrintLookupRow & { gv_id: string } => Boolean(row.gv_id),
   );
-  const childDisplayImageFallbacks = await fetchChildDisplayImageFallbacks(rows);
+  const childDisplayImageFallbacks = await getChildDisplayImageFallbacks(
+    createServerComponentClient(),
+    rows,
+  );
 
   return Promise.all(
     rows.map(async (row) => {
@@ -865,8 +771,10 @@ async function buildExploreRows(
         : undefined;
       const imageFields = await resolveCardImageFieldsV1(row);
       const childDisplayImageFallback = childDisplayImageFallbacks.get(row.id);
-      const displayImageUrl = imageFields.display_image_url ?? childDisplayImageFallback;
-      const isUsingChildDisplayFallback = Boolean(!imageFields.display_image_url && childDisplayImageFallback);
+      const fallbackDisplayImage = !imageFields.display_image_url
+        ? childDisplayImageFallback
+        : undefined;
+      const displayImageUrl = imageFields.display_image_url ?? fallbackDisplayImage?.display_image_url;
 
       return {
         id: row.id,
@@ -883,15 +791,15 @@ async function buildExploreRows(
         representative_image_url: imageFields.representative_image_url ?? undefined,
         image_source: imageFields.image_source ?? undefined,
         display_image_url: displayImageUrl ?? undefined,
-        display_image_fallback_url: childDisplayImageFallback ?? undefined,
-        display_image_kind: isUsingChildDisplayFallback
-          ? "missing_variant_visual"
+        display_image_fallback_url: childDisplayImageFallback?.display_image_url ?? undefined,
+        display_image_kind: fallbackDisplayImage
+          ? fallbackDisplayImage.display_image_kind
           : imageFields.display_image_kind,
-        image_status: isUsingChildDisplayFallback
-          ? "representative_missing_variant_visual"
+        image_status: fallbackDisplayImage
+          ? fallbackDisplayImage.image_status
           : imageFields.image_status ?? undefined,
-        image_note: isUsingChildDisplayFallback
-          ? "Correct printing. Displaying a representative/base image until exact variant imagery is available."
+        image_note: fallbackDisplayImage
+          ? fallbackDisplayImage.image_note
           : imageFields.image_note ?? undefined,
         release_date: setMetadata?.release_date,
         release_year: setMetadata?.release_year,

--- a/apps/web/src/lib/getAdjacentPublicCardsByGvId.ts
+++ b/apps/web/src/lib/getAdjacentPublicCardsByGvId.ts
@@ -1,6 +1,10 @@
 import { cache } from "react";
 import { getCompatiblePublicGvIdCandidates, pickResolvedPublicGvIdRow } from "@/lib/gvIdAlias";
 import { resolveCardImageFieldsV1 } from "@/lib/canon/resolveCardImageFieldsV1";
+import {
+  getChildDisplayImageFallbacks,
+  type ChildDisplayImageFallback,
+} from "@/lib/cards/childDisplayImageFallbacks";
 import { createPublicServerClient } from "@/lib/supabase/publicServer";
 
 type CardNavigationSeedRow = {
@@ -9,6 +13,7 @@ type CardNavigationSeedRow = {
 };
 
 type CardNavigationRow = {
+  id: string | null;
   gv_id: string | null;
   name: string | null;
   set_code: string | null;
@@ -106,11 +111,20 @@ function extractTcgdexExternalId(externalIds?: { tcgdex?: string | null } | null
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-async function toAdjacentCard(row?: CardNavigationRow): Promise<AdjacentPublicCard | undefined> {
+async function toAdjacentCard(
+  row?: CardNavigationRow,
+  childDisplayImageFallbacks = new Map<string, ChildDisplayImageFallback>(),
+): Promise<AdjacentPublicCard | undefined> {
   if (!row?.gv_id) return undefined;
 
   const imageFields = await resolveCardImageFieldsV1(row);
   const setRecord = Array.isArray(row.sets) ? row.sets[0] : row.sets;
+  const childDisplayImageFallback = row.id
+    ? childDisplayImageFallbacks.get(row.id)
+    : undefined;
+  const fallbackDisplayImage = !imageFields.display_image_url
+    ? childDisplayImageFallback
+    : undefined;
 
   return {
     gv_id: row.gv_id,
@@ -122,11 +136,20 @@ async function toAdjacentCard(row?: CardNavigationRow): Promise<AdjacentPublicCa
     printed_identity_modifier: row.printed_identity_modifier?.trim() || undefined,
     image_url: imageFields.image_url ?? undefined,
     representative_image_url: imageFields.representative_image_url ?? undefined,
-    image_status: imageFields.image_status ?? undefined,
-    image_note: imageFields.image_note ?? undefined,
     image_source: imageFields.image_source ?? undefined,
-    display_image_url: imageFields.display_image_url ?? undefined,
-    display_image_kind: imageFields.display_image_kind,
+    display_image_url:
+      imageFields.display_image_url ??
+      fallbackDisplayImage?.display_image_url ??
+      undefined,
+    display_image_kind: fallbackDisplayImage
+      ? fallbackDisplayImage.display_image_kind
+      : imageFields.display_image_kind,
+    image_status: fallbackDisplayImage
+      ? fallbackDisplayImage.image_status
+      : imageFields.image_status ?? undefined,
+    image_note: fallbackDisplayImage
+      ? fallbackDisplayImage.image_note
+      : imageFields.image_note ?? undefined,
     tcgdex_external_id: extractTcgdexExternalId(row.external_ids),
   };
 }
@@ -154,7 +177,7 @@ export const getAdjacentPublicCardsByGvId = cache(async (gv_id: string): Promise
   const { data: setRows, error: setError } = await supabase
     .from("card_prints")
     .select(
-      "gv_id,name,set_code,number,number_plain,variant_key,printed_identity_modifier,image_url,image_alt_url,image_source,image_path,representative_image_url,image_status,image_note,external_ids,sets(identity_model)",
+      "id,gv_id,name,set_code,number,number_plain,variant_key,printed_identity_modifier,image_url,image_alt_url,image_source,image_path,representative_image_url,image_status,image_note,external_ids,sets(identity_model)",
     )
     .eq("set_code", currentCard.set_code)
     .not("gv_id", "is", null);
@@ -176,9 +199,17 @@ export const getAdjacentPublicCardsByGvId = cache(async (gv_id: string): Promise
     return {};
   }
 
+  const adjacentRows = [orderedRows[currentIndex - 1], orderedRows[currentIndex + 1]].filter(
+    (row): row is CardNavigationRow & { gv_id: string } => Boolean(row),
+  );
+  const childDisplayImageFallbacks = await getChildDisplayImageFallbacks(
+    supabase,
+    adjacentRows,
+  );
+
   const [previous, next] = await Promise.all([
-    toAdjacentCard(orderedRows[currentIndex - 1]),
-    toAdjacentCard(orderedRows[currentIndex + 1]),
+    toAdjacentCard(orderedRows[currentIndex - 1], childDisplayImageFallbacks),
+    toAdjacentCard(orderedRows[currentIndex + 1], childDisplayImageFallbacks),
   ]);
 
   return { previous, next };

--- a/apps/web/src/lib/getPublicCardByGvId.ts
+++ b/apps/web/src/lib/getPublicCardByGvId.ts
@@ -10,6 +10,10 @@ import {
 } from "@/lib/gvIdAlias";
 import { getPublicPricingByCardIds } from "@/lib/pricing/getPublicPricingByCardIds";
 import { normalizePublicSetDisplayName } from "@/lib/publicSets.shared";
+import {
+  getChildDisplayImageFallbacks,
+  type ChildDisplayImageFallback,
+} from "@/lib/cards/childDisplayImageFallbacks";
 import type { VariantFlags } from "@/lib/cards/variantPresentation";
 import type {
   ActiveCardPrintIdentity,
@@ -307,6 +311,7 @@ function mapTraitRecord(
 
 async function mapRelatedPrints(
   rows: RelatedCardRow[],
+  childDisplayImageFallbacks = new Map<string, ChildDisplayImageFallback>(),
 ): Promise<RelatedCardPrint[] | undefined> {
   if (rows.length === 0) {
     return undefined;
@@ -322,6 +327,12 @@ async function mapRelatedPrints(
 
     const setRecord = Array.isArray(row.sets) ? row.sets[0] : row.sets;
     const imageFields = await resolveCardImageFieldsV1(row);
+    const childDisplayImageFallback = row.id
+      ? childDisplayImageFallbacks.get(row.id)
+      : undefined;
+    const fallbackDisplayImage = !imageFields.display_image_url
+      ? childDisplayImageFallback
+      : undefined;
 
     mapped.set(gvId, {
       id: row.id ?? gvId,
@@ -335,11 +346,22 @@ async function mapRelatedPrints(
       image_url: imageFields.image_url ?? undefined,
       representative_image_url:
         imageFields.representative_image_url ?? undefined,
-      image_status: imageFields.image_status ?? undefined,
-      image_note: imageFields.image_note ?? undefined,
       image_source: imageFields.image_source ?? undefined,
-      display_image_url: imageFields.display_image_url ?? undefined,
-      display_image_kind: imageFields.display_image_kind,
+      display_image_url:
+        imageFields.display_image_url ??
+        fallbackDisplayImage?.display_image_url ??
+        undefined,
+      display_image_fallback_url:
+        childDisplayImageFallback?.display_image_url ?? undefined,
+      display_image_kind: fallbackDisplayImage
+        ? fallbackDisplayImage.display_image_kind
+        : imageFields.display_image_kind,
+      image_status: fallbackDisplayImage
+        ? fallbackDisplayImage.image_status
+        : imageFields.image_status ?? undefined,
+      image_note: fallbackDisplayImage
+        ? fallbackDisplayImage.image_note
+        : imageFields.image_note ?? undefined,
       tcgdex_external_id: extractTcgdexExternalId(row.external_ids),
       release_date: setRecord?.release_date ?? undefined,
       release_year: getReleaseYear(setRecord?.release_date),
@@ -548,9 +570,13 @@ async function getRelatedPrintsByName(
     return undefined;
   }
 
-  return mapRelatedPrints(
-    (data as RelatedCardRow[]).filter((row) => row.id !== excludeId),
+  const rows = (data as RelatedCardRow[]).filter((row) => row.id !== excludeId);
+  const childDisplayImageFallbacks = await getChildDisplayImageFallbacks(
+    supabase,
+    rows,
   );
+
+  return mapRelatedPrints(rows, childDisplayImageFallbacks);
 }
 
 async function getCameosByGvId(

--- a/docs/audits/image_truth_v1/image_surface_consistency_scan_v1.json
+++ b/docs/audits/image_truth_v1/image_surface_consistency_scan_v1.json
@@ -1,0 +1,1107 @@
+{
+  "contract": "IMAGE_SURFACE_CONSISTENCY_SCAN_V1",
+  "generated_at": "2026-06-22T22:40:59.452Z",
+  "parent_rows_scanned": 25018,
+  "child_rows_scanned": 44137,
+  "surface_coverage": {
+    "helper_exists": true,
+    "data_surfaces": {
+      "apps/web/src/lib/getPublicCardByGvId.ts": true,
+      "apps/web/src/lib/getAdjacentPublicCardsByGvId.ts": true,
+      "apps/web/src/lib/cards/getPublicCardsByGvIds.ts": true,
+      "apps/web/src/lib/explore/getExploreRows.ts": true,
+      "apps/web/src/lib/cards/getFeaturedExploreCards.ts": true
+    },
+    "ui_fallback_surfaces": {
+      "apps/web/src/app/card/[gv_id]/page.tsx": true,
+      "apps/web/src/components/compare/CompareWorkspace.tsx": true,
+      "apps/web/src/components/explore/ExploreDiscoverySections.tsx": true,
+      "apps/web/src/components/explore/ExploreCardGridItem.tsx": true,
+      "apps/web/src/components/explore/ExploreCardListItem.tsx": true,
+      "apps/web/src/components/explore/ExploreCardDetailsRow.tsx": true
+    },
+    "passed": true
+  },
+  "known_cases": {
+    "GV-PK-MEP-051": true
+  },
+  "parent_missing_child_available": {
+    "count": 298,
+    "by_set": [
+      {
+        "set_code": "sm115",
+        "count": 94
+      },
+      {
+        "set_code": "mep",
+        "count": 72
+      },
+      {
+        "set_code": "mfb",
+        "count": 34
+      },
+      {
+        "set_code": "bw11",
+        "count": 20
+      },
+      {
+        "set_code": "2023sv",
+        "count": 15
+      },
+      {
+        "set_code": "2024sv",
+        "count": 15
+      },
+      {
+        "set_code": "mee",
+        "count": 8
+      },
+      {
+        "set_code": "sve",
+        "count": 8
+      },
+      {
+        "set_code": "svp",
+        "count": 7
+      },
+      {
+        "set_code": "xya",
+        "count": 6
+      },
+      {
+        "set_code": "ecard2",
+        "count": 5
+      },
+      {
+        "set_code": "ecard3",
+        "count": 5
+      },
+      {
+        "set_code": "col1",
+        "count": 3
+      },
+      {
+        "set_code": "bwp",
+        "count": 2
+      },
+      {
+        "set_code": "g1",
+        "count": 1
+      },
+      {
+        "set_code": "sm4",
+        "count": 1
+      },
+      {
+        "set_code": "swshp",
+        "count": 1
+      },
+      {
+        "set_code": "xy7",
+        "count": 1
+      }
+    ],
+    "examples": [
+      {
+        "gv_id": "GV-PK-MCD-2023-1",
+        "name": "Sprigatito",
+        "set_code": "2023sv",
+        "number": "1",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-1-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-10",
+        "name": "Sandaconda",
+        "set_code": "2023sv",
+        "number": "10",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-10-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-11",
+        "name": "Klawf",
+        "set_code": "2023sv",
+        "number": "11",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-11-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-12",
+        "name": "Blissey",
+        "set_code": "2023sv",
+        "number": "12",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-12-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-13",
+        "name": "Tandemaus",
+        "set_code": "2023sv",
+        "number": "13",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-13-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-14",
+        "name": "Cyclizar",
+        "set_code": "2023sv",
+        "number": "14",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-14-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-15",
+        "name": "Kirlia",
+        "set_code": "2023sv",
+        "number": "15",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-15-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-2",
+        "name": "Fuecoco",
+        "set_code": "2023sv",
+        "number": "2",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-2-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-3",
+        "name": "Quaxly",
+        "set_code": "2023sv",
+        "number": "3",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-3-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-4",
+        "name": "Cetoddle",
+        "set_code": "2023sv",
+        "number": "4",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-4-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-5",
+        "name": "Cetitan",
+        "set_code": "2023sv",
+        "number": "5",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-5-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-6",
+        "name": "Pikachu",
+        "set_code": "2023sv",
+        "number": "6",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-6-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-7",
+        "name": "Pawmi",
+        "set_code": "2023sv",
+        "number": "7",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-7-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-8",
+        "name": "Kilowattrel",
+        "set_code": "2023sv",
+        "number": "8",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-8-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2023-9",
+        "name": "Flittle",
+        "set_code": "2023sv",
+        "number": "9",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2023-9-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-1",
+        "name": "Charizard",
+        "set_code": "2024sv",
+        "number": "1",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-1-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-10",
+        "name": "Hydreigon",
+        "set_code": "2024sv",
+        "number": "10",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-10-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-11",
+        "name": "Roaring Moon",
+        "set_code": "2024sv",
+        "number": "11",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-11-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-12",
+        "name": "Dragonite",
+        "set_code": "2024sv",
+        "number": "12",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-12-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-13",
+        "name": "Eevee",
+        "set_code": "2024sv",
+        "number": "13",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-13-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-14",
+        "name": "Rayquaza",
+        "set_code": "2024sv",
+        "number": "14",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-14-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-15",
+        "name": "Drampa",
+        "set_code": "2024sv",
+        "number": "15",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-15-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-2",
+        "name": "Pikachu",
+        "set_code": "2024sv",
+        "number": "2",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-2-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-3",
+        "name": "Miraidon",
+        "set_code": "2024sv",
+        "number": "3",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-3-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-4",
+        "name": "Jigglypuff",
+        "set_code": "2024sv",
+        "number": "4",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-4-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-5",
+        "name": "Hatenna",
+        "set_code": "2024sv",
+        "number": "5",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-5-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-6",
+        "name": "Dragapult",
+        "set_code": "2024sv",
+        "number": "6",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-6-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-7",
+        "name": "Quagsire",
+        "set_code": "2024sv",
+        "number": "7",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-7-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-8",
+        "name": "Koraidon",
+        "set_code": "2024sv",
+        "number": "8",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-8-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MCD-2024-9",
+        "name": "Umbreon",
+        "set_code": "2024sv",
+        "number": "9",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MCD-2024-9-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC1",
+        "name": "Snivy",
+        "set_code": "bw11",
+        "number": "RC1",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC1-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC10",
+        "name": "Gardevoir",
+        "set_code": "bw11",
+        "number": "RC10",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC10-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC12",
+        "name": "Stunfisk",
+        "set_code": "bw11",
+        "number": "RC12",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC12-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC13",
+        "name": "Purrloin",
+        "set_code": "bw11",
+        "number": "RC13",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC13-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC14",
+        "name": "Eevee",
+        "set_code": "bw11",
+        "number": "RC14",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC14-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC15",
+        "name": "Teddiursa",
+        "set_code": "bw11",
+        "number": "RC15",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC15-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC16",
+        "name": "Ursaring",
+        "set_code": "bw11",
+        "number": "RC16",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC16-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC18",
+        "name": "Minccino",
+        "set_code": "bw11",
+        "number": "RC18",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC18-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC19",
+        "name": "Cinccino",
+        "set_code": "bw11",
+        "number": "RC19",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC19-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC20",
+        "name": "Elesa",
+        "set_code": "bw11",
+        "number": "RC20",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC20-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC21",
+        "name": "Shaymin-EX",
+        "set_code": "bw11",
+        "number": "RC21",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC21-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC22",
+        "name": "Reshiram",
+        "set_code": "bw11",
+        "number": "RC22",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC22-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC23",
+        "name": "Emolga",
+        "set_code": "bw11",
+        "number": "RC23",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC23-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC24",
+        "name": "Mew-EX",
+        "set_code": "bw11",
+        "number": "RC24",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC24-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC3",
+        "name": "Serperior",
+        "set_code": "bw11",
+        "number": "RC3",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC3-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC4",
+        "name": "Growlithe",
+        "set_code": "bw11",
+        "number": "RC4",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC4-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC5",
+        "name": "Torchic",
+        "set_code": "bw11",
+        "number": "RC5",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC5-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC6",
+        "name": "Piplup",
+        "set_code": "bw11",
+        "number": "RC6",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC6-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC7",
+        "name": "Pikachu",
+        "set_code": "bw11",
+        "number": "RC7",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC7-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-LTR-RC9",
+        "name": "Kirlia",
+        "set_code": "bw11",
+        "number": "RC9",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-LTR-RC9-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-PR-BLW-BW004",
+        "name": "Reshiram",
+        "set_code": "bwp",
+        "number": "BW004",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-PR-BLW-BW004-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-PR-BLW-BW005",
+        "name": "Zekrom",
+        "set_code": "bwp",
+        "number": "BW005",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-PR-BLW-BW005-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-COL-1",
+        "name": "Clefable",
+        "set_code": "col1",
+        "number": "1",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-COL-1-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-COL-10",
+        "name": "Houndoom",
+        "set_code": "col1",
+        "number": "10",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-COL-10-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-COL-5",
+        "name": "Forretress",
+        "set_code": "col1",
+        "number": "5",
+        "image_status": null,
+        "child_count": 3,
+        "first_child_printing_gv_id": "GV-PK-COL-5-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-AQ-H1",
+        "name": "Ampharos",
+        "set_code": "ecard2",
+        "number": "H1",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-AQ-H1-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-AQ-H5",
+        "name": "Bellossom",
+        "set_code": "ecard2",
+        "number": "H5",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-AQ-H5-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-AQ-H6",
+        "name": "Blissey",
+        "set_code": "ecard2",
+        "number": "H6",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-AQ-H6-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-AQ-H7",
+        "name": "Electrode",
+        "set_code": "ecard2",
+        "number": "H7",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-AQ-H7-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-AQ-H9",
+        "name": "Espeon",
+        "set_code": "ecard2",
+        "number": "H9",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-AQ-H9-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-SK-H1",
+        "name": "Alakazam",
+        "set_code": "ecard3",
+        "number": "H1",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-SK-H1-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-SK-H2",
+        "name": "Arcanine",
+        "set_code": "ecard3",
+        "number": "H2",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-SK-H2-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-SK-H3",
+        "name": "Articuno",
+        "set_code": "ecard3",
+        "number": "H3",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-SK-H3-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-SK-H5",
+        "name": "Crobat",
+        "set_code": "ecard3",
+        "number": "H5",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-SK-H5-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-SK-H7",
+        "name": "Flareon",
+        "set_code": "ecard3",
+        "number": "H7",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-SK-H7-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-GEN-73A",
+        "name": "Team Flare Grunt",
+        "set_code": "g1",
+        "number": "73a",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-GEN-73A-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MEE-001",
+        "name": "Basic Grass Energy",
+        "set_code": "mee",
+        "number": "001",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-001-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-MEE-002",
+        "name": "Basic Fire Energy",
+        "set_code": "mee",
+        "number": "002",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-002-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-MEE-003",
+        "name": "Basic Water Energy",
+        "set_code": "mee",
+        "number": "003",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-003-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MEE-004",
+        "name": "Basic Lightning Energy",
+        "set_code": "mee",
+        "number": "004",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-004-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-MEE-005",
+        "name": "Basic Psychic Energy",
+        "set_code": "mee",
+        "number": "005",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-005-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MEE-006",
+        "name": "Basic Fighting Energy",
+        "set_code": "mee",
+        "number": "006",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-006-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-MEE-007",
+        "name": "Basic Darkness Energy",
+        "set_code": "mee",
+        "number": "007",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-007-RH",
+        "first_child_finish_key": "reverse"
+      },
+      {
+        "gv_id": "GV-PK-MEE-008",
+        "name": "Basic Metal Energy",
+        "set_code": "mee",
+        "number": "008",
+        "image_status": null,
+        "child_count": 2,
+        "first_child_printing_gv_id": "GV-PK-MEE-008-STD",
+        "first_child_finish_key": "normal"
+      },
+      {
+        "gv_id": "GV-PK-MEP-011",
+        "name": "Mega Latias ex",
+        "set_code": "mep",
+        "number": "011",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-011-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-012",
+        "name": "Mega Lucario ex",
+        "set_code": "mep",
+        "number": "012",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-012-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-013",
+        "name": "Mega Venusaur ex",
+        "set_code": "mep",
+        "number": "013",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-013-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-014",
+        "name": "Ceruledge",
+        "set_code": "mep",
+        "number": "014",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-014-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-015",
+        "name": "Zacian",
+        "set_code": "mep",
+        "number": "015",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-015-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-016",
+        "name": "Flygon",
+        "set_code": "mep",
+        "number": "016",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-016-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-017",
+        "name": "Toxtricity",
+        "set_code": "mep",
+        "number": "017",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-017-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-018",
+        "name": "Cottonee",
+        "set_code": "mep",
+        "number": "018",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-018-COSMOS",
+        "first_child_finish_key": "cosmos"
+      },
+      {
+        "gv_id": "GV-PK-MEP-019",
+        "name": "Whimsicott",
+        "set_code": "mep",
+        "number": "019",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-019-COSMOS",
+        "first_child_finish_key": "cosmos"
+      },
+      {
+        "gv_id": "GV-PK-MEP-020",
+        "name": "Sneasel",
+        "set_code": "mep",
+        "number": "020",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-020-COSMOS",
+        "first_child_finish_key": "cosmos"
+      },
+      {
+        "gv_id": "GV-PK-MEP-021",
+        "name": "Weavile",
+        "set_code": "mep",
+        "number": "021",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-021-COSMOS",
+        "first_child_finish_key": "cosmos"
+      },
+      {
+        "gv_id": "GV-PK-MEP-022-POKEMON-CENTER-STAMP",
+        "name": "Charcadet",
+        "set_code": "mep",
+        "number": "022",
+        "image_status": "representative_shared_stamp",
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-022-POKEMON-CENTER-STAMP-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-022",
+        "name": "Charcadet",
+        "set_code": "mep",
+        "number": "022",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-022-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-023",
+        "name": "Mega Charizard X ex",
+        "set_code": "mep",
+        "number": "023",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-023-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-024",
+        "name": "Oricorio ex",
+        "set_code": "mep",
+        "number": "024",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-024-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-025",
+        "name": "Mega Kangaskhan ex",
+        "set_code": "mep",
+        "number": "025",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-025-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-026",
+        "name": "Meloetta",
+        "set_code": "mep",
+        "number": "026",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-026-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-027",
+        "name": "Haunter",
+        "set_code": "mep",
+        "number": "027",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-027-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-028",
+        "name": "Celebratory Fanfare",
+        "set_code": "mep",
+        "number": "028",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-028-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-029",
+        "name": "Mega Charizard X ex",
+        "set_code": "mep",
+        "number": "029",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-029-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-030",
+        "name": "Mega Charizard Y ex",
+        "set_code": "mep",
+        "number": "030",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-030-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-031",
+        "name": "N's Zekrom",
+        "set_code": "mep",
+        "number": "031",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-031-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-031-POKEMON-CENTER-STAMP",
+        "name": "N's Zekrom",
+        "set_code": "mep",
+        "number": "031",
+        "image_status": "representative_shared_stamp",
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-031-POKEMON-CENTER-STAMP-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-032",
+        "name": "Mega Gardevoir ex",
+        "set_code": "mep",
+        "number": "032",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-032-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-033",
+        "name": "Mega Lucario ex",
+        "set_code": "mep",
+        "number": "033",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-033-HOLO",
+        "first_child_finish_key": "holo"
+      },
+      {
+        "gv_id": "GV-PK-MEP-034",
+        "name": "Mega Meganium ex",
+        "set_code": "mep",
+        "number": "034",
+        "image_status": null,
+        "child_count": 1,
+        "first_child_printing_gv_id": "GV-PK-MEP-034-HOLO",
+        "first_child_finish_key": "holo"
+      }
+    ]
+  }
+}

--- a/docs/audits/image_truth_v1/image_surface_consistency_scan_v1.md
+++ b/docs/audits/image_truth_v1/image_surface_consistency_scan_v1.md
@@ -1,0 +1,68 @@
+# Image Surface Consistency Scan V1
+
+Generated: 2026-06-22T22:40:59.452Z
+
+## Summary
+
+- Parent identities scanned: 25018
+- Child printings scanned: 44137
+- Parent identities with no parent image evidence but at least one child image: 298
+- Surface coverage gate: PASS
+- Known Oshawott case covered: YES
+
+## Surface Coverage
+
+| Surface | Uses shared child fallback |
+| --- | --- |
+| apps/web/src/lib/getPublicCardByGvId.ts | yes |
+| apps/web/src/lib/getAdjacentPublicCardsByGvId.ts | yes |
+| apps/web/src/lib/cards/getPublicCardsByGvIds.ts | yes |
+| apps/web/src/lib/explore/getExploreRows.ts | yes |
+| apps/web/src/lib/cards/getFeaturedExploreCards.ts | yes |
+
+## Top Sets
+
+| Set code | Count |
+| --- | ---: |
+| sm115 | 94 |
+| mep | 72 |
+| mfb | 34 |
+| bw11 | 20 |
+| 2023sv | 15 |
+| 2024sv | 15 |
+| mee | 8 |
+| sve | 8 |
+| svp | 7 |
+| xya | 6 |
+| ecard2 | 5 |
+| ecard3 | 5 |
+
+## Examples
+
+| GV ID | Name | Set | Number | Child images |
+| --- | --- | --- | --- | ---: |
+| GV-PK-MCD-2023-1 | Sprigatito | 2023sv | 1 | 1 |
+| GV-PK-MCD-2023-10 | Sandaconda | 2023sv | 10 | 1 |
+| GV-PK-MCD-2023-11 | Klawf | 2023sv | 11 | 1 |
+| GV-PK-MCD-2023-12 | Blissey | 2023sv | 12 | 1 |
+| GV-PK-MCD-2023-13 | Tandemaus | 2023sv | 13 | 1 |
+| GV-PK-MCD-2023-14 | Cyclizar | 2023sv | 14 | 1 |
+| GV-PK-MCD-2023-15 | Kirlia | 2023sv | 15 | 1 |
+| GV-PK-MCD-2023-2 | Fuecoco | 2023sv | 2 | 1 |
+| GV-PK-MCD-2023-3 | Quaxly | 2023sv | 3 | 1 |
+| GV-PK-MCD-2023-4 | Cetoddle | 2023sv | 4 | 1 |
+| GV-PK-MCD-2023-5 | Cetitan | 2023sv | 5 | 1 |
+| GV-PK-MCD-2023-6 | Pikachu | 2023sv | 6 | 1 |
+| GV-PK-MCD-2023-7 | Pawmi | 2023sv | 7 | 1 |
+| GV-PK-MCD-2023-8 | Kilowattrel | 2023sv | 8 | 1 |
+| GV-PK-MCD-2023-9 | Flittle | 2023sv | 9 | 1 |
+| GV-PK-MCD-2024-1 | Charizard | 2024sv | 1 | 1 |
+| GV-PK-MCD-2024-10 | Hydreigon | 2024sv | 10 | 1 |
+| GV-PK-MCD-2024-11 | Roaring Moon | 2024sv | 11 | 1 |
+| GV-PK-MCD-2024-12 | Dragonite | 2024sv | 12 | 1 |
+| GV-PK-MCD-2024-13 | Eevee | 2024sv | 13 | 1 |
+| GV-PK-MCD-2024-14 | Rayquaza | 2024sv | 14 | 1 |
+| GV-PK-MCD-2024-15 | Drampa | 2024sv | 15 | 1 |
+| GV-PK-MCD-2024-2 | Pikachu | 2024sv | 2 | 1 |
+| GV-PK-MCD-2024-3 | Miraidon | 2024sv | 3 | 1 |
+| GV-PK-MCD-2024-4 | Jigglypuff | 2024sv | 4 | 1 |

--- a/scripts/audits/image_surface_consistency_scan_v1.mjs
+++ b/scripts/audits/image_surface_consistency_scan_v1.mjs
@@ -1,0 +1,249 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createClient } from "@supabase/supabase-js";
+import { config as loadDotenv } from "dotenv";
+
+loadDotenv({ path: ".env.local", quiet: true });
+loadDotenv({ path: ".env", quiet: true });
+
+const OUT_DIR = "docs/audits/image_truth_v1";
+const JSON_OUT = path.join(OUT_DIR, "image_surface_consistency_scan_v1.json");
+const MD_OUT = path.join(OUT_DIR, "image_surface_consistency_scan_v1.md");
+
+const SURFACE_FILES = [
+  "apps/web/src/lib/getPublicCardByGvId.ts",
+  "apps/web/src/lib/getAdjacentPublicCardsByGvId.ts",
+  "apps/web/src/lib/cards/getPublicCardsByGvIds.ts",
+  "apps/web/src/lib/explore/getExploreRows.ts",
+  "apps/web/src/lib/cards/getFeaturedExploreCards.ts",
+];
+
+const UI_FALLBACK_FILES = [
+  "apps/web/src/app/card/[gv_id]/page.tsx",
+  "apps/web/src/components/compare/CompareWorkspace.tsx",
+  "apps/web/src/components/explore/ExploreDiscoverySections.tsx",
+  "apps/web/src/components/explore/ExploreCardGridItem.tsx",
+  "apps/web/src/components/explore/ExploreCardListItem.tsx",
+  "apps/web/src/components/explore/ExploreCardDetailsRow.tsx",
+];
+
+function requiredEnv(nameCandidates) {
+  for (const name of nameCandidates) {
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  throw new Error(`Missing required env var: ${nameCandidates.join(" or ")}`);
+}
+
+function hasText(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasParentImageEvidence(row) {
+  return Boolean(
+    hasText(row.image_path) ||
+      hasText(row.image_url) ||
+      hasText(row.image_alt_url) ||
+      hasText(row.representative_image_url),
+  );
+}
+
+function hasChildImageEvidence(row) {
+  return Boolean(
+    hasText(row.image_path) ||
+      hasText(row.image_url) ||
+      hasText(row.image_alt_url),
+  );
+}
+
+async function fetchAll(supabase, table, select, orderColumn) {
+  const pageSize = 1000;
+  const rows = [];
+  for (let from = 0; ; from += pageSize) {
+    const to = from + pageSize - 1;
+    const { data, error } = await supabase
+      .from(table)
+      .select(select)
+      .order(orderColumn, { ascending: true })
+      .range(from, to);
+
+    if (error) {
+      throw new Error(`${table} scan failed: ${error.message}`);
+    }
+
+    rows.push(...(data ?? []));
+    if (!data || data.length < pageSize) break;
+  }
+  return rows;
+}
+
+function scoreSurfaceCoverage() {
+  const helperPath = "apps/web/src/lib/cards/childDisplayImageFallbacks.ts";
+  const helperExists = existsSync(helperPath);
+  const surfaces = Object.fromEntries(
+    SURFACE_FILES.map((file) => {
+      const source = existsSync(file) ? readFileSync(file, "utf8") : "";
+      return [file, source.includes("getChildDisplayImageFallbacks")];
+    }),
+  );
+  const uiFallbacks = Object.fromEntries(
+    UI_FALLBACK_FILES.map((file) => {
+      const source = existsSync(file) ? readFileSync(file, "utf8") : "";
+      return [file, source.includes("display_image_fallback_url")];
+    }),
+  );
+
+  return {
+    helper_exists: helperExists,
+    data_surfaces: surfaces,
+    ui_fallback_surfaces: uiFallbacks,
+    passed:
+      helperExists &&
+      Object.values(surfaces).every(Boolean) &&
+      Object.values(uiFallbacks).every(Boolean),
+  };
+}
+
+function buildMarkdown(report) {
+  const topSets = report.parent_missing_child_available.by_set
+    .slice(0, 12)
+    .map((row) => `| ${row.set_code} | ${row.count} |`)
+    .join("\n");
+  const examples = report.parent_missing_child_available.examples
+    .slice(0, 25)
+    .map(
+      (row) =>
+        `| ${row.gv_id} | ${row.name} | ${row.set_code} | ${row.number} | ${row.child_count} |`,
+    )
+    .join("\n");
+
+  return `# Image Surface Consistency Scan V1
+
+Generated: ${report.generated_at}
+
+## Summary
+
+- Parent identities scanned: ${report.parent_rows_scanned}
+- Child printings scanned: ${report.child_rows_scanned}
+- Parent identities with no parent image evidence but at least one child image: ${report.parent_missing_child_available.count}
+- Surface coverage gate: ${report.surface_coverage.passed ? "PASS" : "FAIL"}
+- Known Oshawott case covered: ${report.known_cases["GV-PK-MEP-051"] ? "YES" : "NO"}
+
+## Surface Coverage
+
+| Surface | Uses shared child fallback |
+| --- | --- |
+${Object.entries(report.surface_coverage.data_surfaces)
+  .map(([file, passed]) => `| ${file} | ${passed ? "yes" : "no"} |`)
+  .join("\n")}
+
+## Top Sets
+
+| Set code | Count |
+| --- | ---: |
+${topSets || "| none | 0 |"}
+
+## Examples
+
+| GV ID | Name | Set | Number | Child images |
+| --- | --- | --- | --- | ---: |
+${examples || "| none | none | none | none | 0 |"}
+`;
+}
+
+const supabase = createClient(
+  requiredEnv(["SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_URL"]),
+  requiredEnv([
+    "SUPABASE_SECRET_KEY",
+    "SUPABASE_PUBLISHABLE_KEY",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  ]),
+  { auth: { persistSession: false } },
+);
+
+const parentRows = await fetchAll(
+  supabase,
+  "card_prints",
+  "id,gv_id,name,set_code,number,image_url,image_alt_url,image_source,image_path,representative_image_url,image_status,image_note",
+  "id",
+);
+const childRows = await fetchAll(
+  supabase,
+  "card_printings",
+  "id,card_print_id,printing_gv_id,finish_key,image_url,image_alt_url,image_source,image_path,image_status,image_note",
+  "id",
+);
+
+const childrenWithImagesByParent = new Map();
+for (const child of childRows.filter(hasChildImageEvidence)) {
+  if (!child.card_print_id) continue;
+  const existing = childrenWithImagesByParent.get(child.card_print_id) ?? [];
+  existing.push(child);
+  childrenWithImagesByParent.set(child.card_print_id, existing);
+}
+
+const parentMissingChildAvailable = parentRows
+  .filter((row) => row.gv_id && !hasParentImageEvidence(row))
+  .map((row) => ({
+    ...row,
+    children: childrenWithImagesByParent.get(row.id) ?? [],
+  }))
+  .filter((row) => row.children.length > 0)
+  .sort((left, right) => {
+    const setCompare = String(left.set_code ?? "").localeCompare(
+      String(right.set_code ?? ""),
+    );
+    if (setCompare !== 0) return setCompare;
+    return String(left.number ?? "").localeCompare(String(right.number ?? ""));
+  });
+
+const bySetMap = new Map();
+for (const row of parentMissingChildAvailable) {
+  const setCode = row.set_code ?? "unknown";
+  bySetMap.set(setCode, (bySetMap.get(setCode) ?? 0) + 1);
+}
+
+const report = {
+  contract: "IMAGE_SURFACE_CONSISTENCY_SCAN_V1",
+  generated_at: new Date().toISOString(),
+  parent_rows_scanned: parentRows.length,
+  child_rows_scanned: childRows.length,
+  surface_coverage: scoreSurfaceCoverage(),
+  known_cases: {
+    "GV-PK-MEP-051": parentMissingChildAvailable.some(
+      (row) => row.gv_id === "GV-PK-MEP-051",
+    ),
+  },
+  parent_missing_child_available: {
+    count: parentMissingChildAvailable.length,
+    by_set: Array.from(bySetMap.entries())
+      .map(([set_code, count]) => ({ set_code, count }))
+      .sort((left, right) => right.count - left.count || left.set_code.localeCompare(right.set_code)),
+    examples: parentMissingChildAvailable.slice(0, 100).map((row) => ({
+      gv_id: row.gv_id,
+      name: row.name,
+      set_code: row.set_code,
+      number: row.number,
+      image_status: row.image_status,
+      child_count: row.children.length,
+      first_child_printing_gv_id: row.children[0]?.printing_gv_id ?? null,
+      first_child_finish_key: row.children[0]?.finish_key ?? null,
+    })),
+  },
+};
+
+mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(JSON_OUT, `${JSON.stringify(report, null, 2)}\n`);
+writeFileSync(MD_OUT, buildMarkdown(report));
+
+console.log(JSON.stringify({
+  json: JSON_OUT,
+  markdown: MD_OUT,
+  parent_missing_child_available: report.parent_missing_child_available.count,
+  surface_coverage_passed: report.surface_coverage.passed,
+  known_oshawott_case_covered: report.known_cases["GV-PK-MEP-051"],
+}, null, 2));
+
+if (!report.surface_coverage.passed) {
+  process.exitCode = 1;
+}

--- a/tests/contracts/image_surface_consistency_v1.test.mjs
+++ b/tests/contracts/image_surface_consistency_v1.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function source(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+}
+
+test("card summary surfaces use the shared child image fallback resolver", () => {
+  const helper = source("apps/web/src/lib/cards/childDisplayImageFallbacks.ts");
+  assert.match(helper, /getChildDisplayImageFallbacks/);
+  assert.match(helper, /card_printings/);
+  assert.match(helper, /representative_missing_variant_visual/);
+
+  for (const file of [
+    "apps/web/src/lib/getPublicCardByGvId.ts",
+    "apps/web/src/lib/getAdjacentPublicCardsByGvId.ts",
+    "apps/web/src/lib/cards/getPublicCardsByGvIds.ts",
+    "apps/web/src/lib/explore/getExploreRows.ts",
+    "apps/web/src/lib/cards/getFeaturedExploreCards.ts",
+  ]) {
+    assert.match(
+      source(file),
+      /getChildDisplayImageFallbacks/,
+      `${file} must not regress to parent-only image resolution`,
+    );
+  }
+});
+
+test("web image components pass fallback display URLs through product surfaces", () => {
+  for (const file of [
+    "apps/web/src/app/card/[gv_id]/page.tsx",
+    "apps/web/src/components/compare/CompareWorkspace.tsx",
+    "apps/web/src/components/explore/ExploreDiscoverySections.tsx",
+    "apps/web/src/components/explore/ExploreCardGridItem.tsx",
+    "apps/web/src/components/explore/ExploreCardListItem.tsx",
+    "apps/web/src/components/explore/ExploreCardDetailsRow.tsx",
+  ]) {
+    assert.match(
+      source(file),
+      /display_image_fallback_url/,
+      `${file} must preserve child-image fallback rendering`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a shared child-printing image fallback resolver for parent identities with missing parent imagery
- apply the fallback to related prints, previous/next navigation, compare cards, explore results, and featured explore cards
- add an image surface consistency scan and contract guard for parent-missing / child-present image cases

## Scan
- scanned 25,018 parent identities and 44,137 child printings
- found 298 parent identities with no parent image evidence but at least one child image
- confirmed GV-PK-MEP-051 is covered
- coverage gate passed for the app-facing summary surfaces

## Validation
- npm run shipcheck
- node scripts/audits/image_surface_consistency_scan_v1.mjs