### PR TITLE
[codex] add local wishlist matching feed

### DIFF
--- a/apps/web/src/components/network/LocalCommunityFeedCard.tsx
+++ b/apps/web/src/components/network/LocalCommunityFeedCard.tsx
@@ -90,6 +90,11 @@ export default function LocalCommunityFeedCard({
                 Following
               </span>
             ) : null}
+            {row.viewerWishlistMatch ? (
+              <span className="inline-flex rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-700">
+                Wishlist match
+              </span>
+            ) : null}
           </div>
 
           <div className="space-y-2">
@@ -112,6 +117,11 @@ export default function LocalCommunityFeedCard({
             {hasMultipleSources ? (
               <p className="text-sm text-slate-500">
                 Appears in {labels.join(", ")} for this collector.
+              </p>
+            ) : null}
+            {row.matchReason === "viewer_wishlist" ? (
+              <p className="text-sm font-medium text-amber-700">
+                This card matches your wishlist.
               </p>
             ) : null}
           </div>

--- a/apps/web/src/lib/network/getLocalCommunityFeedRows.ts
+++ b/apps/web/src/lib/network/getLocalCommunityFeedRows.ts
@@ -27,6 +27,8 @@ type LocalCommunityFeedRpcRow = {
   locality_label: string | null;
   distance_bucket: string | null;
   relationship_context: string | null;
+  viewer_wishlist_match: boolean | null;
+  match_reason: string | null;
   created_at: string | null;
   route_target: string | null;
 };
@@ -48,6 +50,8 @@ export type LocalCommunityFeedRow = {
   localityLabel: string;
   distanceBucket: "nearby" | "same_region";
   relationshipContext: "following" | "not_following";
+  viewerWishlistMatch: boolean;
+  matchReason: "viewer_wishlist" | null;
   createdAt: string | null;
   routeTarget: string;
 };
@@ -111,6 +115,10 @@ function normalizeRelationshipContext(value: string | null | undefined): LocalCo
   return normalizeText(value) === "following" ? "following" : "not_following";
 }
 
+function normalizeMatchReason(value: string | null | undefined): LocalCommunityFeedRow["matchReason"] {
+  return normalizeText(value) === "viewer_wishlist" ? "viewer_wishlist" : null;
+}
+
 function normalizeRow(row: LocalCommunityFeedRpcRow): LocalCommunityFeedRow | null {
   const feedItemId = normalizeText(row.feed_item_id);
   const ownerSlug = normalizeText(row.owner_slug);
@@ -140,6 +148,8 @@ function normalizeRow(row: LocalCommunityFeedRpcRow): LocalCommunityFeedRow | nu
     localityLabel: normalizeText(row.locality_label) ?? (distanceBucket === "nearby" ? "Nearby" : "Same region"),
     distanceBucket,
     relationshipContext: normalizeRelationshipContext(row.relationship_context),
+    viewerWishlistMatch: row.viewer_wishlist_match === true,
+    matchReason: normalizeMatchReason(row.match_reason),
     createdAt: row.created_at ?? null,
     routeTarget,
   };
@@ -177,7 +187,7 @@ export async function getLocalCommunityFeedRows({
       return { status: "local_discovery_off", rows: [], setting };
     }
 
-    const { data, error } = await supabase.rpc("local_community_feed_v1", {
+    const { data, error } = await supabase.rpc("local_community_feed_v2", {
       p_limit: Math.max(1, Math.min(limit, 80)),
     });
 

--- a/docs/audits/local_community_feed_v1/local_community_wishlist_matching_readiness_v1.json
+++ b/docs/audits/local_community_feed_v1/local_community_wishlist_matching_readiness_v1.json
@@ -1,0 +1,82 @@
+{
+  "audit_id": "LOCAL_COMMUNITY_WISHLIST_MATCHING_READINESS_V1",
+  "generated_at": "2026-06-24T21:02:32.639Z",
+  "status": "PASS",
+  "summary": {
+    "geofence_ready": true,
+    "wishlist_storage_ready": true,
+    "wishlist_matching_ready": true,
+    "no_db_writes": true,
+    "no_migrations_applied": true
+  },
+  "geofence_checks": [
+    {
+      "name": "Local discovery is opt-in",
+      "ok": true,
+      "detail": "collector_local_discovery_settings defaults local discovery off."
+    },
+    {
+      "name": "Location is coarse only",
+      "ok": true,
+      "detail": "Stored locality is region/coarse geohash prefix; exact location is explicitly out of scope."
+    },
+    {
+      "name": "RPC requires auth",
+      "ok": true,
+      "detail": "local_community_feed_v2 is authenticated-only."
+    },
+    {
+      "name": "Only opted-in local collectors qualify",
+      "ok": true,
+      "detail": "Matches are scoped to same country plus exact coarse-prefix or same-region buckets."
+    },
+    {
+      "name": "Blocks and mutes are enforced",
+      "ok": true,
+      "detail": "Muted and blocked collectors are excluded in the SQL."
+    },
+    {
+      "name": "Public projection hides raw identity and location fields",
+      "ok": true,
+      "detail": "Returned columns omit raw owner user IDs and exact/coarse location internals."
+    },
+    {
+      "name": "Web and mobile call the same RPC",
+      "ok": true,
+      "detail": "App/web parity uses the same local community feed RPC."
+    }
+  ],
+  "wishlist_checks": [
+    {
+      "name": "Wishlist table exists",
+      "ok": true,
+      "detail": "Wishlist rows are stored against card_prints IDs."
+    },
+    {
+      "name": "Wishlist RLS is owner-only",
+      "ok": true,
+      "detail": "Wishlist items are protected by user-owned RLS."
+    },
+    {
+      "name": "Wishlist is a known interaction signal",
+      "ok": true,
+      "detail": "card_signals allows wishlist as a signal type."
+    },
+    {
+      "name": "Nearby RPC joins wishlist data",
+      "ok": true,
+      "detail": "Expected when nearby feed can rank or label cards that match the viewer wishlist."
+    },
+    {
+      "name": "Nearby response exposes a wishlist match field",
+      "ok": true,
+      "detail": "Expected when app/web can show a deterministic wishlist-match reason."
+    },
+    {
+      "name": "Nearby surfaces advertise wishlist matching",
+      "ok": true,
+      "detail": "Expected only after the RPC provides deterministic match data."
+    }
+  ],
+  "recommendation": "Run authenticated live RPC smoke with seeded viewer/wishlist rows."
+}

--- a/docs/audits/local_community_feed_v1/local_community_wishlist_matching_readiness_v1.md
+++ b/docs/audits/local_community_feed_v1/local_community_wishlist_matching_readiness_v1.md
@@ -1,0 +1,35 @@
+# Local Community Wishlist Matching Readiness V1
+
+Status: PASS
+Generated: 2026-06-24T21:02:32.639Z
+
+## Summary
+
+- Geofence feed ready: true
+- Wishlist storage ready: true
+- Wishlist matching wired into nearby feed: true
+- No DB writes: true
+- No migrations applied: true
+
+## Geofence Checks
+
+- PASS: Local discovery is opt-in - collector_local_discovery_settings defaults local discovery off.
+- PASS: Location is coarse only - Stored locality is region/coarse geohash prefix; exact location is explicitly out of scope.
+- PASS: RPC requires auth - local_community_feed_v2 is authenticated-only.
+- PASS: Only opted-in local collectors qualify - Matches are scoped to same country plus exact coarse-prefix or same-region buckets.
+- PASS: Blocks and mutes are enforced - Muted and blocked collectors are excluded in the SQL.
+- PASS: Public projection hides raw identity and location fields - Returned columns omit raw owner user IDs and exact/coarse location internals.
+- PASS: Web and mobile call the same RPC - App/web parity uses the same local community feed RPC.
+
+## Wishlist Checks
+
+- PASS: Wishlist table exists - Wishlist rows are stored against card_prints IDs.
+- PASS: Wishlist RLS is owner-only - Wishlist items are protected by user-owned RLS.
+- PASS: Wishlist is a known interaction signal - card_signals allows wishlist as a signal type.
+- PASS: Nearby RPC joins wishlist data - Expected when nearby feed can rank or label cards that match the viewer wishlist.
+- PASS: Nearby response exposes a wishlist match field - Expected when app/web can show a deterministic wishlist-match reason.
+- PASS: Nearby surfaces advertise wishlist matching - Expected only after the RPC provides deterministic match data.
+
+## Recommendation
+
+Run authenticated live RPC smoke with seeded viewer/wishlist rows.

--- a/lib/screens/network/network_nearby_screen.dart
+++ b/lib/screens/network/network_nearby_screen.dart
@@ -310,6 +310,8 @@ class _NearbyCardRow extends StatelessWidget {
                       _NearbyChip(label: row.sourceLabel, accent: true),
                       if (row.isFollowing)
                         const _NearbyChip(label: 'Following', outline: true),
+                      if (row.viewerWishlistMatch)
+                        const _NearbyChip(label: 'Wishlist match', warm: true),
                     ],
                   ),
                   const SizedBox(height: 10),
@@ -344,6 +346,18 @@ class _NearbyCardRow extends StatelessWidget {
                       fontWeight: FontWeight.w700,
                     ),
                   ),
+                  if (row.matchReason == 'viewer_wishlist') ...[
+                    const SizedBox(height: 6),
+                    Text(
+                      'This card matches your wishlist.',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.tertiary,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: 10),
                   Divider(
                     height: 1,
@@ -398,22 +412,30 @@ class _NearbyChip extends StatelessWidget {
     required this.label,
     this.accent = false,
     this.outline = false,
+    this.warm = false,
   });
 
   final String label;
   final bool accent;
   final bool outline;
+  final bool warm;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final background = accent
+    final background = warm
+        ? colorScheme.tertiaryContainer.withValues(alpha: 0.74)
+        : accent
         ? colorScheme.tertiaryContainer.withValues(alpha: 0.58)
         : colorScheme.surfaceContainerHighest.withValues(alpha: 0.58);
-    final borderColor = outline
+    final borderColor = warm
+        ? colorScheme.tertiary.withValues(alpha: 0.34)
+        : outline
         ? colorScheme.primary.withValues(alpha: 0.32)
         : colorScheme.outline.withValues(alpha: 0.08);
-    final textColor = accent
+    final textColor = warm
+        ? colorScheme.onTertiaryContainer
+        : accent
         ? colorScheme.onTertiaryContainer
         : colorScheme.onSurface.withValues(alpha: 0.72);
 

--- a/lib/services/network/local_community_feed_service.dart
+++ b/lib/services/network/local_community_feed_service.dart
@@ -36,6 +36,8 @@ class LocalCommunityFeedRow {
     required this.localityLabel,
     required this.distanceBucket,
     required this.relationshipContext,
+    required this.viewerWishlistMatch,
+    required this.matchReason,
     required this.createdAt,
     required this.routeTarget,
   });
@@ -55,6 +57,8 @@ class LocalCommunityFeedRow {
   final String localityLabel;
   final String distanceBucket;
   final String relationshipContext;
+  final bool viewerWishlistMatch;
+  final String matchReason;
   final DateTime? createdAt;
   final String routeTarget;
 
@@ -113,6 +117,8 @@ class LocalCommunityFeedRow {
       localityLabel: _text(json['locality_label']),
       distanceBucket: _text(json['distance_bucket']),
       relationshipContext: _text(json['relationship_context']),
+      viewerWishlistMatch: json['viewer_wishlist_match'] == true,
+      matchReason: _text(json['match_reason']),
       createdAt: _date(json['created_at']),
       routeTarget: _text(json['route_target']),
     );
@@ -132,7 +138,7 @@ class LocalCommunityFeedService {
 
     final normalizedLimit = limit.clamp(1, 80).toInt();
     final response = await _client.rpc(
-      'local_community_feed_v1',
+      'local_community_feed_v2',
       params: <String, dynamic>{'p_limit': normalizedLimit},
     );
 

--- a/scripts/audits/local_community_wishlist_matching_readiness_v1.mjs
+++ b/scripts/audits/local_community_wishlist_matching_readiness_v1.mjs
@@ -1,0 +1,215 @@
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const ROOT = process.cwd();
+const OUT_DIR = path.join(ROOT, "docs", "audits", "local_community_feed_v1");
+const JSON_PATH = path.join(OUT_DIR, "local_community_wishlist_matching_readiness_v1.json");
+const MD_PATH = path.join(OUT_DIR, "local_community_wishlist_matching_readiness_v1.md");
+
+function read(relativePath) {
+  return fsSync.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function has(source, pattern) {
+  return pattern.test(source);
+}
+
+function check(name, ok, detail) {
+  return { name, ok, detail };
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+
+  const sources = {
+    infraSql: read("supabase/migrations/20260520233000_local_community_feed_infra_v1.sql"),
+    rpcSql: read("supabase/migrations/20260521124500_local_community_feed_rpc_sanitize_images_v1.sql"),
+    rpcV2Sql: read("supabase/migrations/20260624120000_local_community_feed_wishlist_match_v2.sql"),
+    baselineSql: read("supabase/migrations/20251213153625_baseline_init.sql"),
+    policiesSql: read("supabase/migrations/20251213153633_baseline_policies.sql"),
+    signalsSql: read("supabase/migrations/20260324091500_card_interaction_network_phase1_v1.sql"),
+    webHelper: read("apps/web/src/lib/network/getLocalCommunityFeedRows.ts"),
+    webNearby: read("apps/web/src/app/network/nearby/page.tsx"),
+    webCard: read("apps/web/src/components/network/LocalCommunityFeedCard.tsx"),
+    mobileService: read("lib/services/network/local_community_feed_service.dart"),
+    mobileScreen: read("lib/screens/network/network_nearby_screen.dart"),
+  };
+
+  const rpcReturnSignature = sources.rpcSql.match(/returns table \([\s\S]*?\)/i)?.[0] ?? "";
+  const rpcV2ReturnSignature = sources.rpcV2Sql.match(/returns table \([\s\S]*?\)/i)?.[0] ?? "";
+  const nearbySurface = [
+    sources.rpcV2Sql,
+    sources.webHelper,
+    sources.webNearby,
+    sources.webCard,
+    sources.mobileService,
+    sources.mobileScreen,
+  ].join("\n");
+
+  const geofenceChecks = [
+    check(
+      "Local discovery is opt-in",
+      has(sources.infraSql, /local_discovery_enabled boolean not null default false/i),
+      "collector_local_discovery_settings defaults local discovery off.",
+    ),
+    check(
+      "Location is coarse only",
+      has(sources.infraSql, /location_precision text not null default 'coarse'/i)
+        && has(sources.infraSql, /geohash_prefix ~ '\^\[0-9bcdefghjkmnpqrstuvwxyz\]\{3,5\}\$'/i)
+        && has(sources.infraSql, /never exact lat\/lng, address, raw GPS, IP-derived location, or full geohash/i),
+      "Stored locality is region/coarse geohash prefix; exact location is explicitly out of scope.",
+    ),
+    check(
+      "RPC requires auth",
+      has(sources.rpcV2Sql, /v_uid uuid := auth\.uid\(\)/i)
+        && has(sources.rpcV2Sql, /raise exception 'not_authenticated'/i)
+        && has(sources.rpcV2Sql, /revoke all on function public\.local_community_feed_v2\(integer\) from public, anon/i)
+        && has(sources.rpcV2Sql, /grant execute on function public\.local_community_feed_v2\(integer\) to authenticated/i),
+      "local_community_feed_v2 is authenticated-only.",
+    ),
+    check(
+      "Only opted-in local collectors qualify",
+      has(sources.rpcSql, /owner_setting\.local_discovery_enabled is true/i)
+        && has(sources.rpcSql, /owner_setting\.country_code = vs\.country_code/i)
+        && has(sources.rpcSql, /vs\.geohash_prefix = owner_setting\.geohash_prefix[\s\S]*then 'nearby'/i)
+        && has(sources.rpcSql, /vs\.region_code = owner_setting\.region_code[\s\S]*then 'same_region'/i),
+      "Matches are scoped to same country plus exact coarse-prefix or same-region buckets.",
+    ),
+    check(
+      "Blocks and mutes are enforced",
+      has(sources.rpcSql, /local_community_collectors_are_blocked_v1\(v_uid, sr\.owner_user_id\) is false/i)
+        && has(sources.rpcSql, /collector_local_mutes/i),
+      "Muted and blocked collectors are excluded in the SQL.",
+    ),
+    check(
+      "Public projection hides raw identity and location fields",
+      !/owner_user_id|geohash|latitude|longitude|address|gps|email/i.test(rpcReturnSignature),
+      "Returned columns omit raw owner user IDs and exact/coarse location internals.",
+    ),
+    check(
+      "Web and mobile call the same RPC",
+      has(sources.webHelper, /\.rpc\("local_community_feed_v2"/)
+        && has(sources.mobileService, /'local_community_feed_v2'/),
+      "App/web parity uses the same local community feed RPC.",
+    ),
+  ];
+
+  const wishlistChecks = [
+    check(
+      "Wishlist table exists",
+      has(sources.baselineSql, /CREATE TABLE public\.wishlist_items/i)
+        && has(sources.baselineSql, /card_id uuid NOT NULL/i),
+      "Wishlist rows are stored against card_prints IDs.",
+    ),
+    check(
+      "Wishlist RLS is owner-only",
+      has(sources.policiesSql, /CREATE POLICY wl_rw ON public\.wishlist_items USING \(\(auth\.uid\(\) = user_id\)\)/i),
+      "Wishlist items are protected by user-owned RLS.",
+    ),
+    check(
+      "Wishlist is a known interaction signal",
+      has(sources.signalsSql, /'wishlist'/i),
+      "card_signals allows wishlist as a signal type.",
+    ),
+    check(
+      "Nearby RPC joins wishlist data",
+      has(sources.rpcV2Sql, /create or replace function public\.local_community_feed_v2/i)
+        && has(sources.rpcV2Sql, /from public\.wishlist_items wi/i)
+        && has(sources.rpcV2Sql, /wi\.user_id = v_uid/i)
+        && has(sources.rpcV2Sql, /wi\.card_id = sr\.card_print_id/i),
+      "Expected when nearby feed can rank or label cards that match the viewer wishlist.",
+    ),
+    check(
+      "Nearby response exposes a wishlist match field",
+      /viewer_wishlist_match boolean/i.test(rpcV2ReturnSignature)
+        && /match_reason text/i.test(rpcV2ReturnSignature)
+        && !/wishlist_item_id|wishlist_note|viewer_user_id|owner_user_id|card_print_id/i.test(rpcV2ReturnSignature),
+      "Expected when app/web can show a deterministic wishlist-match reason.",
+    ),
+    check(
+      "Nearby surfaces advertise wishlist matching",
+      /local_community_feed_v2/i.test(nearbySurface)
+        && /Wishlist match/.test(nearbySurface)
+        && /This card matches your wishlist\./.test(nearbySurface)
+        && !/wishlist_item_id|wishlist_note|wishlist note|wi\.note/i.test(nearbySurface),
+      "Expected only after the RPC provides deterministic match data.",
+    ),
+  ];
+
+  const geofenceReady = geofenceChecks.every((item) => item.ok);
+  const wishlistStorageReady = wishlistChecks.slice(0, 3).every((item) => item.ok);
+  const wishlistMatchingReady = wishlistChecks.slice(3).every((item) => item.ok);
+  const status = geofenceReady && wishlistStorageReady && wishlistMatchingReady
+    ? "PASS"
+    : geofenceReady && wishlistStorageReady
+      ? "PARTIAL_WISHLIST_MATCHING_NOT_WIRED"
+      : "FAIL";
+
+  const result = {
+    audit_id: "LOCAL_COMMUNITY_WISHLIST_MATCHING_READINESS_V1",
+    generated_at: new Date().toISOString(),
+    status,
+    summary: {
+      geofence_ready: geofenceReady,
+      wishlist_storage_ready: wishlistStorageReady,
+      wishlist_matching_ready: wishlistMatchingReady,
+      no_db_writes: true,
+      no_migrations_applied: true,
+    },
+    geofence_checks: geofenceChecks,
+    wishlist_checks: wishlistChecks,
+    recommendation: wishlistMatchingReady
+      ? "Run authenticated live RPC smoke with seeded viewer/wishlist rows."
+      : "Implement a deterministic wishlist-match layer by joining viewer wishlist_items to eligible local feed rows, returning a non-sensitive match field, and adding web/mobile display parity.",
+  };
+
+  const lines = [
+    "# Local Community Wishlist Matching Readiness V1",
+    "",
+    `Status: ${status}`,
+    `Generated: ${result.generated_at}`,
+    "",
+    "## Summary",
+    "",
+    `- Geofence feed ready: ${geofenceReady}`,
+    `- Wishlist storage ready: ${wishlistStorageReady}`,
+    `- Wishlist matching wired into nearby feed: ${wishlistMatchingReady}`,
+    "- No DB writes: true",
+    "- No migrations applied: true",
+    "",
+    "## Geofence Checks",
+    "",
+    ...geofenceChecks.map((item) => `- ${item.ok ? "PASS" : "FAIL"}: ${item.name} - ${item.detail}`),
+    "",
+    "## Wishlist Checks",
+    "",
+    ...wishlistChecks.map((item) => `- ${item.ok ? "PASS" : "FAIL"}: ${item.name} - ${item.detail}`),
+    "",
+    "## Recommendation",
+    "",
+    result.recommendation,
+  ];
+
+  await fs.writeFile(JSON_PATH, `${JSON.stringify(result, null, 2)}\n`);
+  await fs.writeFile(MD_PATH, `${lines.join("\n")}\n`);
+
+  console.log(JSON.stringify({
+    status,
+    geofenceReady,
+    wishlistStorageReady,
+    wishlistMatchingReady,
+    json: JSON_PATH,
+    markdown: MD_PATH,
+  }, null, 2));
+
+  if (!geofenceReady || !wishlistStorageReady) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/supabase/migrations/20260624120000_local_community_feed_wishlist_match_v2.sql
+++ b/supabase/migrations/20260624120000_local_community_feed_wishlist_match_v2.sql
@@ -1,0 +1,224 @@
+begin;
+
+create or replace function public.local_community_feed_v2(
+  p_limit integer default 40
+)
+returns table (
+  feed_item_id text,
+  source_type text,
+  owner_slug text,
+  owner_display_name text,
+  owner_avatar_path text,
+  gv_id text,
+  card_name text,
+  set_code text,
+  set_name text,
+  card_number text,
+  intent text,
+  image_url text,
+  display_image_kind text,
+  locality_label text,
+  distance_bucket text,
+  relationship_context text,
+  viewer_wishlist_match boolean,
+  match_reason text,
+  created_at timestamptz,
+  route_target text
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_limit integer := least(greatest(coalesce(p_limit, 40), 1), 80);
+begin
+  if v_uid is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  return query
+  with viewer_setting as (
+    select
+      s.user_id,
+      s.local_discovery_enabled,
+      s.area_label,
+      s.region_code,
+      s.country_code,
+      s.geohash_prefix
+    from public.collector_local_discovery_settings s
+    where s.user_id = v_uid
+      and s.local_discovery_enabled is true
+    limit 1
+  ),
+  source_rows as (
+    select
+      'wall_card'::text as source_type,
+      w.owner_user_id,
+      w.owner_slug,
+      w.owner_display_name,
+      w.card_print_id,
+      w.gv_id,
+      w.name as card_name,
+      w.set_code,
+      w.set_name,
+      w.number as card_number,
+      w.intent,
+      w.display_image_url as raw_image_url,
+      w.display_image_kind,
+      w.created_at
+    from public.v_wall_cards_v1 w
+    union all
+    select
+      coalesce(nullif(btrim(s.intent), ''), 'network_card')::text as source_type,
+      s.owner_user_id,
+      s.owner_slug,
+      s.owner_display_name,
+      s.card_print_id,
+      s.gv_id,
+      s.name as card_name,
+      s.set_code,
+      s.set_name,
+      s.number as card_number,
+      s.intent,
+      s.display_image_url as raw_image_url,
+      s.display_image_kind,
+      s.created_at
+    from public.v_card_stream_v1 s
+  ),
+  eligible as (
+    select
+      sr.*,
+      case
+        when nullif(btrim(pp.avatar_path), '') ~* '^https?://' then pp.avatar_path
+        else null::text
+      end as safe_owner_avatar_path,
+      case
+        when nullif(btrim(sr.raw_image_url), '') ~* '^https?://' then sr.raw_image_url
+        else null::text
+      end as safe_image_url,
+      owner_setting.area_label as owner_area_label,
+      case
+        when nullif(btrim(vs.geohash_prefix), '') is not null
+          and nullif(btrim(owner_setting.geohash_prefix), '') is not null
+          and vs.geohash_prefix = owner_setting.geohash_prefix
+          then 'nearby'
+        when nullif(btrim(vs.region_code), '') is not null
+          and vs.region_code = owner_setting.region_code
+          then 'same_region'
+        else null
+      end as local_distance_bucket,
+      case
+        when exists (
+          select 1
+          from public.collector_follows cf
+          where cf.follower_user_id = v_uid
+            and cf.followed_user_id = sr.owner_user_id
+        ) then 'following'
+        else 'not_following'
+      end as local_relationship_context,
+      exists (
+        select 1
+        from public.wishlist_items wi
+        where wi.user_id = v_uid
+          and wi.card_id = sr.card_print_id
+      ) as local_viewer_wishlist_match
+    from viewer_setting vs
+    join source_rows sr
+      on sr.owner_user_id <> v_uid
+    join public.collector_local_discovery_settings owner_setting
+      on owner_setting.user_id = sr.owner_user_id
+     and owner_setting.local_discovery_enabled is true
+     and owner_setting.country_code = vs.country_code
+    join public.public_profiles pp
+      on pp.user_id = sr.owner_user_id
+     and pp.public_profile_enabled is true
+     and pp.vault_sharing_enabled is true
+    where public.local_community_collectors_are_blocked_v1(v_uid, sr.owner_user_id) is false
+      and not exists (
+        select 1
+        from public.collector_local_mutes m
+        where m.muter_user_id = v_uid
+          and m.muted_user_id = sr.owner_user_id
+          and (m.expires_at is null or m.expires_at > now())
+      )
+  ),
+  matched as (
+    select *
+    from eligible e
+    where e.local_distance_bucket is not null
+  ),
+  ranked as (
+    select
+      m.*,
+      row_number() over (
+        partition by
+          m.source_type,
+          m.owner_slug,
+          m.gv_id,
+          coalesce(m.intent, '')
+        order by m.created_at desc, m.owner_slug
+      ) as duplicate_rank
+    from matched m
+  )
+  select
+    md5(concat_ws(
+      ':',
+      ranked.source_type,
+      ranked.owner_slug,
+      ranked.gv_id,
+      coalesce(ranked.intent, ''),
+      ranked.created_at::text
+    )) as feed_item_id,
+    ranked.source_type,
+    ranked.owner_slug,
+    coalesce(nullif(btrim(ranked.owner_display_name), ''), ranked.owner_slug) as owner_display_name,
+    ranked.safe_owner_avatar_path as owner_avatar_path,
+    ranked.gv_id,
+    ranked.card_name,
+    ranked.set_code,
+    ranked.set_name,
+    ranked.card_number,
+    ranked.intent,
+    ranked.safe_image_url as image_url,
+    case
+      when ranked.safe_image_url is null then 'missing'
+      else ranked.display_image_kind
+    end as display_image_kind,
+    coalesce(nullif(btrim(ranked.owner_area_label), ''), case ranked.local_distance_bucket
+      when 'nearby' then 'Nearby'
+      else 'Same region'
+    end) as locality_label,
+    ranked.local_distance_bucket as distance_bucket,
+    ranked.local_relationship_context as relationship_context,
+    ranked.local_viewer_wishlist_match as viewer_wishlist_match,
+    case
+      when ranked.local_viewer_wishlist_match is true then 'viewer_wishlist'
+      else null::text
+    end as match_reason,
+    ranked.created_at,
+    case
+      when nullif(btrim(ranked.gv_id), '') is not null then '/card/' || ranked.gv_id
+      else null
+    end as route_target
+  from ranked
+  where ranked.duplicate_rank = 1
+  order by
+    case ranked.local_relationship_context when 'following' then 0 else 1 end,
+    case when ranked.local_viewer_wishlist_match is true then 0 else 1 end,
+    case ranked.local_distance_bucket when 'nearby' then 0 else 1 end,
+    ranked.created_at desc nulls last,
+    ranked.owner_slug,
+    ranked.gv_id
+  limit v_limit;
+end;
+$$;
+
+comment on function public.local_community_feed_v2(integer) is
+'LOCAL_COMMUNITY_FEED_V2 authenticated nearby feed RPC. Uses auth.uid(), emits no raw user IDs, exact location, wishlist row IDs, private wishlist metadata, or private card IDs; adds deterministic viewer-owned wishlist match metadata.';
+
+revoke all on function public.local_community_feed_v2(integer) from public, anon;
+grant execute on function public.local_community_feed_v2(integer) to authenticated;
+
+commit;

--- a/test/local_community_feed_mobile_test.dart
+++ b/test/local_community_feed_mobile_test.dart
@@ -8,8 +8,9 @@ void main() {
       'lib/services/network/local_community_feed_service.dart',
     ).readAsStringSync();
 
-    expect(service, contains("rpc(\n      'local_community_feed_v1'"));
+    expect(service, contains("rpc(\n      'local_community_feed_v2'"));
     expect(service, isNot(contains('collector_local_discovery_settings')));
+    expect(service, isNot(contains('wishlist_items')));
     expect(service, isNot(contains('geohash')));
     expect(service, isNot(contains('owner_user_id')));
   });

--- a/tests/contracts/local_community_geofence_wishlist_contract_v1.test.mjs
+++ b/tests/contracts/local_community_geofence_wishlist_contract_v1.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function readSource(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+}
+
+test("local community geofence feed stays coarse, authenticated, and opt-in", () => {
+  const infraSql = readSource("supabase/migrations/20260520233000_local_community_feed_infra_v1.sql");
+  const rpcSql = readSource("supabase/migrations/20260521124500_local_community_feed_rpc_sanitize_images_v1.sql");
+  const webHelper = readSource("apps/web/src/lib/network/getLocalCommunityFeedRows.ts");
+  const mobileService = readSource("lib/services/network/local_community_feed_service.dart");
+
+  assert.match(infraSql, /local_discovery_enabled boolean not null default false/i);
+  assert.match(infraSql, /location_precision text not null default 'coarse'/i);
+  assert.match(infraSql, /geohash_prefix ~ '\^\[0-9bcdefghjkmnpqrstuvwxyz\]\{3,5\}\$'/i);
+  assert.match(infraSql, /radius_miles in \(5, 10, 25, 50, 100\)/i);
+  assert.match(infraSql, /never exact lat\/lng, address, raw GPS, IP-derived location, or full geohash/i);
+
+  assert.match(rpcSql, /v_uid uuid := auth\.uid\(\)/i);
+  assert.match(rpcSql, /raise exception 'not_authenticated'/i);
+  assert.match(rpcSql, /sr\.owner_user_id <> v_uid/i);
+  assert.match(rpcSql, /owner_setting\.local_discovery_enabled is true/i);
+  assert.match(rpcSql, /owner_setting\.country_code = vs\.country_code/i);
+  assert.match(rpcSql, /vs\.geohash_prefix = owner_setting\.geohash_prefix[\s\S]*then 'nearby'/i);
+  assert.match(rpcSql, /vs\.region_code = owner_setting\.region_code[\s\S]*then 'same_region'/i);
+  assert.match(rpcSql, /local_community_collectors_are_blocked_v1\(v_uid, sr\.owner_user_id\) is false/i);
+  assert.match(rpcSql, /collector_local_mutes/i);
+  assert.match(rpcSql, /revoke all on function public\.local_community_feed_v1\(integer\) from public, anon/i);
+  assert.match(rpcSql, /grant execute on function public\.local_community_feed_v1\(integer\) to authenticated/i);
+  assert.doesNotMatch(rpcSql.match(/returns table \([\s\S]*?\)/i)?.[0] ?? "", /owner_user_id|geohash|latitude|longitude|address|gps|email/i);
+
+  assert.match(webHelper, /\.rpc\("local_community_feed_v2"/);
+  assert.match(webHelper, /Math\.max\(1, Math\.min\(limit, 80\)\)/);
+  assert.match(mobileService, /'local_community_feed_v2'/);
+  assert.match(mobileService, /limit\.clamp\(1, 80\)/);
+});
+
+test("wishlist infrastructure is wired into the v2 nearby feed without private wishlist leakage", () => {
+  const baselineSql = readSource("supabase/migrations/20251213153625_baseline_init.sql");
+  const policySql = readSource("supabase/migrations/20251213153633_baseline_policies.sql");
+  const signalSql = readSource("supabase/migrations/20260324091500_card_interaction_network_phase1_v1.sql");
+  const rpcSql = readSource("supabase/migrations/20260624120000_local_community_feed_wishlist_match_v2.sql");
+  const webNearby = readSource("apps/web/src/app/network/nearby/page.tsx");
+  const webHelper = readSource("apps/web/src/lib/network/getLocalCommunityFeedRows.ts");
+  const webCard = readSource("apps/web/src/components/network/LocalCommunityFeedCard.tsx");
+  const mobileService = readSource("lib/services/network/local_community_feed_service.dart");
+  const mobileScreen = readSource("lib/screens/network/network_nearby_screen.dart");
+
+  assert.match(baselineSql, /CREATE TABLE public\.wishlist_items/i);
+  assert.match(baselineSql, /card_id uuid NOT NULL/i);
+  assert.match(policySql, /CREATE POLICY wl_rw ON public\.wishlist_items USING \(\(auth\.uid\(\) = user_id\)\)/i);
+  assert.match(signalSql, /'wishlist'/i);
+
+  const returnSignature = rpcSql.match(/returns table \([\s\S]*?\)/i)?.[0] ?? "";
+  const nearbySurface = [rpcSql, webNearby, webHelper, webCard, mobileService, mobileScreen].join("\n");
+  assert.match(rpcSql, /create or replace function public\.local_community_feed_v2/i);
+  assert.match(rpcSql, /from public\.wishlist_items wi/i);
+  assert.match(rpcSql, /wi\.user_id = v_uid/i);
+  assert.match(rpcSql, /wi\.card_id = sr\.card_print_id/i);
+  assert.match(rpcSql, /ranked\.local_viewer_wishlist_match as viewer_wishlist_match/i);
+  assert.match(rpcSql, /then 'viewer_wishlist'/i);
+  assert.match(returnSignature, /viewer_wishlist_match boolean/i);
+  assert.match(returnSignature, /match_reason text/i);
+  assert.doesNotMatch(returnSignature, /wishlist_item_id|wishlist_note|viewer_user_id|owner_user_id|card_print_id/i);
+
+  assert.match(webHelper, /\.rpc\("local_community_feed_v2"/);
+  assert.match(webHelper, /viewerWishlistMatch/);
+  assert.match(webHelper, /matchReason/);
+  assert.match(webCard, /Wishlist match/);
+  assert.match(webCard, /This card matches your wishlist\./);
+  assert.match(mobileService, /'local_community_feed_v2'/);
+  assert.match(mobileService, /viewerWishlistMatch/);
+  assert.match(mobileScreen, /Wishlist match/);
+  assert.match(mobileScreen, /This card matches your wishlist\./);
+  assert.doesNotMatch(nearbySurface, /wishlist_item_id|wishlist_note|wishlist note|wi\.note/i);
+});


### PR DESCRIPTION
## Summary

Adds deterministic wishlist matching to the opt-in local community feed through a new `local_community_feed_v2` RPC and updates web/mobile Nearby surfaces to consume the same match metadata.

## What changed

- Adds authenticated-only `local_community_feed_v2` with `viewer_wishlist_match` and `match_reason`.
- Matches only viewer-owned `wishlist_items` by exact `card_print_id` against eligible nearby feed rows.
- Preserves the existing geofence/block/mute behavior and keeps raw owner IDs, location internals, wishlist row IDs, wishlist private metadata, and private card IDs out of the response.
- Updates web and mobile Nearby cards to show `Wishlist match` when the RPC returns the deterministic flag.
- Adds contract coverage and a readiness audit for geofence plus wishlist matching parity.

## Validation

- `node scripts\audits\local_community_wishlist_matching_readiness_v1.mjs`
- `node --test tests\contracts\local_community_geofence_wishlist_contract_v1.test.mjs`
- `flutter test test\local_community_feed_mobile_test.dart`
- `npm run contracts:test`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run lint` (pre-existing warehouse `<img>` warning only)
- `flutter analyze`
- `npm run web:build:strict` (pre-existing warehouse `<img>` warning only)
- Rollback-only SQL smoke for the new migration
- Pre-push `npm run shipcheck`

## Deployment note

The migration has been syntax-smoked rollback-only locally. It still needs to be applied through the normal deployment path before the v2 Nearby surface can serve from production.