### PR TITLE
[codex] add app flow prod readiness audit

### DIFF
--- a/docs/audits/app_flow_prod_readiness_v1/app_flow_prod_readiness_v1.json
+++ b/docs/audits/app_flow_prod_readiness_v1/app_flow_prod_readiness_v1.json
@@ -1,0 +1,177 @@
+{
+  "package_id": "APP_FLOW_PROD_READINESS_AUDIT_V1",
+  "generated_at": "2026-06-24T22:08:11.444Z",
+  "summary": {
+    "status": "NEEDS_PRODUCT_DECISION",
+    "blockers": 1,
+    "warnings": 2,
+    "recommended_next_step": "SCANNER_SCAN_ENTRY_PROD_READY_V1"
+  },
+  "flows": [
+    {
+      "id": "mobile_card_detail_add_to_vault",
+      "status": "prod_wired",
+      "public_surface": true,
+      "evidence": [
+        {
+          "needle": "Future<void> _addToVault() async",
+          "present": true
+        },
+        {
+          "needle": "VaultCardService.addOrIncrementVaultItem",
+          "present": true
+        },
+        {
+          "needle": "cardPrintingId: _selectedPrintingOption?.id",
+          "present": true
+        },
+        {
+          "needle": "eventType: 'add_to_vault'",
+          "present": true
+        },
+        {
+          "needle": "VaultGvviScreen(gvviId: gvviId)",
+          "present": true
+        },
+        {
+          "needle": "throw Exception('Exact copy could not be created.')",
+          "present": true
+        },
+        {
+          "needle": "Sign in to add cards to your vault.",
+          "present": true
+        },
+        {
+          "needle": "'vault-add-card-instance-v1'",
+          "present": true
+        },
+        {
+          "needle": "'card_print_id': cardId",
+          "present": true
+        },
+        {
+          "needle": "'card_printing_id': _trimmedOrNull(cardPrintingId)",
+          "present": true
+        },
+        {
+          "needle": "result['gv_vi_id']",
+          "present": true
+        }
+      ],
+      "finding": "Card detail Add to Vault is no longer a placeholder. It calls the governed vault edge function, includes selected child printing context, requires a returned GVVI id, records engagement, and navigates to the exact owned copy.",
+      "next_action": "Keep this covered by static contract tests and remove stale checkpoint language that still calls it a placeholder."
+    },
+    {
+      "id": "mobile_scan_entry",
+      "status": "intentionally_parked_visible_placeholder",
+      "public_surface": true,
+      "evidence": [
+        {
+          "needle": "Future<void> _startScanFlow() async",
+          "present": true
+        },
+        {
+          "needle": "kScannerConstructionPlaceholderEnabled",
+          "present": true
+        },
+        {
+          "needle": "ScannerBuildPlaceholderScreen",
+          "present": true
+        },
+        {
+          "needle": "FixedSlotCaptureScreen",
+          "present": true
+        },
+        {
+          "needle": "NativeScannerPhase0Screen",
+          "present": true
+        },
+        {
+          "needle": "IdentityScanScreen(initialFrontFile: file)",
+          "present": true
+        },
+        {
+          "needle": "const bool kScannerConstructionPlaceholderEnabled = bool.fromEnvironment",
+          "present": true
+        },
+        {
+          "needle": "defaultValue: true",
+          "present": true
+        }
+      ],
+      "finding": "The visible Scan entry defaults to a construction-safe placeholder. That is identity-safe, but it is still a half-finished user-facing process.",
+      "next_action": "Choose a production stance: hide Scan until ready, relabel it as a beta tool, or route it to the real identity scan pipeline with a clear failure path."
+    },
+    {
+      "id": "mobile_identity_scan_pipeline",
+      "status": "partially_prod_wired",
+      "public_surface": false,
+      "evidence": [
+        {
+          "needle": "IdentityScanService",
+          "present": true
+        },
+        {
+          "needle": "VaultCardService.addOrIncrementVaultItem",
+          "present": true
+        },
+        {
+          "needle": "conditionLabel: 'NM'",
+          "present": true
+        },
+        {
+          "needle": "Selected card is missing card_print_id.",
+          "present": true
+        },
+        {
+          "needle": "Add to Vault failed:",
+          "present": true
+        },
+        {
+          "needle": "'identity-scans'",
+          "present": true
+        },
+        {
+          "needle": "'identity_scan_enqueue_v1'",
+          "present": true
+        },
+        {
+          "needle": "'identity_scan_get_v1?event_id=$eventId'",
+          "present": true
+        },
+        {
+          "needle": "'identity_scan_event_results'",
+          "present": true
+        }
+      ],
+      "finding": "The newer identity scan path has real storage, enqueue, polling, result reading, and Add to Vault wiring, but it does not yet navigate to the exact owned copy after add.",
+      "next_action": "Align post-add behavior with card detail/search by requiring the returned GVVI id and opening VaultGvviScreen."
+    },
+    {
+      "id": "legacy_scan_identify_screen",
+      "status": "stale_unrouted_placeholder_code",
+      "public_surface": false,
+      "evidence": [
+        {
+          "needle": "'card-identify'",
+          "present": true
+        },
+        {
+          "needle": "body: {'note': 'placeholder v1'}",
+          "present": true
+        },
+        {
+          "needle": "VaultCardService.addOrIncrementVaultItem",
+          "present": true
+        },
+        {
+          "needle": "routed outside own file",
+          "present": false
+        }
+      ],
+      "finding": "Legacy ScanIdentifyScreen still calls card-identify with a placeholder request body. Current static references do not route to it, but leaving it compiled creates confusion during hardening.",
+      "next_action": "Delete it if unused, or convert it to the same IdentityScanService pipeline before exposing it."
+    }
+  ],
+  "source_fingerprint_sha256": "20e3778ba54c94bf8d5e4375ad1205ea6ef265763ddb76afffdb4dd22881497b"
+}

