### PR TITLE
[codex] add grouped Vault section assignment

### DIFF
--- a/lib/screens/vault/vault_manage_card_screen.dart
+++ b/lib/screens/vault/vault_manage_card_screen.dart
@@ -67,9 +67,12 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
 
   VaultManageCardData? _data;
   CardSurfacePricingData? _pricing;
+  Map<String, List<VaultManageCopySectionMembership>> _copySectionMemberships =
+      const <String, List<VaultManageCopySectionMembership>>{};
   bool _loading = true;
   bool _intentSaving = false;
   String? _copyIntentSavingId;
+  String? _copySectionSavingKey;
   bool _noteSaving = false;
   bool _priceSaving = false;
   _ManageCardPriceMode _selectedPriceMode = _ManageCardPriceMode.grookai;
@@ -129,6 +132,15 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
         cardPrintIds: <String>[widget.cardPrintId],
       );
       final pricing = pricingById[widget.cardPrintId];
+      var copySectionMemberships =
+          const <String, List<VaultManageCopySectionMembership>>{};
+      try {
+        copySectionMemberships =
+            await VaultCardService.loadCopySectionMemberships(
+              client: _client,
+              instanceIds: data.copies.map((copy) => copy.instanceId),
+            );
+      } catch (_) {}
 
       if (!mounted) {
         return;
@@ -138,6 +150,7 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
       setState(() {
         _data = data;
         _pricing = pricing;
+        _copySectionMemberships = copySectionMemberships;
         _loading = false;
       });
     } catch (error) {
@@ -149,6 +162,8 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
         _error = error is Error
             ? error.toString()
             : 'Unable to load this card.';
+        _copySectionMemberships =
+            const <String, List<VaultManageCopySectionMembership>>{};
         _loading = false;
       });
     }
@@ -582,6 +597,70 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
 
       setState(() {
         _copyIntentSavingId = null;
+      });
+      _showStatus(error.toString().replaceFirst('Exception: ', ''));
+    }
+  }
+
+  Future<void> _toggleCopySectionMembership(
+    VaultManageCardCopy copy,
+    VaultManageCopySectionMembership section,
+  ) async {
+    final sectionKey = '${copy.instanceId}:${section.id}';
+    if (_copySectionSavingKey != null) {
+      return;
+    }
+
+    setState(() {
+      _copySectionSavingKey = sectionKey;
+      _statusMessage = null;
+    });
+
+    try {
+      if (section.isMember) {
+        await VaultCardService.removeCopySectionMembership(
+          client: _client,
+          instanceId: copy.instanceId,
+          sectionId: section.id,
+        );
+      } else {
+        await VaultCardService.assignCopySectionMembership(
+          client: _client,
+          instanceId: copy.instanceId,
+          sectionId: section.id,
+        );
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        final currentSections =
+            _copySectionMemberships[copy.instanceId] ??
+            const <VaultManageCopySectionMembership>[];
+        _copySectionMemberships = {
+          ..._copySectionMemberships,
+          copy.instanceId: currentSections
+              .map(
+                (current) => current.id == section.id
+                    ? current.copyWith(isMember: !section.isMember)
+                    : current,
+              )
+              .toList(growable: false),
+        };
+        _copySectionSavingKey = null;
+        _statusMessage = section.isMember
+            ? 'Copy removed from section.'
+            : 'Copy added to section.';
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _copySectionSavingKey = null;
       });
       _showStatus(error.toString().replaceFirst('Exception: ', ''));
     }
@@ -1442,12 +1521,24 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
                     copy: data.copies[index],
                     intentSaving:
                         _copyIntentSavingId == data.copies[index].instanceId,
+                    sections:
+                        _copySectionMemberships[data
+                            .copies[index]
+                            .instanceId] ??
+                        const <VaultManageCopySectionMembership>[],
+                    busySectionKey: _copySectionSavingKey,
                     onTap: (data.copies[index].gvviId ?? '').trim().isEmpty
                         ? null
                         : () => _openExactCopy(data.copies[index]),
                     onIntentSelected: _copyIntentSavingId == null
                         ? (intent) =>
                               _saveCopyIntent(data.copies[index], intent)
+                        : null,
+                    onToggleSection: _copySectionSavingKey == null
+                        ? (section) => _toggleCopySectionMembership(
+                            data.copies[index],
+                            section,
+                          )
                         : null,
                     secondaryActionLabel:
                         _canUpgradeCopyToSlab(data, data.copies[index])
