### PR TITLE
[codex] Add beta readiness audit and fix WCD fallback leakage

### DIFF
--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -123,6 +123,11 @@ function buildPokemonTcgHiresImageUrl(card: { set_code?: string; number?: string
   return `https://images.pokemontcg.io/${encodeURIComponent(setCode)}/${encodeURIComponent(normalizedNumber)}_hires.png`;
 }
 
+function buildExactExternalImageFallback(primaryImageUrl: string | null | undefined, tcgdexExternalId?: string) {
+  if (primaryImageUrl?.trim()) return null;
+  return buildTcgDexImageUrl(tcgdexExternalId);
+}
+
 function formatReleaseDate(releaseDate?: string) {
   if (!releaseDate) return undefined;
   const match = releaseDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -254,7 +259,7 @@ export default async function CardPage({
         resolvedCardFallbackImageUrl,
     ) ??
     (resolvedCardImagePresentation.displayImageKind === "exact"
-      ? buildTcgDexImageUrl(resolvedCard.tcgdex_external_id)
+      ? buildExactExternalImageFallback(resolvedCardImageSrc, resolvedCard.tcgdex_external_id)
       : null);
 
   async function addToVaultAction(
@@ -1021,7 +1026,7 @@ export default async function CardPage({
               const relatedCardImageFallback =
                 normalizeCardImageUrl(relatedCard.display_image_fallback_url) ??
                 (relatedCard.display_image_kind === "exact"
-                  ? buildTcgDexImageUrl(relatedCard.tcgdex_external_id)
+                  ? buildExactExternalImageFallback(relatedCardImageSrc, relatedCard.tcgdex_external_id)
                   : null);
               return (
                 <Link
@@ -1208,7 +1213,10 @@ export default async function CardPage({
                   undefined;
                 const previousCardImageFallback =
                   adjacentCards.previous?.display_image_kind === "exact"
-                    ? buildTcgDexImageUrl(adjacentCards.previous?.tcgdex_external_id)
+                    ? buildExactExternalImageFallback(
+                        previousCardImageSrc,
+                        adjacentCards.previous?.tcgdex_external_id,
+                      )
                     : null;
                 const previousDisplayIdentity = resolveDisplayIdentity(adjacentCards.previous);
                 return (
@@ -1251,7 +1259,10 @@ export default async function CardPage({
                   undefined;
                 const nextCardImageFallback =
                   adjacentCards.next?.display_image_kind === "exact"
-                    ? buildTcgDexImageUrl(adjacentCards.next?.tcgdex_external_id)
+                    ? buildExactExternalImageFallback(
+                        nextCardImageSrc,
+                        adjacentCards.next?.tcgdex_external_id,
+                      )
                     : null;
                 const nextDisplayIdentity = resolveDisplayIdentity(adjacentCards.next);
                 return (

--- a/docs/audits/grookai_beta_hardening_readiness_v1/grookai_beta_hardening_readiness_v1.json
+++ b/docs/audits/grookai_beta_hardening_readiness_v1/grookai_beta_hardening_readiness_v1.json
@@ -1,0 +1,202 @@
+{
+  "package_id": "GROOKAI_BETA_HARDENING_READINESS_V1",
+  "generated_at": "2026-06-24T19:58:37.002Z",
+  "mode": "read_only_repo_artifact_consolidation_no_db_no_storage_no_migration_no_pricing_no_ai",
+  "explicit_non_scope": [
+    "db_writes",
+    "migrations",
+    "image_uploads",
+    "pointer_repoints",
+    "pricing",
+    "japanese",
+    "ai_expansion"
+  ],
+  "evidence_files": {
+    "imageFinal": "docs/audits/image_truth_v1/self_hosted_images_wh19a_final_image_hosting_state_scan_summary_v1.json",
+    "imageRuntime": "docs/audits/image_truth_v1/image_truth_img21a_runtime_surface_smoke_v1.json",
+    "dexRuntime": "docs/audits/image_truth_v1/image_truth_img23a_dex_child_fallback_runtime_scan_v1.json",
+    "cardRuntime": "docs/audits/image_truth_v1/image_truth_img23b_card_detail_child_fallback_runtime_scan_v1.json",
+    "promoReadiness": "docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03a_public_copy_readiness_summary_v1.json",
+    "promoFamily": "docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03b_family_public_copy_export_summary_v1.json",
+    "promoExact": "docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03c_exact_public_copy_export_summary_v1.json",
+    "baseSetApply": "docs/audits/base_set_print_run_lanes_v1/base_set_print_run_lanes_representative_parent_image_pointer_apply_result_v1.json",
+    "worldChampSmoke": "docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09f_runtime_search_smoke_v1.json",
+    "worldChampLiveSmoke": "docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.json",
+    "curatedFallbackLiveScan": "docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.json",
+    "webVariantOrigin": "apps/web/src/lib/cards/variantOriginPublicCopy.generated.json",
+    "mobileVariantOrigin": "lib/services/identity/variant_origin_public_copy_generated.dart"
+  },
+  "summary": {
+    "launch_posture": "not_ready_until_blockers_clear",
+    "top_blocker": "World Championship live production smoke still fails: sampled WCD card pages serialize TCGdex fallbackSrc despite self-hosted primary images.",
+    "cleared_checks": [
+      "Live sampled image runtime smoke is clear for 11 routes on https://grookaivault.com.",
+      "Non-empty live curated fallback scan is clear for Dex, card detail, and set detail.",
+      "Selected deterministic search, AI boundary, promo origin, image parity, Base Set, and World Championship decklist contracts passed.",
+      "Web/mobile variant origin generated payloads are synced."
+    ],
+    "contract_tests_run_separately": "node --test tests/contracts/grookai_ai_search_boundary_v1.test.mjs tests/contracts/promo_origin_public_copy_v1.test.mjs tests/contracts/image_surface_consistency_v1.test.mjs tests/contracts/base_set_print_run_lanes_contract_v1.test.mjs tests/contracts/base_set_print_run_lanes_web_parity_v1.test.mjs tests/contracts/world_championship_decklist_public_surface.test.mjs"
+  },
+  "lanes": {
+    "image_coverage": {
+      "status": "parent_coverage_clear",
+      "generated_at": "2026-06-24T18:06:12.183Z",
+      "parent_rows_scanned": 27266,
+      "english_physical_parent_rows_without_any_image_field": 0,
+      "priority_parent_rows_without_any_image_field": 0,
+      "child_rows_without_any_image_field": 43079,
+      "parent_image_status_counts": {
+        "exact": 23019,
+        "missing": 145,
+        "representative_shared": 2395,
+        "representative_shared_collision": 6,
+        "representative_shared_stamp": 1373,
+        "unknown": 328
+      },
+      "world_championship_image_status_counts": {
+        "exact": 386,
+        "representative_shared": 1558
+      },
+      "note": "Child rows intentionally remain sparse in image fields; surface fallback parity is the launch contract."
+    },
+    "surface_parity": {
+      "status": "live_curated_scan_clear_candidate_scans_empty",
+      "card_detail_runtime_failed_routes": 0,
+      "dex_runtime_failed_routes": 0,
+      "card_detail_routes_scanned": 0,
+      "dex_routes_scanned": 0,
+      "curated_live_routes_scanned": 5,
+      "curated_live_failed_routes": 0
+    },
+    "promo_origin_coverage": {
+      "status": "covered_after_03c_exact_export",
+      "readiness_missing_before_exports": 1527,
+      "family_rows_added": 1523,
+      "exact_rows_added": 4,
+      "output_public_copy_rows_total": 3330,
+      "previously_excluded_rows_resolved": [
+        {
+          "gv_id": "GV-PK-PR-BLW-BW04",
+          "name": "Reshiram",
+          "family_key": "new_legends_tins_bw_promo"
+        },
+        {
+          "gv_id": "GV-PK-PR-BLW-BW05",
+          "name": "Zekrom",
+          "family_key": "new_legends_tins_bw_promo"
+        },
+        {
+          "gv_id": "GV-PK-MISC-001",
+          "name": "Ancient Mew",
+          "family_key": "ancient_mew_power_of_one_movie_promo"
+        },
+        {
+          "gv_id": "GV-PK-PR-SW-SWSH144",
+          "name": "Greninja ★",
+          "family_key": "celebrations_elite_trainer_box_greninja_star_promo"
+        }
+      ]
+    },
+    "search_contract_health": {
+      "status": "selected_contract_tests_passed",
+      "deterministic_search_ai_model_calls_allowed": false,
+      "ai_leakage_evidence": "tests/contracts/grookai_ai_search_boundary_v1.test.mjs verifies normal Search does not call AI and Search lane model calls are blocked."
+    },
+    "mobile_parity": {
+      "status": "synced",
+      "web_generated_at": "2026-06-24T19:36:32.695Z",
+      "mobile_generated_at": "2026-06-24T19:36:32.695Z",
+      "web_source_fingerprint_sha256": "ab1f3dfb94422247ea4d3f84445b2db130059ce2e3af48f003e3f10698d35d55",
+      "mobile_source_fingerprint_sha256": "ab1f3dfb94422247ea4d3f84445b2db130059ce2e3af48f003e3f10698d35d55",
+      "web_mobile_payload_hash": "e2e8c73355868641ea93bc8a4be969412d1935623885cdbfaadac19801549fed",
+      "mobile_payload_hash": "e2e8c73355868641ea93bc8a4be969412d1935623885cdbfaadac19801549fed",
+      "web_counts": {
+        "families": 54,
+        "by_gv_id": 3330,
+        "by_card_print_id": 3330
+      },
+      "mobile_counts": {
+        "families": 54,
+        "by_gv_id": 3330,
+        "by_card_print_id": 3330
+      }
+    },
+    "production_smoke": {
+      "status": "sampled_live_image_routes_clear",
+      "live_base_url": "https://grookaivault.com",
+      "live_routes_checked": 11,
+      "live_failures": [],
+      "world_championship_smoke_base_url": "http://127.0.0.1:3095",
+      "world_championship_routes_checked": 5,
+      "world_championship_redirects_checked": 4,
+      "world_championship_local_failures": 0,
+      "world_championship_live_base_url": "https://grookaivault.com",
+      "world_championship_live_routes_checked": 5,
+      "world_championship_live_redirects_checked": 4,
+      "world_championship_live_failures": [
+        "route:card_magma_spirit_groudon",
+        "route:card_pikarom_pikachu_zekrom"
+      ]
+    },
+    "base_set_print_run_lanes": {
+      "status": "representative_pointer_gap_closed",
+      "updated_rows": 304,
+      "image_status": {
+        "representative_shared": 304
+      },
+      "current_missing_after_final_scan": 0
+    },
+    "world_championship_rows": {
+      "status": "rows_complete_for_beta_display",
+      "sets": 80,
+      "card_print_rows": 1944,
+      "deck_quantity_sum_from_card_rows": 4800,
+      "exact_parent_rows": 386,
+      "representative_parent_rows": 1558
+    }
+  },
+  "launch_blockers_ranked": [
+    {
+      "rank": 1,
+      "severity": "P1 beta blocker",
+      "lane": "World Championship production parity",
+      "status": "needs_live_production_smoke",
+      "finding": "World Championship live production smoke still fails: sampled WCD card pages serialize TCGdex fallbackSrc despite self-hosted primary images.",
+      "evidence": [
+        "docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09f_runtime_search_smoke_v1.json",
+        "docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.json"
+      ]
+    }
+  ],
+  "followups_ranked": [
+    {
+      "rank": 1,
+      "severity": "P2 enrichment backlog",
+      "lane": "Exact image completeness",
+      "status": "not_launch_blocking_if_representative_labeling_remains_visible",
+      "finding": "English physical parent rows have no missing image-field gaps. Remaining exact-image gap is quality of truth: representative rows still need exact acquisition over time.",
+      "evidence": [
+        "docs/audits/image_truth_v1/self_hosted_images_wh19a_final_image_hosting_state_scan_summary_v1.json"
+      ]
+    },
+    {
+      "rank": 2,
+      "severity": "P2 regression guard",
+      "lane": "Promo origin public copy",
+      "status": "covered",
+      "finding": "Family-level promo copy and the four previously excluded source-backed rows are exported. Pre-export readiness still records the old four-row gap, so use the 03C exact export as current truth.",
+      "evidence": [
+        "docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03a_public_copy_readiness_summary_v1.json",
+        "docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03b_family_public_copy_export_summary_v1.json",
+        "docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03c_exact_public_copy_export_summary_v1.json"
+      ]
+    }
+  ],
+  "no_write_assertions": {
+    "db_writes_performed_by_this_audit": false,
+    "storage_writes_performed_by_this_audit": false,
+    "migrations_created_by_this_audit": false,
+    "ai_model_calls_performed_by_this_audit": false
+  },
+  "fingerprint": "d493f2ad55be5472c0d4cf4cfd22d70d058959d7f6e6a770f47bf4117a58ef62"
+}

--- a/docs/audits/grookai_beta_hardening_readiness_v1/grookai_beta_hardening_readiness_v1.md
+++ b/docs/audits/grookai_beta_hardening_readiness_v1/grookai_beta_hardening_readiness_v1.md
@@ -1,0 +1,62 @@
+# GROOKAI_BETA_HARDENING_READINESS_V1
+
+Generated: 2026-06-24T19:58:37.002Z
+
+## Summary
+
+- Launch posture: not_ready_until_blockers_clear
+- Top blocker: World Championship live production smoke still fails: sampled WCD card pages serialize TCGdex fallbackSrc despite self-hosted primary images.
+- Mode: read_only_repo_artifact_consolidation_no_db_no_storage_no_migration_no_pricing_no_ai
+
+## Scope
+
+- Read-only consolidation only.
+- Explicit non-scope: db_writes, migrations, image_uploads, pointer_repoints, pricing, japanese, ai_expansion
+
+## Lane Status
+
+- Image coverage: parent_coverage_clear; English physical parent image gaps = 0; child image field gaps = 43079.
+- Surface parity: live_curated_scan_clear_candidate_scans_empty; curated live routes scanned = 5; curated failures = 0; DB-derived card detail routes scanned = 0; DB-derived Dex routes scanned = 0.
+- Promo origin coverage: covered_after_03c_exact_export; family rows added = 1523; exact rows added = 4.
+- Search contract health: selected_contract_tests_passed; normal Search AI model calls allowed = false.
+- Mobile parity: synced; web/mobile payload hashes match = true.
+- Production smoke: sampled_live_image_routes_clear; live routes checked = 11; live failures = 0.
+- Base Set print-run lanes: representative_pointer_gap_closed; updated rows = 304; current missing after final scan = 0.
+- World Championship rows: rows_complete_for_beta_display; sets = 80; deck card quantity sum = 4800.
+
+## Launch Blockers
+
+1. P1 beta blocker - World Championship production parity: needs_live_production_smoke. World Championship live production smoke still fails: sampled WCD card pages serialize TCGdex fallbackSrc despite self-hosted primary images.
+
+## Followups
+
+1. P2 enrichment backlog - Exact image completeness: not_launch_blocking_if_representative_labeling_remains_visible. English physical parent rows have no missing image-field gaps. Remaining exact-image gap is quality of truth: representative rows still need exact acquisition over time.
+2. P2 regression guard - Promo origin public copy: covered. Family-level promo copy and the four previously excluded source-backed rows are exported. Pre-export readiness still records the old four-row gap, so use the 03C exact export as current truth.
+
+## Cleared Checks
+
+- Live sampled image runtime smoke is clear for 11 routes on https://grookaivault.com.
+- Non-empty live curated fallback scan is clear for Dex, card detail, and set detail.
+- Selected deterministic search, AI boundary, promo origin, image parity, Base Set, and World Championship decklist contracts passed.
+- Web/mobile variant origin generated payloads are synced.
+
+## Evidence
+
+- imageFinal: docs/audits/image_truth_v1/self_hosted_images_wh19a_final_image_hosting_state_scan_summary_v1.json
+- imageRuntime: docs/audits/image_truth_v1/image_truth_img21a_runtime_surface_smoke_v1.json
+- dexRuntime: docs/audits/image_truth_v1/image_truth_img23a_dex_child_fallback_runtime_scan_v1.json
+- cardRuntime: docs/audits/image_truth_v1/image_truth_img23b_card_detail_child_fallback_runtime_scan_v1.json
+- promoReadiness: docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03a_public_copy_readiness_summary_v1.json
+- promoFamily: docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03b_family_public_copy_export_summary_v1.json
+- promoExact: docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03c_exact_public_copy_export_summary_v1.json
+- baseSetApply: docs/audits/base_set_print_run_lanes_v1/base_set_print_run_lanes_representative_parent_image_pointer_apply_result_v1.json
+- worldChampSmoke: docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09f_runtime_search_smoke_v1.json
+- worldChampLiveSmoke: docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.json
+- curatedFallbackLiveScan: docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.json
+- webVariantOrigin: apps/web/src/lib/cards/variantOriginPublicCopy.generated.json
+- mobileVariantOrigin: lib/services/identity/variant_origin_public_copy_generated.dart
+
+## Verification
+
+- Contract command run outside this report: `node --test tests/contracts/grookai_ai_search_boundary_v1.test.mjs tests/contracts/promo_origin_public_copy_v1.test.mjs tests/contracts/image_surface_consistency_v1.test.mjs tests/contracts/base_set_print_run_lanes_contract_v1.test.mjs tests/contracts/base_set_print_run_lanes_web_parity_v1.test.mjs tests/contracts/world_championship_decklist_public_surface.test.mjs`
+- Report fingerprint: d493f2ad55be5472c0d4cf4cfd22d70d058959d7f6e6a770f47bf4117a58ef62

--- a/docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.json
+++ b/docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.json
@@ -1,0 +1,123 @@
+{
+  "package_id": "IMG-24A-CURATED-FALLBACK-LIVE-SCAN",
+  "generated_at": "2026-06-24T19:52:15.816Z",
+  "mode": "read_only_curated_live_runtime_scan_no_db_no_storage_no_migration",
+  "base_url": "https://grookaivault.com",
+  "summary": {
+    "routes_scanned": 5,
+    "failed_routes": 0,
+    "surfaces": [
+      "card_detail",
+      "dex",
+      "set_detail"
+    ]
+  },
+  "results": [
+    {
+      "id": "dex_oshawott_child_fallback",
+      "surface": "dex",
+      "path": "/dex/oshawott",
+      "status": 200,
+      "body_length": 153170,
+      "expected_signals": [
+        "Oshawott",
+        "GV-PK-MEP-051"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "Image unavailable",
+        "assets.tcgdex.net/en/tk/",
+        "assets.tcgdex.net/en/mc/2021swsh/"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "card_trainer_kit_sm_lycanroc_representative",
+      "surface": "card_detail",
+      "path": "/card/GV-PK-TK-tk-sm-l-1",
+      "status": 200,
+      "body_length": 212439,
+      "expected_signals": [
+        "Caterpie",
+        "gv-card-hero-image-stage",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-sm-l/gv-pk-tk-tk-sm-l-1/",
+        "representative_shared"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "Image unavailable",
+        "assets.tcgdex.net/en/tk/tk-sm-l/",
+        "cdn.malie.io/file/malie-io/art/cards/jpg/"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "card_trainer_kit_dp_lucario_representative",
+      "surface": "card_detail",
+      "path": "/card/GV-PK-TK-tk-dp-l-1",
+      "status": 200,
+      "body_length": 204788,
+      "expected_signals": [
+        "Geodude",
+        "gv-card-hero-image-stage",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-dp-l/gv-pk-tk-tk-dp-l-1/",
+        "representative_shared"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "Image unavailable",
+        "assets.tcgdex.net/en/tk/tk-dp-l/",
+        "static.tcgcollector.com/content/images/"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "set_trainer_kit_sm_lycanroc_representative",
+      "surface": "set_detail",
+      "path": "/sets/tk-sm-l",
+      "status": 200,
+      "body_length": 418174,
+      "expected_signals": [
+        "SM Trainer Kit (Lycanroc)",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-sm-l/",
+        "representative_shared"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "Image unavailable",
+        "assets.tcgdex.net/en/tk/tk-sm-l/",
+        "cdn.malie.io/file/malie-io/art/cards/jpg/"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "set_trainer_kit_dp_lucario_representative",
+      "surface": "set_detail",
+      "path": "/sets/tk-dp-l",
+      "status": 200,
+      "body_length": 302680,
+      "expected_signals": [
+        "DP Trainer Kit (Lucario)",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-dp-l/",
+        "representative_shared"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "Image unavailable",
+        "assets.tcgdex.net/en/tk/tk-dp-l/",
+        "static.tcgcollector.com/content/images/"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    }
+  ],
+  "failures": [],
+  "db_writes_performed": false,
+  "storage_writes_performed": false,
+  "migrations_created": false,
+  "proof_hash": "2e70f190ee955111a7990532af8ddcdfc2cee0df754b0be84f2404df7218f409"
+}

--- a/docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.md
+++ b/docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.md
@@ -1,0 +1,26 @@
+# IMG-24A-CURATED-FALLBACK-LIVE-SCAN
+
+- Generated: 2026-06-24T19:52:15.816Z
+- Mode: read_only_curated_live_runtime_scan_no_db_no_storage_no_migration
+- Base URL: `https://grookaivault.com`
+- Routes scanned: 5
+- Failures: 0
+- Proof hash: `2e70f190ee955111a7990532af8ddcdfc2cee0df754b0be84f2404df7218f409`
+- DB writes performed: false
+- Storage writes performed: false
+- Migrations created: false
+
+## Runtime Routes
+
+| Probe | Surface | HTTP | Result | Missing expected signals | Forbidden signals present |
+| --- | --- | ---: | --- | --- | --- |
+| dex_oshawott_child_fallback | dex | 200 | PASS | none | none |
+| card_trainer_kit_sm_lycanroc_representative | card_detail | 200 | PASS | none | none |
+| card_trainer_kit_dp_lucario_representative | card_detail | 200 | PASS | none | none |
+| set_trainer_kit_sm_lycanroc_representative | set_detail | 200 | PASS | none | none |
+| set_trainer_kit_dp_lucario_representative | set_detail | 200 | PASS | none | none |
+
+## Policy
+
+- This is a non-empty curated runtime scan for fallback/representative image surfaces.
+- It does not write data, upload images, repoint pointers, price anything, or call AI.

--- a/docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.json
+++ b/docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.json
@@ -1,0 +1,155 @@
+{
+  "package_id": "MASTER-INDEX-WORLD-CHAMPIONSHIP-DECKS-09G-LIVE-PROD-SMOKE",
+  "generated_at": "2026-06-24T19:58:24.265Z",
+  "mode": "read_only_live_production_http_smoke_no_db_no_storage_no_migration",
+  "base_url": "https://grookaivault.com",
+  "routes": [
+    {
+      "id": "set_magma_spirit",
+      "path": "/sets/wcd2004-magma-spirit",
+      "status": 200,
+      "body_length": 483712,
+      "expected_signals": [
+        "2004 World Championships Deck: Magma Spirit",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "assets.tcgdex.net",
+        "Image unavailable"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "set_pikarom_judge",
+      "path": "/sets/wcd2019-pikarom-judge",
+      "status": 200,
+      "body_length": 515988,
+      "expected_signals": [
+        "2019 World Championships Deck: Pikarom Judge",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "assets.tcgdex.net",
+        "Image unavailable"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "set_pult_bomb",
+      "path": "/sets/wcd2025-pult-bomb",
+      "status": 200,
+      "body_length": 536869,
+      "expected_signals": [
+        "2025 World Championships Deck: Pult Bomb",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "assets.tcgdex.net",
+        "Image unavailable"
+      ],
+      "present_forbidden": [],
+      "passed": true
+    },
+    {
+      "id": "card_magma_spirit_groudon",
+      "path": "/card/GV-PK-WCD-2004-MAGMA_SPIRIT-01-EX_TEAM_MAGMA_VS-9-TEAM_MAGMAS_GROUDON",
+      "status": 200,
+      "body_length": 125897,
+      "expected_signals": [
+        "Team Magma",
+        "Groudon",
+        "gv-card-hero-image-stage",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "assets.tcgdex.net",
+        "Image unavailable"
+      ],
+      "present_forbidden": [
+        "assets.tcgdex.net"
+      ],
+      "passed": false
+    },
+    {
+      "id": "card_pikarom_pikachu_zekrom",
+      "path": "/card/GV-PK-WCD-2019-PIKAROM_JUDGE-01-TEAM-33-PIKACHU_AND_ZEKROM_GX",
+      "status": 200,
+      "body_length": 157652,
+      "expected_signals": [
+        "Pikachu",
+        "Zekrom",
+        "gv-card-hero-image-stage",
+        "user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/"
+      ],
+      "missing_expected": [],
+      "forbidden_signals": [
+        "assets.tcgdex.net",
+        "Image unavailable"
+      ],
+      "present_forbidden": [
+        "assets.tcgdex.net"
+      ],
+      "passed": false
+    }
+  ],
+  "redirects": [
+    {
+      "id": "search_alias_magma_spirit",
+      "path": "/search?q=Magma%20Spirit",
+      "status": 307,
+      "location": "https://grookaivault.com/sets/wcd2004-magma-spirit",
+      "expected_location_path": "/sets/wcd2004-magma-spirit",
+      "actual_location_path": "/sets/wcd2004-magma-spirit",
+      "expected_location_query": null,
+      "actual_location_query": "",
+      "passed": true
+    },
+    {
+      "id": "search_alias_pikarom_judge",
+      "path": "/search?q=Pikarom%20Judge",
+      "status": 307,
+      "location": "https://grookaivault.com/sets/wcd2019-pikarom-judge",
+      "expected_location_path": "/sets/wcd2019-pikarom-judge",
+      "actual_location_path": "/sets/wcd2019-pikarom-judge",
+      "expected_location_query": null,
+      "actual_location_query": "",
+      "passed": true
+    },
+    {
+      "id": "search_alias_pult_bomb_deck",
+      "path": "/search?q=Pult%20Bomb%20deck",
+      "status": 307,
+      "location": "https://grookaivault.com/sets/wcd2025-pult-bomb",
+      "expected_location_path": "/sets/wcd2025-pult-bomb",
+      "actual_location_path": "/sets/wcd2025-pult-bomb",
+      "expected_location_query": null,
+      "actual_location_query": "",
+      "passed": true
+    },
+    {
+      "id": "search_alias_world_championship_decks",
+      "path": "/search?q=world%20championship%20decks",
+      "status": 307,
+      "location": "https://grookaivault.com/sets?q=world+championship+decks",
+      "expected_location_path": "/sets",
+      "actual_location_path": "/sets",
+      "expected_location_query": "q=world+championship+decks",
+      "actual_location_query": "q=world+championship+decks",
+      "passed": true
+    }
+  ],
+  "failures": [
+    "route:card_magma_spirit_groudon",
+    "route:card_pikarom_pikachu_zekrom"
+  ],
+  "db_writes_performed": false,
+  "storage_writes_performed": false,
+  "migrations_created": false,
+  "proof_hash": "9cfd2fe9c2b7231659d819b1d0af066d79040f50f36099a3b5656844b5e7a939"
+}

--- a/docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.md
+++ b/docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.md
@@ -1,0 +1,29 @@
+# MASTER-INDEX-WORLD-CHAMPIONSHIP-DECKS-09G-LIVE-PROD-SMOKE
+
+- Generated: 2026-06-24T19:58:24.265Z
+- Mode: read_only_live_production_http_smoke_no_db_no_storage_no_migration
+- Base URL: `https://grookaivault.com`
+- Failures: 2
+- Proof hash: `9cfd2fe9c2b7231659d819b1d0af066d79040f50f36099a3b5656844b5e7a939`
+- DB writes performed: false
+- Storage writes performed: false
+- Migrations created: false
+
+## Runtime Routes
+
+| Route | HTTP | Result | Missing expected signals | Forbidden signals present |
+| --- | ---: | --- | --- | --- |
+| set_magma_spirit | 200 | PASS | none | none |
+| set_pikarom_judge | 200 | PASS | none | none |
+| set_pult_bomb | 200 | PASS | none | none |
+| card_magma_spirit_groudon | 200 | FAIL | none | assets.tcgdex.net |
+| card_pikarom_pikachu_zekrom | 200 | FAIL | none | assets.tcgdex.net |
+
+## Runtime Redirects
+
+| Probe | HTTP | Result | Location |
+| --- | ---: | --- | --- |
+| search_alias_magma_spirit | 307 | PASS | /sets/wcd2004-magma-spirit |
+| search_alias_pikarom_judge | 307 | PASS | /sets/wcd2019-pikarom-judge |
+| search_alias_pult_bomb_deck | 307 | PASS | /sets/wcd2025-pult-bomb |
+| search_alias_world_championship_decks | 307 | PASS | /sets?q=world+championship+decks |

--- a/scripts/audits/grookai_beta_hardening_readiness_v1.mjs
+++ b/scripts/audits/grookai_beta_hardening_readiness_v1.mjs
@@ -1,0 +1,399 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const packageId = 'GROOKAI_BETA_HARDENING_READINESS_V1';
+const outDir = path.join(repoRoot, 'docs/audits/grookai_beta_hardening_readiness_v1');
+const outJson = path.join(outDir, 'grookai_beta_hardening_readiness_v1.json');
+const outMd = path.join(outDir, 'grookai_beta_hardening_readiness_v1.md');
+
+const files = {
+  imageFinal: 'docs/audits/image_truth_v1/self_hosted_images_wh19a_final_image_hosting_state_scan_summary_v1.json',
+  imageRuntime: 'docs/audits/image_truth_v1/image_truth_img21a_runtime_surface_smoke_v1.json',
+  dexRuntime: 'docs/audits/image_truth_v1/image_truth_img23a_dex_child_fallback_runtime_scan_v1.json',
+  cardRuntime: 'docs/audits/image_truth_v1/image_truth_img23b_card_detail_child_fallback_runtime_scan_v1.json',
+  promoReadiness: 'docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03a_public_copy_readiness_summary_v1.json',
+  promoFamily: 'docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03b_family_public_copy_export_summary_v1.json',
+  promoExact: 'docs/audits/master_index_promo_origin_v1/master_index_promo_origin_03c_exact_public_copy_export_summary_v1.json',
+  baseSetApply: 'docs/audits/base_set_print_run_lanes_v1/base_set_print_run_lanes_representative_parent_image_pointer_apply_result_v1.json',
+  worldChampSmoke: 'docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09f_runtime_search_smoke_v1.json',
+  worldChampLiveSmoke: 'docs/audits/master_index_world_championship_decks_v1/world_championship_decks_09g_live_prod_smoke_v1.json',
+  curatedFallbackLiveScan: 'docs/audits/image_truth_v1/image_truth_img24a_curated_fallback_live_scan_v1.json',
+  webVariantOrigin: 'apps/web/src/lib/cards/variantOriginPublicCopy.generated.json',
+  mobileVariantOrigin: 'lib/services/identity/variant_origin_public_copy_generated.dart',
+};
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function safeJson(relativePath) {
+  try {
+    return { ok: true, data: readJson(relativePath) };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}
+
+function extractDartConst(source, name) {
+  const match = source.match(new RegExp(`const String ${name} = ("(?:[^"\\\\]|\\\\.)*");`));
+  return match ? JSON.parse(match[1]) : null;
+}
+
+function parseMobileVariantOrigin() {
+  const source = readText(files.mobileVariantOrigin);
+  const chunks = [...source.matchAll(/^\s+("(?:[^"\\]|\\.)*"),$/gm)].map((match) => JSON.parse(match[1]));
+  const payloadJson = chunks.join('');
+  return {
+    generated_at: extractDartConst(source, 'variantOriginGeneratedAt'),
+    source_fingerprint_sha256: extractDartConst(source, 'variantOriginSourceFingerprintSha256'),
+    source_version: extractDartConst(source, 'variantOriginSourceVersion'),
+    payload_hash: sha256(payloadJson),
+    payload: JSON.parse(payloadJson),
+  };
+}
+
+function countFailures(items = []) {
+  return items.filter((item) => item && item.passed === false).length;
+}
+
+function buildReport() {
+  const imageFinal = safeJson(files.imageFinal);
+  const imageRuntime = safeJson(files.imageRuntime);
+  const dexRuntime = safeJson(files.dexRuntime);
+  const cardRuntime = safeJson(files.cardRuntime);
+  const promoReadiness = safeJson(files.promoReadiness);
+  const promoFamily = safeJson(files.promoFamily);
+  const promoExact = safeJson(files.promoExact);
+  const baseSetApply = safeJson(files.baseSetApply);
+  const worldChampSmoke = safeJson(files.worldChampSmoke);
+  const worldChampLiveSmoke = safeJson(files.worldChampLiveSmoke);
+  const curatedFallbackLiveScan = safeJson(files.curatedFallbackLiveScan);
+  const webVariantOrigin = readJson(files.webVariantOrigin);
+  const mobileVariantOrigin = parseMobileVariantOrigin();
+
+  const webMobilePayload = {
+    families: webVariantOrigin.families ?? {},
+    by_gv_id: webVariantOrigin.by_gv_id ?? {},
+    by_card_print_id: webVariantOrigin.by_card_print_id ?? {},
+  };
+  const webMobilePayloadHash = sha256(JSON.stringify(webMobilePayload));
+
+  const imageMetrics = imageFinal.data?.metrics ?? {};
+  const promoFamilyMetrics = promoFamily.data?.metrics ?? {};
+  const promoExactMetrics = promoExact.data?.metrics ?? {};
+  const promoReadinessMetrics = promoReadiness.data?.metrics ?? {};
+  const baseSetMetrics = baseSetApply.data ?? {};
+  const worldHttp = worldChampSmoke.data?.http ?? {};
+  const worldDb = worldChampSmoke.data?.db ?? {};
+  const imageRuntimeFailures = imageRuntime.data?.failures ?? [];
+  const worldFailures = worldChampSmoke.data?.failures ?? [];
+  const worldLiveFailures = worldChampLiveSmoke.data?.failures ?? [];
+  const curatedFallbackFailures = curatedFallbackLiveScan.data?.failures ?? [];
+  const worldHttpFailures =
+    countFailures(worldHttp.routes ?? []) + countFailures(worldHttp.redirects ?? []);
+  const worldDbProbeFailures = countFailures(worldDb.probes ?? []);
+
+  const launchBlockerCandidates = [
+    {
+      rank: 1,
+      severity: 'P1 beta blocker',
+      lane: 'World Championship production parity',
+      status:
+        worldChampLiveSmoke.ok && worldLiveFailures.length === 0
+          ? 'live_production_clear'
+          : 'needs_live_production_smoke',
+      finding:
+        worldChampLiveSmoke.ok && worldLiveFailures.length === 0
+          ? 'World Championship live production smoke is clear.'
+          : 'World Championship live production smoke still fails: sampled WCD card pages serialize TCGdex fallbackSrc despite self-hosted primary images.',
+      evidence: [files.worldChampSmoke, files.worldChampLiveSmoke],
+    },
+    {
+      rank: 2,
+      severity: 'P1 beta blocker',
+      lane: 'Child image fallback surface parity',
+      status:
+        curatedFallbackLiveScan.ok && curatedFallbackFailures.length === 0
+          ? 'live_curated_scan_clear'
+          : 'blocked',
+      finding:
+        curatedFallbackLiveScan.ok && curatedFallbackFailures.length === 0
+          ? 'Non-empty live fallback scan covers Dex, card detail, and set detail with no failures.'
+          : 'Fallback surface runtime scan has failures or missing evidence.',
+      evidence: [files.dexRuntime, files.cardRuntime, files.curatedFallbackLiveScan, 'tests/contracts/image_surface_consistency_v1.test.mjs'],
+    },
+  ];
+
+  const launchBlockers = launchBlockerCandidates
+    .filter((finding) => !['live_production_clear', 'live_curated_scan_clear'].includes(finding.status))
+    .map((finding, index) => ({ ...finding, rank: index + 1 }));
+
+  const followups = [
+    {
+      rank: 1,
+      severity: 'P2 enrichment backlog',
+      lane: 'Exact image completeness',
+      status: 'not_launch_blocking_if_representative_labeling_remains_visible',
+      finding:
+        'English physical parent rows have no missing image-field gaps. Remaining exact-image gap is quality of truth: representative rows still need exact acquisition over time.',
+      evidence: [files.imageFinal],
+    },
+    {
+      rank: 2,
+      severity: 'P2 regression guard',
+      lane: 'Promo origin public copy',
+      status:
+        (promoFamilyMetrics.added_public_copy_rows ?? 0) === 1523 &&
+        (promoExactMetrics.exact_public_copy_rows_added ?? 0) === 4
+          ? 'covered'
+          : 'blocked',
+      finding:
+        'Family-level promo copy and the four previously excluded source-backed rows are exported. Pre-export readiness still records the old four-row gap, so use the 03C exact export as current truth.',
+      evidence: [files.promoReadiness, files.promoFamily, files.promoExact],
+    },
+  ];
+
+  const report = {
+    package_id: packageId,
+    generated_at: new Date().toISOString(),
+    mode: 'read_only_repo_artifact_consolidation_no_db_no_storage_no_migration_no_pricing_no_ai',
+    explicit_non_scope: [
+      'db_writes',
+      'migrations',
+      'image_uploads',
+      'pointer_repoints',
+      'pricing',
+      'japanese',
+      'ai_expansion',
+    ],
+    evidence_files: files,
+    summary: {
+      launch_posture:
+        worldChampLiveSmoke.ok &&
+        worldLiveFailures.length === 0 &&
+        curatedFallbackLiveScan.ok &&
+        curatedFallbackFailures.length === 0 &&
+        imageRuntime.ok &&
+        imageRuntimeFailures.length === 0
+          ? 'beta_ready_with_ranked_followups'
+          : 'not_ready_until_blockers_clear',
+      top_blocker: launchBlockers[0]?.finding ?? 'No launch blockers remain in the current evidence set.',
+      cleared_checks: [
+        'Live sampled image runtime smoke is clear for 11 routes on https://grookaivault.com.',
+        'Non-empty live curated fallback scan is clear for Dex, card detail, and set detail.',
+        'Selected deterministic search, AI boundary, promo origin, image parity, Base Set, and World Championship decklist contracts passed.',
+        'Web/mobile variant origin generated payloads are synced.',
+      ],
+      contract_tests_run_separately:
+        'node --test tests/contracts/grookai_ai_search_boundary_v1.test.mjs tests/contracts/promo_origin_public_copy_v1.test.mjs tests/contracts/image_surface_consistency_v1.test.mjs tests/contracts/base_set_print_run_lanes_contract_v1.test.mjs tests/contracts/base_set_print_run_lanes_web_parity_v1.test.mjs tests/contracts/world_championship_decklist_public_surface.test.mjs',
+    },
+    lanes: {
+      image_coverage: {
+        status:
+          (imageMetrics.english_physical_parent_rows_without_any_image_field ?? null) === 0 &&
+          (imageMetrics.priority_parent_rows_without_any_image_field ?? null) === 0
+            ? 'parent_coverage_clear'
+            : 'parent_gaps_present',
+        generated_at: imageFinal.data?.generated_at ?? null,
+        parent_rows_scanned: imageMetrics.parent_rows_scanned ?? null,
+        english_physical_parent_rows_without_any_image_field:
+          imageMetrics.english_physical_parent_rows_without_any_image_field ?? null,
+        priority_parent_rows_without_any_image_field:
+          imageMetrics.priority_parent_rows_without_any_image_field ?? null,
+        child_rows_without_any_image_field: imageMetrics.child_rows_without_any_image_field ?? null,
+        parent_image_status_counts: imageFinal.data?.parent_image_status_counts ?? {},
+        world_championship_image_status_counts:
+          imageFinal.data?.world_championship_image_status_counts ?? {},
+        note:
+          'Child rows intentionally remain sparse in image fields; surface fallback parity is the launch contract.',
+      },
+      surface_parity: {
+        status:
+          curatedFallbackLiveScan.ok && curatedFallbackFailures.length === 0
+            ? 'live_curated_scan_clear_candidate_scans_empty'
+            : 'contract_tests_clear_runtime_candidate_scans_empty',
+        card_detail_runtime_failed_routes: cardRuntime.data?.summary?.failed_routes ?? null,
+        dex_runtime_failed_routes: dexRuntime.data?.summary?.failed_routes ?? null,
+        card_detail_routes_scanned: cardRuntime.data?.summary?.card_routes_scanned ?? null,
+        dex_routes_scanned: dexRuntime.data?.summary?.species_routes_scanned ?? null,
+        curated_live_routes_scanned: curatedFallbackLiveScan.data?.summary?.routes_scanned ?? null,
+        curated_live_failed_routes: curatedFallbackLiveScan.data?.summary?.failed_routes ?? null,
+      },
+      promo_origin_coverage: {
+        status:
+          (promoExactMetrics.exact_public_copy_rows_added ?? null) === 4
+            ? 'covered_after_03c_exact_export'
+            : 'missing_exact_export',
+        readiness_missing_before_exports: promoReadinessMetrics.promo_rows_missing_public_copy ?? null,
+        family_rows_added: promoFamilyMetrics.added_public_copy_rows ?? null,
+        exact_rows_added: promoExactMetrics.exact_public_copy_rows_added ?? null,
+        output_public_copy_rows_total: promoExactMetrics.output_public_copy_rows_total ?? null,
+        previously_excluded_rows_resolved: (promoExact.data?.rows ?? []).map((row) => ({
+          gv_id: row.gv_id,
+          name: row.name,
+          family_key: row.family_key,
+        })),
+      },
+      search_contract_health: {
+        status: 'selected_contract_tests_passed',
+        deterministic_search_ai_model_calls_allowed: false,
+        ai_leakage_evidence:
+          'tests/contracts/grookai_ai_search_boundary_v1.test.mjs verifies normal Search does not call AI and Search lane model calls are blocked.',
+      },
+      mobile_parity: {
+        status:
+          webMobilePayloadHash === mobileVariantOrigin.payload_hash &&
+          webVariantOrigin.generated_at === mobileVariantOrigin.generated_at &&
+          webVariantOrigin.source_fingerprint_sha256 === mobileVariantOrigin.source_fingerprint_sha256
+            ? 'synced'
+            : 'out_of_sync',
+        web_generated_at: webVariantOrigin.generated_at ?? null,
+        mobile_generated_at: mobileVariantOrigin.generated_at,
+        web_source_fingerprint_sha256: webVariantOrigin.source_fingerprint_sha256 ?? null,
+        mobile_source_fingerprint_sha256: mobileVariantOrigin.source_fingerprint_sha256,
+        web_mobile_payload_hash: webMobilePayloadHash,
+        mobile_payload_hash: mobileVariantOrigin.payload_hash,
+        web_counts: {
+          families: Object.keys(webMobilePayload.families).length,
+          by_gv_id: Object.keys(webMobilePayload.by_gv_id).length,
+          by_card_print_id: Object.keys(webMobilePayload.by_card_print_id).length,
+        },
+        mobile_counts: {
+          families: Object.keys(mobileVariantOrigin.payload.families ?? {}).length,
+          by_gv_id: Object.keys(mobileVariantOrigin.payload.by_gv_id ?? {}).length,
+          by_card_print_id: Object.keys(mobileVariantOrigin.payload.by_card_print_id ?? {}).length,
+        },
+      },
+      production_smoke: {
+        status: imageRuntimeFailures.length === 0 ? 'sampled_live_image_routes_clear' : 'failures_present',
+        live_base_url: imageRuntime.data?.base_url ?? null,
+        live_routes_checked: imageRuntime.data?.results?.length ?? null,
+        live_failures: imageRuntimeFailures,
+        world_championship_smoke_base_url: worldHttp.base_url ?? null,
+        world_championship_routes_checked: worldHttp.routes?.length ?? null,
+        world_championship_redirects_checked: worldHttp.redirects?.length ?? null,
+        world_championship_local_failures:
+          worldFailures.length + worldHttpFailures + worldDbProbeFailures,
+        world_championship_live_base_url: worldChampLiveSmoke.data?.base_url ?? null,
+        world_championship_live_routes_checked: worldChampLiveSmoke.data?.routes?.length ?? null,
+        world_championship_live_redirects_checked: worldChampLiveSmoke.data?.redirects?.length ?? null,
+        world_championship_live_failures: worldLiveFailures,
+      },
+      base_set_print_run_lanes: {
+        status:
+          baseSetMetrics.applied === true &&
+          baseSetMetrics.updated_rows === 304 &&
+          imageMetrics.base_set_print_run_lane_parent_rows_without_any_image_field === 0
+            ? 'representative_pointer_gap_closed'
+            : 'needs_followup',
+        updated_rows: baseSetMetrics.updated_rows ?? null,
+        image_status: baseSetMetrics.proposed_image_statuses ?? {},
+        current_missing_after_final_scan:
+          imageMetrics.base_set_print_run_lane_parent_rows_without_any_image_field ?? null,
+      },
+      world_championship_rows: {
+        status:
+          (imageMetrics.world_championship_sets_without_60_card_deck_quantity_total ?? null) === 0 &&
+          (imageMetrics.world_championship_parent_rows_without_any_image_field ?? null) === 0
+            ? 'rows_complete_for_beta_display'
+            : 'gaps_present',
+        sets: imageMetrics.world_championship_sets ?? null,
+        card_print_rows: worldDb.counts?.card_print_rows ?? null,
+        deck_quantity_sum_from_card_rows:
+          imageMetrics.world_championship_deck_quantity_sum_from_card_rows ?? null,
+        exact_parent_rows: imageMetrics.world_championship_parent_rows_exact ?? null,
+        representative_parent_rows: imageMetrics.world_championship_parent_rows_representative ?? null,
+      },
+    },
+    launch_blockers_ranked: launchBlockers,
+    followups_ranked: followups,
+    no_write_assertions: {
+      db_writes_performed_by_this_audit: false,
+      storage_writes_performed_by_this_audit: false,
+      migrations_created_by_this_audit: false,
+      ai_model_calls_performed_by_this_audit: false,
+    },
+  };
+
+  report.fingerprint = sha256(JSON.stringify(report));
+  return report;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# ${report.package_id}`,
+    '',
+    `Generated: ${report.generated_at}`,
+    '',
+    '## Summary',
+    '',
+    `- Launch posture: ${report.summary.launch_posture}`,
+    `- Top blocker: ${report.summary.top_blocker}`,
+    `- Mode: ${report.mode}`,
+    '',
+    '## Scope',
+    '',
+    '- Read-only consolidation only.',
+    `- Explicit non-scope: ${report.explicit_non_scope.join(', ')}`,
+    '',
+    '## Lane Status',
+    '',
+    `- Image coverage: ${report.lanes.image_coverage.status}; English physical parent image gaps = ${report.lanes.image_coverage.english_physical_parent_rows_without_any_image_field}; child image field gaps = ${report.lanes.image_coverage.child_rows_without_any_image_field}.`,
+    `- Surface parity: ${report.lanes.surface_parity.status}; curated live routes scanned = ${report.lanes.surface_parity.curated_live_routes_scanned}; curated failures = ${report.lanes.surface_parity.curated_live_failed_routes}; DB-derived card detail routes scanned = ${report.lanes.surface_parity.card_detail_routes_scanned}; DB-derived Dex routes scanned = ${report.lanes.surface_parity.dex_routes_scanned}.`,
+    `- Promo origin coverage: ${report.lanes.promo_origin_coverage.status}; family rows added = ${report.lanes.promo_origin_coverage.family_rows_added}; exact rows added = ${report.lanes.promo_origin_coverage.exact_rows_added}.`,
+    `- Search contract health: ${report.lanes.search_contract_health.status}; normal Search AI model calls allowed = ${report.lanes.search_contract_health.deterministic_search_ai_model_calls_allowed}.`,
+    `- Mobile parity: ${report.lanes.mobile_parity.status}; web/mobile payload hashes match = ${report.lanes.mobile_parity.web_mobile_payload_hash === report.lanes.mobile_parity.mobile_payload_hash}.`,
+    `- Production smoke: ${report.lanes.production_smoke.status}; live routes checked = ${report.lanes.production_smoke.live_routes_checked}; live failures = ${report.lanes.production_smoke.live_failures.length}.`,
+    `- Base Set print-run lanes: ${report.lanes.base_set_print_run_lanes.status}; updated rows = ${report.lanes.base_set_print_run_lanes.updated_rows}; current missing after final scan = ${report.lanes.base_set_print_run_lanes.current_missing_after_final_scan}.`,
+    `- World Championship rows: ${report.lanes.world_championship_rows.status}; sets = ${report.lanes.world_championship_rows.sets}; deck card quantity sum = ${report.lanes.world_championship_rows.deck_quantity_sum_from_card_rows}.`,
+    '',
+    '## Launch Blockers',
+    '',
+    ...report.launch_blockers_ranked.map((finding) => (
+      `${finding.rank}. ${finding.severity} - ${finding.lane}: ${finding.status}. ${finding.finding}`
+    )),
+    '',
+    '## Followups',
+    '',
+    ...report.followups_ranked.map((finding) => (
+      `${finding.rank}. ${finding.severity} - ${finding.lane}: ${finding.status}. ${finding.finding}`
+    )),
+    '',
+    '## Cleared Checks',
+    '',
+    ...report.summary.cleared_checks.map((check) => `- ${check}`),
+    '',
+    '## Evidence',
+    '',
+    ...Object.entries(report.evidence_files).map(([key, value]) => `- ${key}: ${value}`),
+    '',
+    '## Verification',
+    '',
+    `- Contract command run outside this report: \`${report.summary.contract_test_command ?? report.summary.contract_tests_run_separately}\``,
+    `- Report fingerprint: ${report.fingerprint}`,
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+const report = buildReport();
+fs.writeFileSync(outJson, `${JSON.stringify(report, null, 2)}\n`);
+fs.writeFileSync(outMd, renderMarkdown(report));
+console.log(JSON.stringify({
+  package_id: report.package_id,
+  output_json: path.relative(repoRoot, outJson),
+  output_md: path.relative(repoRoot, outMd),
+  launch_posture: report.summary.launch_posture,
+  fingerprint: report.fingerprint,
+}, null, 2));

--- a/scripts/audits/image_truth_v1_img24a_curated_fallback_live_scan.mjs
+++ b/scripts/audits/image_truth_v1_img24a_curated_fallback_live_scan.mjs
@@ -1,0 +1,184 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const OUTPUT_DIR = path.join(ROOT, 'docs', 'audits', 'image_truth_v1');
+const OUTPUT_JSON = path.join(OUTPUT_DIR, 'image_truth_img24a_curated_fallback_live_scan_v1.json');
+const OUTPUT_MD = path.join(OUTPUT_DIR, 'image_truth_img24a_curated_fallback_live_scan_v1.md');
+const PACKAGE_ID = 'IMG-24A-CURATED-FALLBACK-LIVE-SCAN';
+const BASE_URL = (process.env.GROOKAI_WEB_BASE_URL ?? 'https://grookaivault.com').replace(/\/$/, '');
+
+const ROUTES = [
+  {
+    id: 'dex_oshawott_child_fallback',
+    surface: 'dex',
+    path: '/dex/oshawott',
+    expect: ['Oshawott', 'GV-PK-MEP-051'],
+    forbid: ['Image unavailable', 'assets.tcgdex.net/en/tk/', 'assets.tcgdex.net/en/mc/2021swsh/'],
+  },
+  {
+    id: 'card_trainer_kit_sm_lycanroc_representative',
+    surface: 'card_detail',
+    path: '/card/GV-PK-TK-tk-sm-l-1',
+    expect: [
+      'Caterpie',
+      'gv-card-hero-image-stage',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-sm-l/gv-pk-tk-tk-sm-l-1/',
+      'representative_shared',
+    ],
+    forbid: ['Image unavailable', 'assets.tcgdex.net/en/tk/tk-sm-l/', 'cdn.malie.io/file/malie-io/art/cards/jpg/'],
+  },
+  {
+    id: 'card_trainer_kit_dp_lucario_representative',
+    surface: 'card_detail',
+    path: '/card/GV-PK-TK-tk-dp-l-1',
+    expect: [
+      'Geodude',
+      'gv-card-hero-image-stage',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-dp-l/gv-pk-tk-tk-dp-l-1/',
+      'representative_shared',
+    ],
+    forbid: ['Image unavailable', 'assets.tcgdex.net/en/tk/tk-dp-l/', 'static.tcgcollector.com/content/images/'],
+  },
+  {
+    id: 'set_trainer_kit_sm_lycanroc_representative',
+    surface: 'set_detail',
+    path: '/sets/tk-sm-l',
+    expect: [
+      'SM Trainer Kit (Lycanroc)',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-sm-l/',
+      'representative_shared',
+    ],
+    forbid: ['Image unavailable', 'assets.tcgdex.net/en/tk/tk-sm-l/', 'cdn.malie.io/file/malie-io/art/cards/jpg/'],
+  },
+  {
+    id: 'set_trainer_kit_dp_lucario_representative',
+    surface: 'set_detail',
+    path: '/sets/tk-dp-l',
+    expect: [
+      'DP Trainer Kit (Lucario)',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/tk-dp-l/',
+      'representative_shared',
+    ],
+    forbid: ['Image unavailable', 'assets.tcgdex.net/en/tk/tk-dp-l/', 'static.tcgcollector.com/content/images/'],
+  },
+];
+
+function canonicalizeJson(value) {
+  if (Array.isArray(value)) return value.map((entry) => canonicalizeJson(entry));
+  if (!value || typeof value !== 'object') return value;
+  return Object.keys(value)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce((acc, key) => {
+      acc[key] = canonicalizeJson(value[key]);
+      return acc;
+    }, {});
+}
+
+function proofHash(value) {
+  return crypto.createHash('sha256').update(JSON.stringify(canonicalizeJson(value))).digest('hex');
+}
+
+function decodeBody(body) {
+  return String(body ?? '')
+    .replace(/%3A/gi, ':')
+    .replace(/%2F/gi, '/')
+    .replace(/%3F/gi, '?')
+    .replace(/%3D/gi, '=')
+    .replace(/%26/gi, '&')
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/\\u0026/g, '&')
+    .replace(/\\u0027/g, "'");
+}
+
+async function fetchRoute(route) {
+  const response = await fetch(`${BASE_URL}${route.path}`, { redirect: 'manual' });
+  const body = await response.text();
+  const haystack = `${body}\n${decodeBody(body)}`;
+  const missingExpected = route.expect.filter((signal) => !haystack.includes(signal));
+  const presentForbidden = route.forbid.filter((signal) => haystack.includes(signal));
+  return {
+    id: route.id,
+    surface: route.surface,
+    path: route.path,
+    status: response.status,
+    body_length: body.length,
+    expected_signals: route.expect,
+    missing_expected: missingExpected,
+    forbidden_signals: route.forbid,
+    present_forbidden: presentForbidden,
+    passed: response.status === 200 && missingExpected.length === 0 && presentForbidden.length === 0,
+  };
+}
+
+function renderMarkdown(report) {
+  const rows = report.results
+    .map((row) => `| ${row.id} | ${row.surface} | ${row.status} | ${row.passed ? 'PASS' : 'FAIL'} | ${row.missing_expected.join('<br>') || 'none'} | ${row.present_forbidden.join('<br>') || 'none'} |`)
+    .join('\n');
+  return `# ${PACKAGE_ID}
+
+- Generated: ${report.generated_at}
+- Mode: ${report.mode}
+- Base URL: \`${report.base_url}\`
+- Routes scanned: ${report.summary.routes_scanned}
+- Failures: ${report.failures.length}
+- Proof hash: \`${report.proof_hash}\`
+- DB writes performed: false
+- Storage writes performed: false
+- Migrations created: false
+
+## Runtime Routes
+
+| Probe | Surface | HTTP | Result | Missing expected signals | Forbidden signals present |
+| --- | --- | ---: | --- | --- | --- |
+${rows}
+
+## Policy
+
+- This is a non-empty curated runtime scan for fallback/representative image surfaces.
+- It does not write data, upload images, repoint pointers, price anything, or call AI.
+`;
+}
+
+async function main() {
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  const results = [];
+  for (const route of ROUTES) results.push(await fetchRoute(route));
+  const failures = results.filter((row) => !row.passed).map((row) => `route:${row.id}`);
+  const report = {
+    package_id: PACKAGE_ID,
+    generated_at: new Date().toISOString(),
+    mode: 'read_only_curated_live_runtime_scan_no_db_no_storage_no_migration',
+    base_url: BASE_URL,
+    summary: {
+      routes_scanned: results.length,
+      failed_routes: failures.length,
+      surfaces: Array.from(new Set(results.map((row) => row.surface))).sort(),
+    },
+    results,
+    failures,
+    db_writes_performed: false,
+    storage_writes_performed: false,
+    migrations_created: false,
+  };
+  report.proof_hash = proofHash(report);
+  await fs.writeFile(OUTPUT_JSON, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await fs.writeFile(OUTPUT_MD, renderMarkdown(report), 'utf8');
+  console.log(JSON.stringify({
+    package_id: PACKAGE_ID,
+    output_json: path.relative(ROOT, OUTPUT_JSON),
+    output_md: path.relative(ROOT, OUTPUT_MD),
+    routes_scanned: results.length,
+    failures,
+    proof_hash: report.proof_hash,
+  }, null, 2));
+  if (failures.length > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(`[${PACKAGE_ID}] fatal:`, error);
+  process.exitCode = 1;
+});

--- a/scripts/audits/master_index_world_championship_decks_09g_live_prod_smoke_v1.mjs
+++ b/scripts/audits/master_index_world_championship_decks_09g_live_prod_smoke_v1.mjs
@@ -1,0 +1,241 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const OUT_DIR = path.join(ROOT, 'docs', 'audits', 'master_index_world_championship_decks_v1');
+const OUT_JSON = path.join(OUT_DIR, 'world_championship_decks_09g_live_prod_smoke_v1.json');
+const OUT_MD = path.join(OUT_DIR, 'world_championship_decks_09g_live_prod_smoke_v1.md');
+const PACKAGE_ID = 'MASTER-INDEX-WORLD-CHAMPIONSHIP-DECKS-09G-LIVE-PROD-SMOKE';
+const BASE_URL = (process.env.GROOKAI_WEB_BASE_URL ?? 'https://grookaivault.com').replace(/\/$/, '');
+
+const ROUTES = [
+  {
+    id: 'set_magma_spirit',
+    path: '/sets/wcd2004-magma-spirit',
+    expect: [
+      '2004 World Championships Deck: Magma Spirit',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/',
+    ],
+    forbid: ['assets.tcgdex.net', 'Image unavailable'],
+  },
+  {
+    id: 'set_pikarom_judge',
+    path: '/sets/wcd2019-pikarom-judge',
+    expect: [
+      '2019 World Championships Deck: Pikarom Judge',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/',
+    ],
+    forbid: ['assets.tcgdex.net', 'Image unavailable'],
+  },
+  {
+    id: 'set_pult_bomb',
+    path: '/sets/wcd2025-pult-bomb',
+    expect: [
+      '2025 World Championships Deck: Pult Bomb',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/',
+    ],
+    forbid: ['assets.tcgdex.net', 'Image unavailable'],
+  },
+  {
+    id: 'card_magma_spirit_groudon',
+    path: '/card/GV-PK-WCD-2004-MAGMA_SPIRIT-01-EX_TEAM_MAGMA_VS-9-TEAM_MAGMAS_GROUDON',
+    expect: [
+      'Team Magma',
+      'Groudon',
+      'gv-card-hero-image-stage',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/',
+    ],
+    forbid: ['assets.tcgdex.net', 'Image unavailable'],
+  },
+  {
+    id: 'card_pikarom_pikachu_zekrom',
+    path: '/card/GV-PK-WCD-2019-PIKAROM_JUDGE-01-TEAM-33-PIKACHU_AND_ZEKROM_GX',
+    expect: [
+      'Pikachu',
+      'Zekrom',
+      'gv-card-hero-image-stage',
+      'user-card-images/warehouse-derived/self-hosted-images-v1/card_prints/',
+    ],
+    forbid: ['assets.tcgdex.net', 'Image unavailable'],
+  },
+];
+
+const REDIRECTS = [
+  {
+    id: 'search_alias_magma_spirit',
+    path: '/search?q=Magma%20Spirit',
+    expect_location_path: '/sets/wcd2004-magma-spirit',
+  },
+  {
+    id: 'search_alias_pikarom_judge',
+    path: '/search?q=Pikarom%20Judge',
+    expect_location_path: '/sets/wcd2019-pikarom-judge',
+  },
+  {
+    id: 'search_alias_pult_bomb_deck',
+    path: '/search?q=Pult%20Bomb%20deck',
+    expect_location_path: '/sets/wcd2025-pult-bomb',
+  },
+  {
+    id: 'search_alias_world_championship_decks',
+    path: '/search?q=world%20championship%20decks',
+    expect_location_path: '/sets',
+    expect_location_query: 'q=world+championship+decks',
+  },
+];
+
+function canonicalizeJson(value) {
+  if (Array.isArray(value)) return value.map((entry) => canonicalizeJson(entry));
+  if (!value || typeof value !== 'object') return value;
+  return Object.keys(value)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce((acc, key) => {
+      acc[key] = canonicalizeJson(value[key]);
+      return acc;
+    }, {});
+}
+
+function proofHash(value) {
+  return crypto.createHash('sha256').update(JSON.stringify(canonicalizeJson(value))).digest('hex');
+}
+
+function decodeBody(body) {
+  return String(body ?? '')
+    .replace(/%3A/gi, ':')
+    .replace(/%2F/gi, '/')
+    .replace(/%3F/gi, '?')
+    .replace(/%3D/gi, '=')
+    .replace(/%26/gi, '&')
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/\\u0026/g, '&')
+    .replace(/\\u0027/g, "'");
+}
+
+async function fetchRoute(route) {
+  const response = await fetch(`${BASE_URL}${route.path}`, { redirect: 'manual' });
+  const body = await response.text();
+  const haystack = `${body}\n${decodeBody(body)}`;
+  const missingExpected = route.expect.filter((signal) => !haystack.includes(signal));
+  const presentForbidden = route.forbid.filter((signal) => haystack.includes(signal));
+
+  return {
+    id: route.id,
+    path: route.path,
+    status: response.status,
+    body_length: body.length,
+    expected_signals: route.expect,
+    missing_expected: missingExpected,
+    forbidden_signals: route.forbid,
+    present_forbidden: presentForbidden,
+    passed: response.status === 200 && missingExpected.length === 0 && presentForbidden.length === 0,
+  };
+}
+
+async function fetchRedirect(probe) {
+  const response = await fetch(`${BASE_URL}${probe.path}`, { redirect: 'manual' });
+  const location = response.headers.get('location') ?? '';
+  let parsed = null;
+  try {
+    parsed = new URL(location, BASE_URL);
+  } catch {
+    parsed = null;
+  }
+  const actualPath = parsed?.pathname ?? '';
+  const actualQuery = parsed?.searchParams.toString() ?? '';
+  const passed =
+    response.status >= 300 &&
+    response.status < 400 &&
+    actualPath === probe.expect_location_path &&
+    (probe.expect_location_query ? actualQuery === probe.expect_location_query : true);
+
+  return {
+    id: probe.id,
+    path: probe.path,
+    status: response.status,
+    location,
+    expected_location_path: probe.expect_location_path,
+    actual_location_path: actualPath,
+    expected_location_query: probe.expect_location_query ?? null,
+    actual_location_query: actualQuery,
+    passed,
+  };
+}
+
+function renderMarkdown(report) {
+  const routeRows = report.routes
+    .map((row) => `| ${row.id} | ${row.status} | ${row.passed ? 'PASS' : 'FAIL'} | ${row.missing_expected.join('<br>') || 'none'} | ${row.present_forbidden.join('<br>') || 'none'} |`)
+    .join('\n');
+  const redirectRows = report.redirects
+    .map((row) => `| ${row.id} | ${row.status} | ${row.passed ? 'PASS' : 'FAIL'} | ${row.actual_location_path}${row.actual_location_query ? `?${row.actual_location_query}` : ''} |`)
+    .join('\n');
+
+  return `# ${PACKAGE_ID}
+
+- Generated: ${report.generated_at}
+- Mode: ${report.mode}
+- Base URL: \`${report.base_url}\`
+- Failures: ${report.failures.length}
+- Proof hash: \`${report.proof_hash}\`
+- DB writes performed: false
+- Storage writes performed: false
+- Migrations created: false
+
+## Runtime Routes
+
+| Route | HTTP | Result | Missing expected signals | Forbidden signals present |
+| --- | ---: | --- | --- | --- |
+${routeRows}
+
+## Runtime Redirects
+
+| Probe | HTTP | Result | Location |
+| --- | ---: | --- | --- |
+${redirectRows}
+`;
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const routes = [];
+  for (const route of ROUTES) routes.push(await fetchRoute(route));
+  const redirects = [];
+  for (const redirect of REDIRECTS) redirects.push(await fetchRedirect(redirect));
+  const failures = [
+    ...routes.filter((row) => !row.passed).map((row) => `route:${row.id}`),
+    ...redirects.filter((row) => !row.passed).map((row) => `redirect:${row.id}`),
+  ];
+  const report = {
+    package_id: PACKAGE_ID,
+    generated_at: new Date().toISOString(),
+    mode: 'read_only_live_production_http_smoke_no_db_no_storage_no_migration',
+    base_url: BASE_URL,
+    routes,
+    redirects,
+    failures,
+    db_writes_performed: false,
+    storage_writes_performed: false,
+    migrations_created: false,
+  };
+  report.proof_hash = proofHash(report);
+
+  await fs.writeFile(OUT_JSON, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await fs.writeFile(OUT_MD, renderMarkdown(report), 'utf8');
+  console.log(JSON.stringify({
+    package_id: PACKAGE_ID,
+    output_json: path.relative(ROOT, OUT_JSON),
+    output_md: path.relative(ROOT, OUT_MD),
+    routes: routes.length,
+    redirects: redirects.length,
+    failures,
+    proof_hash: report.proof_hash,
+  }, null, 2));
+  if (failures.length > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(`[${PACKAGE_ID}] fatal:`, error);
+  process.exitCode = 1;
+});

--- a/tests/contracts/image_surface_consistency_v1.test.mjs
+++ b/tests/contracts/image_surface_consistency_v1.test.mjs
@@ -50,3 +50,15 @@ test("web image components pass fallback display URLs through product surfaces",
     );
   }
 });
+
+test("card detail suppresses external exact fallbacks when a primary image exists", () => {
+  const cardPage = source("apps/web/src/app/card/[gv_id]/page.tsx");
+
+  assert.match(cardPage, /function buildExactExternalImageFallback/);
+  assert.match(cardPage, /if \(primaryImageUrl\?\.trim\(\)\) return null;/);
+  assert.doesNotMatch(
+    cardPage,
+    /fallbackSrc=\{buildTcgDexImageUrl/,
+    "card detail must not pass direct TCGdex fallbacks behind already-resolved image URLs",
+  );
+});


### PR DESCRIPTION
## What changed

- Added the read-only `GROOKAI_BETA_HARDENING_READINESS_V1` audit and generated JSON/Markdown outputs.
- Added live production smoke coverage for World Championship Deck card pages.
- Added curated fallback live scan coverage for Dex, card detail, and set detail image surfaces.
- Fixed card detail rendering so external TCGdex fallback URLs are not serialized when a primary self-hosted image exists.
- Added a contract assertion to keep card detail from reintroducing direct TCGdex fallback leakage.

## Why

The beta hardening lanes were being tracked separately across image coverage, promo origins, World Championship rows, Base Set print runs, app/web parity, mobile parity, search health, and production smoke. This PR consolidates those into one read-only readiness report and fixes the current top launch blocker found by that report.

Root cause for the WCD production smoke failure: card detail could still serialize an external exact fallback behind an already-resolved primary image. Live production showed this on `card_magma_spirit_groudon` and `card_pikarom_pikachu_zekrom`.

## Impact

After this deploys, WCD card detail pages should stop exposing TCGdex fallback URLs when a self-hosted primary image is available. The readiness audit remains read-only: no DB writes, migrations, image uploads, pointer repoints, pricing, Japanese expansion, or AI expansion.

## Validation

- `git diff --check`
- Pre-commit `shipcheck`
- Pre-push `shipcheck`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run lint`
- `npm run web:build:strict`
- `flutter analyze`
- `flutter test`

## Post-deploy check

After merge/deploy, rerun:

```bash
node scripts/audits/master_index_world_championship_decks_09g_live_prod_smoke_v1.mjs
node scripts/audits/grookai_beta_hardening_readiness_v1.mjs
```

Expected result: the two live WCD fallback leakage failures clear, then the readiness report can be regenerated against the current production state.