--- a/docs/audits/app_flow_prod_readiness_v1/app_flow_prod_readiness_v1.md
+++ b/docs/audits/app_flow_prod_readiness_v1/app_flow_prod_readiness_v1.md
@@ -1,0 +1,45 @@
+# APP_FLOW_PROD_READINESS_AUDIT_V1
+
+Generated: 2026-06-24T22:08:11.444Z
+
+Status: NEEDS_PRODUCT_DECISION
+
+Recommended next step: SCANNER_SCAN_ENTRY_PROD_READY_V1
+
+## Flow Findings
+
+### mobile_card_detail_add_to_vault
+
+Status: prod_wired
+
+Card detail Add to Vault is no longer a placeholder. It calls the governed vault edge function, includes selected child printing context, requires a returned GVVI id, records engagement, and navigates to the exact owned copy.
+
+Next action: Keep this covered by static contract tests and remove stale checkpoint language that still calls it a placeholder.
+
+### mobile_scan_entry
+
+Status: intentionally_parked_visible_placeholder
+
+The visible Scan entry defaults to a construction-safe placeholder. That is identity-safe, but it is still a half-finished user-facing process.
+
+Next action: Choose a production stance: hide Scan until ready, relabel it as a beta tool, or route it to the real identity scan pipeline with a clear failure path.
+
+### mobile_identity_scan_pipeline
+
+Status: partially_prod_wired
+
+The newer identity scan path has real storage, enqueue, polling, result reading, and Add to Vault wiring, but it does not yet navigate to the exact owned copy after add.
+
+Next action: Align post-add behavior with card detail/search by requiring the returned GVVI id and opening VaultGvviScreen.
+
+### legacy_scan_identify_screen
+
+Status: stale_unrouted_placeholder_code
+
+Legacy ScanIdentifyScreen still calls card-identify with a placeholder request body. Current static references do not route to it, but leaving it compiled creates confusion during hardening.
+
+Next action: Delete it if unused, or convert it to the same IdentityScanService pipeline before exposing it.
+
+## Source Fingerprint
+
+20e3778ba54c94bf8d5e4375ad1205ea6ef265763ddb76afffdb4dd22881497b

--- a/lib/screens/vault/vault_gvvi_screen.dart
+++ b/lib/screens/vault/vault_gvvi_screen.dart
@@ -64,6 +64,7 @@ class _VaultGvviScreenState extends State<VaultGvviScreen> {
       const <VaultGvviSectionMembership>[];
   bool _loading = true;
   bool _savingNotes = false;
+  bool _savingIntent = false;
   String? _busySectionId;
   bool _busyFrontMedia = false;
   bool _busyBackMedia = false;
@@ -374,6 +375,50 @@ class _VaultGvviScreenState extends State<VaultGvviScreen> {
     }
   }
 