@@ -1856,16 +1947,22 @@ class _CopyRow extends StatelessWidget {
   const _CopyRow({
     required this.copy,
     required this.intentSaving,
+    required this.sections,
+    this.busySectionKey,
     this.onTap,
     this.onIntentSelected,
+    this.onToggleSection,
     this.secondaryActionLabel,
     this.onSecondaryAction,
   });
 
   final VaultManageCardCopy copy;
   final bool intentSaving;
+  final List<VaultManageCopySectionMembership> sections;
+  final String? busySectionKey;
   final VoidCallback? onTap;
   final ValueChanged<String>? onIntentSelected;
+  final ValueChanged<VaultManageCopySectionMembership>? onToggleSection;
   final String? secondaryActionLabel;
   final VoidCallback? onSecondaryAction;
 
@@ -1942,6 +2039,42 @@ class _CopyRow extends StatelessWidget {
               ),
           ],
         ),
+        if (sections.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Text(
+            'Sections',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: colorScheme.onSurface.withValues(alpha: 0.54),
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.18,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final section in sections)
+                FilterChip(
+                  label: Text(section.name),
+                  selected: section.isMember,
+                  avatar: busySectionKey == '${copy.instanceId}:${section.id}'
+                      ? SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: colorScheme.primary,
+                          ),
+                        )
+                      : null,
+                  onSelected: busySectionKey == null && onToggleSection != null
+                      ? (_) => onToggleSection!(section)
+                      : null,
+                ),
+            ],
+          ),
+        ],
         if (metaParts.isNotEmpty) ...[
           const SizedBox(height: 8),
           Text(

--- a/lib/services/vault/vault_card_service.dart
+++ b/lib/services/vault/vault_card_service.dart
@@ -232,6 +232,29 @@ class VaultManageCardCopy {
   }
 }
 
+class VaultManageCopySectionMembership {
+  const VaultManageCopySectionMembership({
+    required this.id,
+    required this.name,
+    required this.position,
+    required this.isMember,
+  });
+
+  final String id;
+  final String name;
+  final int position;
+  final bool isMember;
+
+  VaultManageCopySectionMembership copyWith({bool? isMember}) {
+    return VaultManageCopySectionMembership(
+      id: id,
+      name: name,
+      position: position,
+      isMember: isMember ?? this.isMember,
+    );
+  }
+}
+
 class VaultManageCardData {
   const VaultManageCardData({
     required this.vaultItemId,
@@ -915,6 +938,159 @@ class VaultCardService {
     return savedIntent;
   }
 
+  static Future<Map<String, List<VaultManageCopySectionMembership>>>
+  loadCopySectionMemberships({
+    required SupabaseClient client,
+    required Iterable<String> instanceIds,
+  }) async {
+    final userId = client.auth.currentUser?.id;
+    if (userId == null || userId.isEmpty) {
+      return const <String, List<VaultManageCopySectionMembership>>{};
+    }
+
+    final normalizedInstanceIds = instanceIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalizedInstanceIds.isEmpty) {
+      return const <String, List<VaultManageCopySectionMembership>>{};
+    }
+
+    final ownershipRows = await client
+        .from('vault_item_instances')
+        .select('id,user_id,archived_at')
+        .eq('user_id', userId)
+        .filter('archived_at', 'is', null)
+        .inFilter('id', normalizedInstanceIds);
+    final ownedInstanceIds = (ownershipRows as List<dynamic>)
+        .map((row) => _trimmedOrNull((row as Map)['id']))
+        .whereType<String>()
+        .toSet();
+    if (ownedInstanceIds.isEmpty) {
+      return const <String, List<VaultManageCopySectionMembership>>{};
+    }
+
+    final results = await Future.wait<dynamic>([
+      client
+          .from('wall_sections')
+          .select('id,name,position,is_active')
+          .eq('user_id', userId)
+          .eq('is_active', true)
+          .order('position', ascending: true)
+          .order('created_at', ascending: true),
+      client
+          .from('wall_section_memberships')
+          .select('section_id,vault_item_instance_id')
+          .inFilter('vault_item_instance_id', ownedInstanceIds.toList()),
+    ]);
+
+    final sectionRows = (results[0] as List<dynamic>)
+        .map((row) => Map<String, dynamic>.from(row as Map))
+        .where((row) {
+          return _trimmedOrNull(row['id']) != null &&
+              _trimmedOrNull(row['name']) != null &&
+              row['is_active'] == true;
+        })
+        .toList(growable: false);
+    final membershipPairs = (results[1] as List<dynamic>)
+        .map((row) => Map<String, dynamic>.from(row as Map))
+        .map(
+          (row) =>
+              '${_trimmedOrNull(row['vault_item_instance_id']) ?? ''}:${_trimmedOrNull(row['section_id']) ?? ''}',
+        )
+        .where((value) => !value.endsWith(':') && !value.startsWith(':'))
+        .toSet();
+
+    return <String, List<VaultManageCopySectionMembership>>{
+      for (final instanceId in ownedInstanceIds)
+        instanceId: sectionRows
+            .map((row) {
+              final sectionId = _trimmedOrNull(row['id'])!;
+              return VaultManageCopySectionMembership(
+                id: sectionId,
+                name: _trimmedOrNull(row['name'])!,
+                position: _toInt(row['position']) ?? 0,
+                isMember: membershipPairs.contains('$instanceId:$sectionId'),
+              );
+            })
+            .toList(growable: false),
+    };
+  }
+
+  static Future<void> assignCopySectionMembership({
+    required SupabaseClient client,
+    required String instanceId,
+    required String sectionId,
+  }) async {
+    final userId = client.auth.currentUser?.id;
+    final normalizedInstanceId = _trimmedOrNull(instanceId);
+    final normalizedSectionId = _trimmedOrNull(sectionId);
+    if (userId == null ||
+        userId.isEmpty ||
+        normalizedInstanceId == null ||
+        normalizedSectionId == null ||
+        normalizedSectionId.toLowerCase() == 'wall') {
+      throw Exception('Section assignment could not be saved.');
+    }
+
+    await _assertOwnedSectionTarget(
+      client: client,
+      userId: userId,
+      instanceId: normalizedInstanceId,
+      sectionId: normalizedSectionId,
+    );
+
+    final existing = await client
+        .from('wall_section_memberships')
+        .select('section_id')
+        .eq('vault_item_instance_id', normalizedInstanceId)
+        .eq('section_id', normalizedSectionId)
+        .maybeSingle();
+    if (existing != null) {
+      return;
+    }
+
+    // LOCK: Grouped card row section assignment is exact-copy only.
+    // LOCK: Do not write shared_cards or grouped vault_items.
+    await client.from('wall_section_memberships').insert({
+      'section_id': normalizedSectionId,
+      'vault_item_instance_id': normalizedInstanceId,
+    });
+  }
+
+  static Future<void> removeCopySectionMembership({
+    required SupabaseClient client,
+    required String instanceId,
+    required String sectionId,
+  }) async {
+    final userId = client.auth.currentUser?.id;
+    final normalizedInstanceId = _trimmedOrNull(instanceId);
+    final normalizedSectionId = _trimmedOrNull(sectionId);
+    if (userId == null ||
+        userId.isEmpty ||
+        normalizedInstanceId == null ||
+        normalizedSectionId == null ||
+        normalizedSectionId.toLowerCase() == 'wall') {
+      throw Exception('Section assignment could not be saved.');
+    }
+
+    await _assertOwnedSectionTarget(
+      client: client,
+      userId: userId,
+      instanceId: normalizedInstanceId,
+      sectionId: normalizedSectionId,
+    );
+
+    // LOCK: Grouped card row section removal is exact-copy only.
+    // LOCK: Do not write shared_cards or grouped vault_items.
+    await client
+        .from('wall_section_memberships')
+        .delete()
+        .eq('vault_item_instance_id', normalizedInstanceId)
+        .eq('section_id', normalizedSectionId);
+  }
+
   static Future<String?> saveSharedCardWallCategory({
     required SupabaseClient client,
     required String cardPrintId,
@@ -1070,6 +1246,34 @@ class VaultCardService {
           _normalizeCurrency(updated['asking_price_currency']) ??
           normalizedCurrency,
     );
+  }
+
+  static Future<void> _assertOwnedSectionTarget({
+    required SupabaseClient client,
+    required String userId,
+    required String instanceId,
+    required String sectionId,
+  }) async {
+    final results = await Future.wait<dynamic>([
+      client
+          .from('vault_item_instances')
+          .select('id,user_id,archived_at')
+          .eq('id', instanceId)
+          .eq('user_id', userId)
+          .filter('archived_at', 'is', null)
+          .maybeSingle(),
+      client
+          .from('wall_sections')
+          .select('id,user_id,is_active')
+          .eq('id', sectionId)
+          .eq('user_id', userId)
+          .eq('is_active', true)
+          .maybeSingle(),
+    ]);
+
+    if (results[0] == null || results[1] == null) {
+      throw Exception('Section assignment could not be saved.');
+    }
   }
 
   static Future<Map<String, dynamic>?> _loadSharedCardRow({
@@ -1342,6 +1546,16 @@ double? _toMoney(dynamic value) {
     return null;
   }
   return double.parse(parsed.toStringAsFixed(2));
+}
+
+int? _toInt(dynamic value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  return int.tryParse((value ?? '').toString().trim());
 }
 
 String _deriveManageCardIntent({required List<VaultManageCardCopy> copies}) {

--- a/test/grouped_vault_management_mobile_test.dart
+++ b/test/grouped_vault_management_mobile_test.dart
@@ -18,6 +18,21 @@ void main() {
     expect(screen, contains('data.inPlayCount > 0'));
   });
 
+  test('grouped card copy rows expose exact-copy section controls', () {
+    final screen = File(
+      'lib/screens/vault/vault_manage_card_screen.dart',
+    ).readAsStringSync();
+
+    expect(screen, contains('Future<void> _toggleCopySectionMembership'));
+    expect(screen, contains('VaultCardService.loadCopySectionMemberships'));
+    expect(screen, contains('VaultCardService.assignCopySectionMembership'));
+    expect(screen, contains('VaultCardService.removeCopySectionMembership'));
+    expect(screen, contains('onToggleSection'));
+    expect(screen, contains('FilterChip'));
+    expect(screen, contains('Copy added to section.'));
+    expect(screen, contains('Copy removed from section.'));
+  });
+
   test('copy-row intent writes are exact-copy scoped', () {
     final service = File(
       'lib/services/vault/vault_card_service.dart',
@@ -42,5 +57,51 @@ void main() {
     expect(methodSource, isNot(contains("from('vault_items')")));
     expect(methodSource, isNot(contains("from('shared_cards')")));
     expect(methodSource, isNot(contains('legacy_vault_item_id')));
+  });
+
+  test('copy-row section writes are exact-copy scoped', () {
+    final service = File(
+      'lib/services/vault/vault_card_service.dart',
+    ).readAsStringSync();
+    final assignStart = service.indexOf(
+      'static Future<void> assignCopySectionMembership',
+    );
+    final removeStart = service.indexOf(
+      'static Future<void> removeCopySectionMembership',
+    );
+    final boundary = service.indexOf(
+      'static Future<String?> saveSharedCardWallCategory',
+    );
+    expect(assignStart, greaterThanOrEqualTo(0));
+    expect(removeStart, greaterThan(assignStart));
+    expect(boundary, greaterThan(removeStart));
+    final sectionSource = service.substring(assignStart, boundary);
+
+    expect(sectionSource, contains("from('wall_section_memberships')"));
+    expect(
+      sectionSource,
+      contains("'vault_item_instance_id': normalizedInstanceId"),
+    );
+    expect(
+      sectionSource,
+      contains(".eq('vault_item_instance_id', normalizedInstanceId)"),
+    );
+    expect(
+      sectionSource,
+      contains('Grouped card row section assignment is exact-copy only'),
+    );
+    expect(
+      sectionSource,
+      contains('Grouped card row section removal is exact-copy only'),
+    );
+    expect(sectionSource, isNot(contains("from('vault_items')")));
+    expect(sectionSource, isNot(contains("from('shared_cards')")));
+    expect(sectionSource, isNot(contains('legacy_vault_item_id')));
+    expect(service, contains('static Future<void> _assertOwnedSectionTarget'));
+    expect(service, contains("from('vault_item_instances')"));
+    expect(service, contains("from('wall_sections')"));
+    expect(service, contains(".eq('id', instanceId)"));
+    expect(service, contains(".eq('user_id', userId)"));
+    expect(service, contains(".filter('archived_at', 'is', null)"));
   });
 }


### PR DESCRIPTION
## Summary
- adds exact-copy section chips to grouped mobile Vault copy rows
- loads owner section membership for visible copies without blocking the grouped card page
- assigns/removes sections only through wall_section_memberships using vault_item_instances.id

## Validation
- flutter analyze lib/screens/vault/vault_manage_card_screen.dart lib/services/vault/vault_card_service.dart test/grouped_vault_management_mobile_test.dart --no-fatal-infos --no-fatal-warnings
- flutter test test/grouped_vault_management_mobile_test.dart test/wall_section_membership_assignment_test.dart test/app_wall_sections_parity_test.dart
- full pre-commit shipcheck
- full pre-push shipcheck