### PR TITLE
[codex] harden mobile GVVI section creation

### DIFF
--- a/lib/screens/vault/vault_gvvi_screen.dart
+++ b/lib/screens/vault/vault_gvvi_screen.dart
@@ -65,6 +65,7 @@ class _VaultGvviScreenState extends State<VaultGvviScreen> {
   bool _loading = true;
   bool _savingNotes = false;
   bool _savingIntent = false;
+  bool _creatingSection = false;
   String? _busySectionId;
   bool _busyFrontMedia = false;
   bool _busyBackMedia = false;
@@ -473,6 +474,92 @@ class _VaultGvviScreenState extends State<VaultGvviScreen> {
     }
   }
 
+  Future<void> _createAndAssignSection() async {
+    final data = _data;
+    if (data == null ||
+        data.isArchived ||
+        _creatingSection ||
+        _busySectionId != null) {
+      return;
+    }
+
+    final controller = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Create section'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          textInputAction: TextInputAction.done,
+          decoration: const InputDecoration(hintText: 'Section name'),
+          onSubmitted: (value) => Navigator.of(dialogContext).pop(value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(controller.text.trim()),
+            child: const Text('Create section'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+
+    final normalizedName = (name ?? '').trim();
+    if (normalizedName.isEmpty || !mounted) {
+      return;
+    }
+
+    setState(() {
+      _creatingSection = true;
+      _status = null;
+    });
+
+    try {
+      final section = await VaultGvviService.createSection(
+        client: _client,
+        name: normalizedName,
+      );
+      await VaultGvviService.assignSectionMembership(
+        client: _client,
+        instanceId: data.instanceId,
+        sectionId: section.id,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _sectionMemberships =
+            [
+              ..._sectionMemberships.where(
+                (current) => current.id != section.id,
+              ),
+              section.copyWith(isMember: true),
+            ]..sort((left, right) {
+              final byPosition = left.position.compareTo(right.position);
+              return byPosition != 0
+                  ? byPosition
+                  : left.name.compareTo(right.name);
+            });
+        _creatingSection = false;
+        _status = 'Section created and copy added.';
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _creatingSection = false;
+        _status = error.toString().replaceFirst('Exception: ', '');
+      });
+    }
+  }
+
   Future<void> _pickMedia(GvviImageSide side) async {
     final data = _data;
     final userId = _client.auth.currentUser?.id;
@@ -713,7 +800,9 @@ class _VaultGvviScreenState extends State<VaultGvviScreen> {
                     child: _VaultSectionMembershipSurface(
                       sections: _sectionMemberships,
                       busySectionId: _busySectionId,
+                      creatingSection: _creatingSection,
                       onToggleSection: _toggleSectionMembership,
+                      onCreateSection: _createAndAssignSection,
                     ),
                   ),
                   const SizedBox(height: 10),
@@ -1388,13 +1477,17 @@ class _VaultSectionMembershipSurface extends StatelessWidget {
   const _VaultSectionMembershipSurface({
     required this.sections,
     required this.busySectionId,
+    required this.creatingSection,
     required this.onToggleSection,
+    required this.onCreateSection,
   });
 
   final List<VaultGvviSectionMembership> sections;
   final String? busySectionId;
+  final bool creatingSection;
   final Future<void> Function(VaultGvviSectionMembership section)
   onToggleSection;
+  final VoidCallback onCreateSection;
 
   @override
   Widget build(BuildContext context) {
@@ -1402,37 +1495,79 @@ class _VaultSectionMembershipSurface extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     if (sections.isEmpty) {
-      return Text(
-        'Not in any sections yet.',
-        style: theme.textTheme.bodySmall?.copyWith(
-          color: colorScheme.onSurface.withValues(alpha: 0.62),
-          height: 1.35,
-        ),
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Not in any sections yet.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurface.withValues(alpha: 0.62),
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: 10),
+          FilledButton.icon(
+            onPressed: creatingSection ? null : onCreateSection,
+            icon: creatingSection
+                ? SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: colorScheme.onPrimary,
+                    ),
+                  )
+                : const Icon(Icons.add),
+            label: Text(creatingSection ? 'Creating...' : 'Create section'),
+          ),
+        ],
       );
     }
 
-    return Wrap(
-      spacing: 8,
-      runSpacing: 8,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (final section in sections)
-          FilterChip(
-            label: Text(section.name),
-            selected: section.isMember,
-            avatar: busySectionId == section.id
-                ? SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: colorScheme.primary,
-                    ),
-                  )
-                : null,
-            onSelected: busySectionId == null
-                ? (_) => unawaited(onToggleSection(section))
-                : null,
-          ),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final section in sections)
+              FilterChip(
+                label: Text(section.name),
+                selected: section.isMember,
+                avatar: busySectionId == section.id
+                    ? SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: colorScheme.primary,
+                        ),
+                      )
+                    : null,
+                onSelected: busySectionId == null && !creatingSection
+                    ? (_) => unawaited(onToggleSection(section))
+                    : null,
+              ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        OutlinedButton.icon(
+          onPressed: creatingSection || busySectionId != null
+              ? null
+              : onCreateSection,
+          icon: creatingSection
+              ? SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: colorScheme.primary,
+                  ),
+                )
+              : const Icon(Icons.add),
+          label: Text(creatingSection ? 'Creating...' : 'Create section'),
+        ),
       ],
     );
   }