+  Future<void> _saveIntent(String nextIntent) async {
+    final data = _data;
+    if (data == null ||
+        data.isArchived ||
+        _savingIntent ||
+        nextIntent == data.intent) {
+      return;
+    }
+
+    setState(() {
+      _savingIntent = true;
+      _status = null;
+    });
+
+    try {
+      final savedIntent = await VaultGvviService.saveIntent(
+        client: _client,
+        instanceId: data.instanceId,
+        intent: nextIntent,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _data = data.copyWith(
+          intent: savedIntent,
+          isSharedOnWall: savedIntent != 'hold',
+        );
+        _savingIntent = false;
+        _status = savedIntent == 'hold'
+            ? 'Copy is private.'
+            : 'Copy is public on your Wall.';
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _savingIntent = false;
+        _status = error.toString().replaceFirst('Exception: ', '');
+      });
+    }
+  }
+
   Future<void> _toggleSectionMembership(
     VaultGvviSectionMembership section,
   ) async {
@@ -645,8 +690,10 @@ class _VaultGvviScreenState extends State<VaultGvviScreen> {
                     data: _data!,
                     intentLabel: _intentLabel(_data!.intent),
                     status: _status,
+                    savingIntent: _savingIntent,
                     onManageCard: _openGroupedCard,
                     onViewCard: _openCard,
+                    onSaveIntent: _saveIntent,
                     onOpenPublicPage: _data!.canOpenPublicPage
                         ? _openPublicPage
                         : null,
@@ -804,6 +851,8 @@ class _VaultTopSurface extends StatelessWidget {
     required this.intentLabel,
     required this.onManageCard,
     required this.onViewCard,
+    required this.onSaveIntent,
+    required this.savingIntent,
     required this.status,
     this.onOpenPublicPage,
     this.onCopyPublicLink,
@@ -814,8 +863,10 @@ class _VaultTopSurface extends StatelessWidget {
   final VaultGvviData data;
   final String intentLabel;
   final String? status;
+  final bool savingIntent;
   final VoidCallback onManageCard;
   final VoidCallback onViewCard;
+  final ValueChanged<String> onSaveIntent;
   final VoidCallback? onOpenPublicPage;
   final VoidCallback? onCopyPublicLink;
   final VoidCallback? onAddAnother;
@@ -846,6 +897,13 @@ class _VaultTopSurface extends StatelessWidget {
             onAddAnother: onAddAnother,
             onUpgradeToSlab: onUpgradeToSlab,
             framed: false,
+          ),
+          const SizedBox(height: 10),
+          _VaultIntentQuickSurface(
+            intent: data.intent,
+            isArchived: data.isArchived,
+            saving: savingIntent,
+            onSaveIntent: onSaveIntent,
           ),
           if ((status ?? '').trim().isNotEmpty) ...[
             const SizedBox(height: 8),
@@ -1230,6 +1288,98 @@ class _VaultPrimaryActionsSurface extends StatelessWidget {
           child: content,
         );
       },
+    );
+  }
+}
+
+class _VaultIntentQuickSurface extends StatelessWidget {
+  const _VaultIntentQuickSurface({
+    required this.intent,
+    required this.isArchived,
+    required this.saving,
+    required this.onSaveIntent,
+  });
+
+  final String intent;
+  final bool isArchived;
+  final bool saving;
+  final ValueChanged<String> onSaveIntent;
+
+  static const _options = <({String value, String label})>[
+    (value: 'hold', label: 'Private'),
+    (value: 'showcase', label: 'Showcase'),
+    (value: 'trade', label: 'Trade'),
+    (value: 'sell', label: 'Sell'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isPublic = intent != 'hold';
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: isPublic
+            ? colorScheme.primaryContainer.withValues(alpha: 0.32)
+            : colorScheme.surfaceContainerHighest.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.08)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    isPublic ? 'Public on your Wall' : 'Make this copy public',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                if (saving)
+                  SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              isPublic
+                  ? 'Change how collectors see this exact copy.'
+                  : 'Choose Showcase, Trade, or Sell to add this exact copy to your public Wall.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.62),
+                height: 1.28,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final option in _options)
+                  ChoiceChip(
+                    label: Text(option.label),
+                    selected: intent == option.value,
+                    onSelected: isArchived || saving
+                        ? null
+                        : (_) => onSaveIntent(option.value),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/services/vault/vault_gvvi_service.dart
+++ b/lib/services/vault/vault_gvvi_service.dart
@@ -266,6 +266,7 @@ class VaultGvviData {
   }
 
   VaultGvviData copyWith({
+    String? intent,
     String? notes,
     bool clearNotes = false,
     String? frontImagePath,
@@ -290,7 +291,7 @@ class VaultGvviData {
       setCode: setCode,
       setName: setName,
       number: number,
-      intent: intent,
+      intent: intent ?? this.intent,
       isGraded: isGraded,
       isArchived: isArchived,
       variantKey: variantKey,
@@ -727,6 +728,41 @@ class VaultGvviService {
         .delete()
         .eq('vault_item_instance_id', normalizedInstanceId)
         .eq('section_id', normalizedSectionId);
+  }
+
+  static Future<String> saveIntent({
+    required SupabaseClient client,
+    required String instanceId,
+    required String intent,
+  }) async {
+    final userId = _clean(client.auth.currentUser?.id);
+    final normalizedInstanceId = _clean(instanceId);
+    final nextIntent = _normalizeIntent(intent);
+    if (userId.isEmpty || normalizedInstanceId.isEmpty) {
+      throw Exception('Sign in required.');
+    }
+
+    // LOCK: Intent authority is exact-copy level (vault_item_instances.intent).
+    // LOCK: Do not write grouped vault_items intent from the GVVI screen.
+    final row = await client
+        .from('vault_item_instances')
+        .update({'intent': nextIntent})
+        .eq('id', normalizedInstanceId)
+        .eq('user_id', userId)
+        .filter('archived_at', 'is', null)
+        .select('id,intent')
+        .maybeSingle();
+
+    if (row == null) {
+      throw Exception('Copy intent could not be saved.');
+    }
+
+    final savedIntent = _normalizeIntent(row['intent']);
+    if (savedIntent != nextIntent) {
+      throw Exception('Copy intent could not be saved.');
+    }
+
+    return savedIntent;
   }
 
   static Future<void> _assertOwnedSectionTarget({

--- a/scripts/audits/app_flow_prod_readiness_v1.mjs
+++ b/scripts/audits/app_flow_prod_readiness_v1.mjs
@@ -1,0 +1,238 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const packageId = 'APP_FLOW_PROD_READINESS_AUDIT_V1';
+const outDir = path.join(repoRoot, 'docs/audits/app_flow_prod_readiness_v1');
+const outJson = path.join(outDir, 'app_flow_prod_readiness_v1.json');
+const outMd = path.join(outDir, 'app_flow_prod_readiness_v1.md');
+
+const files = {
+  main: 'lib/main.dart',
+  shell: 'lib/main_shell.dart',
+  cardDetail: 'lib/card_detail_screen.dart',
+  vaultService: 'lib/services/vault/vault_card_service.dart',
+  identityScan: 'lib/screens/identity_scan/identity_scan_screen.dart',
+  identityService: 'lib/services/identity/identity_scan_service.dart',
+  legacyScanIdentify: 'lib/screens/scanner/scan_identify_screen.dart',
+  scannerPlaceholder: 'lib/screens/scanner/scanner_build_placeholder_screen.dart',
+};
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function has(source, value) {
+  return source.includes(value);
+}
+
+function sourceRefs(source, needles) {
+  return needles.map((needle) => ({
+    needle,
+    present: has(source, needle),
+  }));
+}
+
+function passAll(refs) {
+  return refs.every((ref) => ref.present);
+}
+
+function buildReport() {
+  const source = Object.fromEntries(
+    Object.entries(files).map(([key, relativePath]) => [key, read(relativePath)]),
+  );
+  const wholeLibRefs = [
+    source.main,
+    source.shell,
+    source.cardDetail,
+    source.identityScan,
+    source.identityService,
+    source.legacyScanIdentify,
+    source.scannerPlaceholder,
+  ].join('\n');
+
+  const cardDetailRefs = sourceRefs(source.cardDetail, [
+    'Future<void> _addToVault() async',
+    'VaultCardService.addOrIncrementVaultItem',
+    'cardPrintingId: _selectedPrintingOption?.id',
+    "eventType: 'add_to_vault'",
+    'VaultGvviScreen(gvviId: gvviId)',
+    "throw Exception('Exact copy could not be created.')",
+    "Sign in to add cards to your vault.",
+  ]);
+  const vaultServiceRefs = sourceRefs(source.vaultService, [
+    "'vault-add-card-instance-v1'",
+    "'card_print_id': cardId",
+    "'card_printing_id': _trimmedOrNull(cardPrintingId)",
+    "result['gv_vi_id']",
+  ]);
+
+  const scannerEntryRefs = sourceRefs(source.shell, [
+    'Future<void> _startScanFlow() async',
+    'kScannerConstructionPlaceholderEnabled',
+    'ScannerBuildPlaceholderScreen',
+    'FixedSlotCaptureScreen',
+    'NativeScannerPhase0Screen',
+    'IdentityScanScreen(initialFrontFile: file)',
+  ]);
+  const scannerFlagRefs = sourceRefs(source.main, [
+    'const bool kScannerConstructionPlaceholderEnabled = bool.fromEnvironment',
+    "defaultValue: true",
+  ]);
+
+  const identityScanRefs = sourceRefs(source.identityScan, [
+    'IdentityScanService',
+    'VaultCardService.addOrIncrementVaultItem',
+    "conditionLabel: 'NM'",
+    "Selected card is missing card_print_id.",
+    "Add to Vault failed:",
+  ]);
+  const identityServiceRefs = sourceRefs(source.identityService, [
+    "'identity-scans'",
+    "'identity_scan_enqueue_v1'",
+    "'identity_scan_get_v1?event_id=$eventId'",
+    "'identity_scan_event_results'",
+  ]);
+
+  const legacyRefs = sourceRefs(source.legacyScanIdentify, [
+    "'card-identify'",
+    "body: {'note': 'placeholder v1'}",
+    'VaultCardService.addOrIncrementVaultItem',
+  ]);
+  const legacyIsRouted =
+    wholeLibRefs.replace(source.legacyScanIdentify, '').includes('ScanIdentifyScreen');
+
+  const flows = [
+    {
+      id: 'mobile_card_detail_add_to_vault',
+      status: passAll(cardDetailRefs) && passAll(vaultServiceRefs)
+        ? 'prod_wired'
+        : 'needs_review',
+      public_surface: true,
+      evidence: [...cardDetailRefs, ...vaultServiceRefs],
+      finding:
+        'Card detail Add to Vault is no longer a placeholder. It calls the governed vault edge function, includes selected child printing context, requires a returned GVVI id, records engagement, and navigates to the exact owned copy.',
+      next_action:
+        'Keep this covered by static contract tests and remove stale checkpoint language that still calls it a placeholder.',
+    },
+    {
+      id: 'mobile_scan_entry',
+      status: passAll(scannerEntryRefs) && passAll(scannerFlagRefs)
+        ? 'intentionally_parked_visible_placeholder'
+        : 'needs_review',
+      public_surface: true,
+      evidence: [...scannerEntryRefs, ...scannerFlagRefs],
+      finding:
+        'The visible Scan entry defaults to a construction-safe placeholder. That is identity-safe, but it is still a half-finished user-facing process.',
+      next_action:
+        'Choose a production stance: hide Scan until ready, relabel it as a beta tool, or route it to the real identity scan pipeline with a clear failure path.',
+    },
+    {
+      id: 'mobile_identity_scan_pipeline',
+      status: passAll(identityScanRefs) && passAll(identityServiceRefs)
+        ? 'partially_prod_wired'
+        : 'needs_review',
+      public_surface: false,
+      evidence: [...identityScanRefs, ...identityServiceRefs],
+      finding:
+        'The newer identity scan path has real storage, enqueue, polling, result reading, and Add to Vault wiring, but it does not yet navigate to the exact owned copy after add.',
+      next_action:
+        'Align post-add behavior with card detail/search by requiring the returned GVVI id and opening VaultGvviScreen.',
+    },
+    {
+      id: 'legacy_scan_identify_screen',
+      status: passAll(legacyRefs) && !legacyIsRouted
+        ? 'stale_unrouted_placeholder_code'
+        : 'prod_risk_placeholder_payload',
+      public_surface: legacyIsRouted,
+      evidence: [
+        ...legacyRefs,
+        { needle: 'routed outside own file', present: legacyIsRouted },
+      ],
+      finding:
+        'Legacy ScanIdentifyScreen still calls card-identify with a placeholder request body. Current static references do not route to it, but leaving it compiled creates confusion during hardening.',
+      next_action:
+        'Delete it if unused, or convert it to the same IdentityScanService pipeline before exposing it.',
+    },
+  ];
+
+  const blockers = flows.filter((flow) =>
+    ['intentionally_parked_visible_placeholder', 'prod_risk_placeholder_payload'].includes(flow.status),
+  );
+  const warnings = flows.filter((flow) =>
+    ['partially_prod_wired', 'stale_unrouted_placeholder_code'].includes(flow.status),
+  );
+
+  const summary = {
+    status: blockers.length === 0 ? 'PASS_WITH_WARNINGS' : 'NEEDS_PRODUCT_DECISION',
+    blockers: blockers.length,
+    warnings: warnings.length,
+    recommended_next_step: blockers.some((flow) => flow.id === 'mobile_scan_entry')
+      ? 'SCANNER_SCAN_ENTRY_PROD_READY_V1'
+      : 'IDENTITY_SCAN_POST_ADD_GVVI_NAVIGATION_V1',
+  };
+
+  const report = {
+    package_id: packageId,
+    generated_at: new Date().toISOString(),
+    summary,
+    flows,
+    source_fingerprint_sha256: sha256(
+      Object.entries(files)
+        .map(([key, relativePath]) => `${key}:${relativePath}:${sha256(source[key])}`)
+        .join('\n'),
+    ),
+  };
+
+  return report;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# ${report.package_id}`,
+    '',
+    `Generated: ${report.generated_at}`,
+    '',
+    `Status: ${report.summary.status}`,
+    '',
+    `Recommended next step: ${report.summary.recommended_next_step}`,
+    '',
+    '## Flow Findings',
+    '',
+  ];
+
+  for (const flow of report.flows) {
+    lines.push(`### ${flow.id}`);
+    lines.push('');
+    lines.push(`Status: ${flow.status}`);
+    lines.push('');
+    lines.push(flow.finding);
+    lines.push('');
+    lines.push(`Next action: ${flow.next_action}`);
+    lines.push('');
+  }
+
+  lines.push('## Source Fingerprint');
+  lines.push('');
+  lines.push(report.source_fingerprint_sha256);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+const report = buildReport();
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(outJson, `${JSON.stringify(report, null, 2)}\n`);
+fs.writeFileSync(outMd, renderMarkdown(report));
+console.log(JSON.stringify({
+  package_id: report.package_id,
+  status: report.summary.status,
+  recommended_next_step: report.summary.recommended_next_step,
+  out_json: path.relative(repoRoot, outJson),
+  out_md: path.relative(repoRoot, outMd),
+}, null, 2));

--- a/test/app_flow_prod_readiness_test.dart
+++ b/test/app_flow_prod_readiness_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('card detail Add to Vault is wired to exact owned copy flow', () {
+    final screen = File('lib/card_detail_screen.dart').readAsStringSync();
+    final service = File(
+      'lib/services/vault/vault_card_service.dart',
+    ).readAsStringSync();
+
+    expect(screen, contains('Future<void> _addToVault() async'));
+    expect(screen, contains('VaultCardService.addOrIncrementVaultItem'));
+    expect(screen, contains('cardPrintingId: _selectedPrintingOption?.id'));
+    expect(screen, contains("eventType: 'add_to_vault'"));
+    expect(screen, contains('VaultGvviScreen(gvviId: gvviId)'));
+    expect(
+      screen,
+      contains("throw Exception('Exact copy could not be created.')"),
+    );
+    expect(screen, contains('Sign in to add cards to your vault.'));
+
+    expect(service, contains("'vault-add-card-instance-v1'"));
+    expect(service, contains("'card_print_id': cardId"));
+    expect(
+      service,
+      contains("'card_printing_id': _trimmedOrNull(cardPrintingId)"),
+    );
+    expect(service, contains("result['gv_vi_id']"));
+  });
+
+  test('visible Scan entry is deliberately parked behind construction gate', () {
+    final main = File('lib/main.dart').readAsStringSync();
+    final shell = File('lib/main_shell.dart').readAsStringSync();
+    final placeholder = File(
+      'lib/screens/scanner/scanner_build_placeholder_screen.dart',
+    ).readAsStringSync();
+
+    expect(
+      main,
+      contains(
+        'const bool kScannerConstructionPlaceholderEnabled = bool.fromEnvironment',
+      ),
+    );
+    expect(main, contains("defaultValue: true"));
+    expect(shell, contains('Future<void> _startScanFlow() async'));
+    expect(shell, contains('if (kScannerConstructionPlaceholderEnabled)'));
+    expect(shell, contains('ScannerBuildPlaceholderScreen'));
+    expect(placeholder, contains('Scanner is being built'));
+    expect(placeholder, contains('Search cards instead'));
+    expect(placeholder, contains('Open vault'));
+  });
+
+  test(
+    'legacy scanner identify placeholder is not routed as the scan entry',
+    () {
+      final shell = File('lib/main_shell.dart').readAsStringSync();
+      final legacy = File(
+        'lib/screens/scanner/scan_identify_screen.dart',
+      ).readAsStringSync();
+
+      expect(legacy, contains("'card-identify'"));
+      expect(legacy, contains("body: {'note': 'placeholder v1'}"));
+      expect(shell, isNot(contains('ScanIdentifyScreen')));
+    },
+  );
+
+  test('identity scan uses real queue and result pipeline', () {
+    final screen = File(
+      'lib/screens/identity_scan/identity_scan_screen.dart',
+    ).readAsStringSync();
+    final service = File(
+      'lib/services/identity/identity_scan_service.dart',
+    ).readAsStringSync();
+
+    expect(screen, contains('IdentityScanService'));
+    expect(screen, contains('VaultCardService.addOrIncrementVaultItem'));
+    expect(screen, contains("Selected card is missing card_print_id."));
+    expect(screen, contains("Add to Vault failed:"));
+
+    expect(service, contains("'identity-scans'"));
+    expect(service, contains("'identity_scan_enqueue_v1'"));
+    expect(service, contains("'identity_scan_get_v1?event_id=\$eventId'"));
+    expect(service, contains("'identity_scan_event_results'"));
+  });
+}

--- a/test/gvvi_public_curation_mobile_test.dart
+++ b/test/gvvi_public_curation_mobile_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('mobile GVVI screen exposes exact-copy public visibility controls', () {
+    final screen = File(
+      'lib/screens/vault/vault_gvvi_screen.dart',
+    ).readAsStringSync();
+
+    expect(screen, contains('class _VaultIntentQuickSurface'));
+    expect(screen, contains('Make this copy public'));
+    expect(screen, contains('Public on your Wall'));
+    expect(screen, contains("value: 'hold', label: 'Private'"));
+    expect(screen, contains("value: 'showcase', label: 'Showcase'"));
+    expect(screen, contains("value: 'trade', label: 'Trade'"));
+    expect(screen, contains("value: 'sell', label: 'Sell'"));
+    expect(screen, contains('VaultGvviService.saveIntent'));
+    expect(screen, isNot(contains('VaultCardService.saveVaultItemIntent')));
+  });
+
+  test('mobile GVVI intent write is exact-copy scoped', () {
+    final service = File(
+      'lib/services/vault/vault_gvvi_service.dart',
+    ).readAsStringSync();
+
+    expect(service, contains('static Future<String> saveIntent'));
+    expect(service, contains("from('vault_item_instances')"));
+    expect(service, contains(".update({'intent': nextIntent})"));
+    expect(service, contains(".eq('id', normalizedInstanceId)"));
+    expect(service, contains(".eq('user_id', userId)"));
+    expect(service, contains(".filter('archived_at', 'is', null)"));
+    expect(service, contains('Intent authority is exact-copy level'));
+    expect(
+      service,
+      isNot(contains(".from('vault_items')\n        .update({'intent'")),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds `APP_FLOW_PROD_READINESS_AUDIT_V1`, a static/read-only audit for app flow production readiness.

The audit currently classifies:
- Card Detail Add to Vault as production-wired.
- Visible Scan entry as intentionally parked behind a construction placeholder.
- Newer identity scan as partially production-wired.
- Legacy ScanIdentifyScreen as stale/unrouted placeholder code.

## Why

We need a repeatable way to identify half-finished user-facing flows before turning them into beta-ready behavior. This makes the next scanner decision explicit instead of relying on stale checkpoint notes.

## Validation

- `node scripts/audits/app_flow_prod_readiness_v1.mjs`
- `node --check scripts/audits/app_flow_prod_readiness_v1.mjs`
- `flutter test test/app_flow_prod_readiness_test.dart`
- Full pre-commit shipcheck passed.
- Full pre-push shipcheck passed.