--- a/lib/services/vault/vault_gvvi_service.dart
+++ b/lib/services/vault/vault_gvvi_service.dart
@@ -599,6 +599,67 @@ class VaultGvviService {
     );
   }
 
+  static Future<VaultGvviSectionMembership> createSection({
+    required SupabaseClient client,
+    required String name,
+  }) async {
+    final userId = _clean(client.auth.currentUser?.id);
+    final normalizedName = _clean(name).replaceAll(RegExp(r'\s+'), ' ');
+    if (userId.isEmpty) {
+      throw Exception('Sign in required.');
+    }
+    if (normalizedName.isEmpty) {
+      throw Exception('Section name is required.');
+    }
+    if (normalizedName.toLowerCase() == 'wall') {
+      throw Exception('Wall is managed automatically.');
+    }
+
+    final existingRows = await client
+        .from('wall_sections')
+        .select('id,name,position')
+        .eq('user_id', userId)
+        .order('position', ascending: true);
+    final existing = (existingRows as List<dynamic>)
+        .map((row) => Map<String, dynamic>.from(row as Map))
+        .toList();
+    if (existing.any(
+      (row) =>
+          _clean(row['name']).toLowerCase() == normalizedName.toLowerCase(),
+    )) {
+      throw Exception('You already have a section with that name.');
+    }
+
+    final nextPosition =
+        existing.fold<int>(-1, (max, row) {
+          final position = _toInt(row['position']) ?? 0;
+          return position > max ? position : max;
+        }) +
+        1;
+
+    final inserted = await client
+        .from('wall_sections')
+        .insert({
+          'user_id': userId,
+          'name': normalizedName.length > 80
+              ? normalizedName.substring(0, 80)
+              : normalizedName,
+          'position': nextPosition,
+          'is_active': true,
+          'is_public': true,
+        })
+        .select('id,name,position')
+        .single();
+    final row = Map<String, dynamic>.from(inserted as Map);
+
+    return VaultGvviSectionMembership(
+      id: _clean(row['id']),
+      name: _clean(row['name']),
+      position: _toInt(row['position']) ?? nextPosition,
+      isMember: false,
+    );
+  }
+
   static Future<List<VaultGvviSectionMembership>> loadSectionMemberships({
     required SupabaseClient client,
     required String instanceId,

--- a/test/gvvi_public_curation_mobile_test.dart
+++ b/test/gvvi_public_curation_mobile_test.dart
@@ -36,4 +36,43 @@ void main() {
       isNot(contains(".from('vault_items')\n        .update({'intent'")),
     );
   });
+
+  test('mobile GVVI screen can create a Wall section for this exact copy', () {
+    final screen = File(
+      'lib/screens/vault/vault_gvvi_screen.dart',
+    ).readAsStringSync();
+
+    expect(screen, contains('Future<void> _createAndAssignSection()'));
+    expect(screen, contains('Create section'));
+    expect(screen, contains('Section name'));
+    expect(screen, contains('VaultGvviService.createSection'));
+    expect(screen, contains('VaultGvviService.assignSectionMembership'));
+    expect(screen, contains('Section created and copy added.'));
+    expect(screen, contains('creatingSection'));
+    expect(
+      screen,
+      isNot(contains('PublicCollectorService.createOwnerWallSection')),
+    );
+  });
+
+  test('mobile GVVI section creation writes owner sections only', () {
+    final service = File(
+      'lib/services/vault/vault_gvvi_service.dart',
+    ).readAsStringSync();
+
+    expect(
+      service,
+      contains('static Future<VaultGvviSectionMembership> createSection'),
+    );
+    expect(service, contains("from('wall_sections')"));
+    expect(service, contains(".insert({"));
+    expect(service, contains("'user_id': userId"));
+    expect(service, contains("'is_active': true"));
+    expect(service, contains("'is_public': true"));
+    expect(service, contains('Section name is required.'));
+    expect(service, contains('Wall is managed automatically.'));
+    expect(service, contains('You already have a section with that name.'));
+    expect(service, isNot(contains(".from('shared_cards').insert")));
+    expect(service, isNot(contains(".from('vault_items').insert")));
+  });
 }


### PR DESCRIPTION
## Summary
- adds mobile GVVI section creation from the exact-copy page
- immediately assigns the current vault item instance to the new section
- keeps writes scoped to wall_sections and exact-copy wall_section_memberships

## Validation
- flutter analyze lib/screens/vault/vault_gvvi_screen.dart lib/services/vault/vault_gvvi_service.dart test/gvvi_public_curation_mobile_test.dart --no-fatal-infos --no-fatal-warnings
- flutter test test/gvvi_public_curation_mobile_test.dart test/wall_section_membership_assignment_test.dart
- flutter test test/app_wall_sections_parity_test.dart test/wall_section_management_test.dart test/gvvi_public_curation_mobile_test.dart
- node scripts/audits/grookai_beta_hardening_readiness_v1.mjs
- full pre-commit shipcheck
- full pre-push shipcheck