### PR TITLE
[codex] add web exact-copy Vault curation

### DIFF
--- a/apps/web/src/app/vault/card/[cardId]/page.tsx
+++ b/apps/web/src/app/vault/card/[cardId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import PublicCardImage from "@/components/PublicCardImage";
 import ShareCardButton from "@/components/ShareCardButton";
 import TrackPageEvent from "@/components/telemetry/TrackPageEvent";
+import VaultManageCopyCurationControls from "@/components/vault/VaultManageCopyCurationControls";
 import VaultManageCardSettingsPanel from "@/components/vault/VaultManageCardSettingsPanel";
 import OwnedObjectRemoveAction from "@/components/vault/OwnedObjectRemoveAction";
 import PageSection from "@/components/layout/PageSection";
@@ -26,6 +27,7 @@ import {
 import { getVaultIntentLabel } from "@/lib/network/intent";
 import { createServerComponentClient } from "@/lib/supabase/server";
 import { getOwnerVaultItems } from "@/lib/vault/getOwnerVaultItems";
+import { getOwnerWallSectionMemberships } from "@/lib/wallSections/getOwnerWallSectionMemberships";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -74,6 +76,13 @@ export default async function VaultManageCardPage({
     activeMessageCount: item.active_message_count,
   });
   const displayIdentity = resolveDisplayIdentity(item);
+  const sectionMembershipEntries = await Promise.all(
+    item.copy_items.map(async (copy) => [
+      copy.instance_id,
+      await getOwnerWallSectionMemberships(user.id, copy.instance_id),
+    ] as const),
+  );
+  const sectionMembershipByInstanceId = new Map(sectionMembershipEntries);
 
   return (
     <>
@@ -197,7 +206,7 @@ export default async function VaultManageCardPage({
           </PageSection>
         ) : null}
 
-        {/* LOCK: Grouped card pages must not expose Wall or Section write actions. */}
+        {/* LOCK: Grouped card pages may expose curation only inside exact-copy rows. */}
         <VaultManageCardSettingsPanel
           item={item}
           publicCollectionHref={item.in_play_count > 0 ? publicCollectionHref : null}
@@ -261,6 +270,18 @@ export default async function VaultManageCardPage({
                         />
                       </div>
                     </div>
+                    <VaultManageCopyCurationControls
+                      instanceId={copy.instance_id}
+                      initialIntent={copy.intent}
+                      membershipModel={
+                        sectionMembershipByInstanceId.get(copy.instance_id) ?? {
+                          instanceId: copy.instance_id,
+                          sections: [],
+                          loadError: "Section assignments could not be loaded.",
+                        }
+                      }
+                      isActive
+                    />
                   </VaultInsetCard>
                 );
               })}

--- a/apps/web/src/components/vault/VaultManageCopyCurationControls.tsx
+++ b/apps/web/src/components/vault/VaultManageCopyCurationControls.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import {
+  getVaultIntentHelper,
+  getVaultIntentLabel,
+  type VaultIntent,
+} from "@/lib/network/intent";
+import { saveVaultItemInstanceIntentAction } from "@/lib/network/saveVaultItemInstanceIntentAction";
+import { assignWallSectionMembershipAction } from "@/lib/wallSections/assignWallSectionMembershipAction";
+import { removeWallSectionMembershipAction } from "@/lib/wallSections/removeWallSectionMembershipAction";
+import {
+  WALL_SECTION_HELPER_COPY,
+  type OwnerWallSectionMembership,
+  type OwnerWallSectionMembershipModel,
+  type WallSectionMembershipActionResult,
+} from "@/lib/wallSections/wallSectionTypes";
+
+const INTENT_OPTIONS: VaultIntent[] = ["hold", "trade", "sell", "showcase"];
+
+type VaultManageCopyCurationControlsProps = {
+  instanceId: string;
+  initialIntent: VaultIntent;
+  membershipModel: OwnerWallSectionMembershipModel;
+  isActive: boolean;
+};
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function resolveStatusTone(result: { ok: boolean } | null): "success" | "error" | null {
+  if (!result) {
+    return null;
+  }
+
+  return result.ok ? "success" : "error";
+}
+
+export default function VaultManageCopyCurationControls({
+  instanceId,
+  initialIntent,
+  membershipModel,
+  isActive,
+}: VaultManageCopyCurationControlsProps) {
+  const router = useRouter();
+  const [intent, setIntent] = useState(initialIntent);
+  const [sections, setSections] = useState<OwnerWallSectionMembership[]>(membershipModel.sections);
+  const [statusMessage, setStatusMessage] = useState<{ ok: boolean; message: string } | null>(
+    membershipModel.loadError
+      ? {
+          ok: false,
+          message: membershipModel.loadError,
+        }
+      : null,
+  );
+  const [pendingIntent, setPendingIntent] = useState<VaultIntent | null>(null);
+  const [pendingSectionId, setPendingSectionId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    setIntent(initialIntent);
+  }, [initialIntent]);
+
+  useEffect(() => {
+    setSections(membershipModel.sections);
+  }, [membershipModel.sections]);
+
+  const statusTone = resolveStatusTone(statusMessage);
+  const assignedCount = sections.filter((section) => section.is_member).length;
+  const disabled = !isActive || pendingIntent !== null || pendingSectionId !== null;
+
+  function applyMembershipResult(result: WallSectionMembershipActionResult) {
+    setStatusMessage(result);
+    if (result.sections) {
+      setSections(result.sections);
+    }
+  }
+
+  function handleIntentChange(nextIntent: VaultIntent) {
+    if (disabled || nextIntent === intent) {
+      return;
+    }
+
+    const previousIntent = intent;
+    setIntent(nextIntent);
+    setPendingIntent(nextIntent);
+    setStatusMessage(null);
+
+    startTransition(async () => {
+      try {
+        const result = await saveVaultItemInstanceIntentAction({
+          instanceId,
+          intent: nextIntent,
+        });
+
+        if (!result.ok) {
+          setIntent(previousIntent);
+          setStatusMessage({ ok: false, message: result.message });
+          return;
+        }
+
+        setIntent(result.intent);
+        setStatusMessage({ ok: true, message: "Copy visibility saved." });
+        router.refresh();
+      } catch {
+        setIntent(previousIntent);
+        setStatusMessage({ ok: false, message: "Copy visibility could not be saved." });
+      } finally {
+        setPendingIntent(null);
+      }
+    });
+  }
+
+  function handleSectionToggle(section: OwnerWallSectionMembership) {
+    if (disabled) {
+      return;
+    }
+
+    setPendingSectionId(section.id);
+    setStatusMessage(null);
+
+    startTransition(async () => {
+      try {
+        const result = section.is_member
+          ? await removeWallSectionMembershipAction({
+              sectionId: section.id,
+              vaultItemInstanceId: instanceId,
+            })
+          : await assignWallSectionMembershipAction({
+              sectionId: section.id,
+              vaultItemInstanceId: instanceId,
+            });
+
+        applyMembershipResult(result);
+        router.refresh();
+      } catch {
+        setStatusMessage({
+          ok: false,
+          message: "Section assignment could not be saved.",
+        });
+      } finally {
+        setPendingSectionId(null);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-4 border-t border-slate-200 pt-4">
+      <div className="space-y-1">
+        {/* LOCK: Grouped card row curation is exact-copy only (vault_item_instances.id). */}
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">Organize Copy</p>
+        <p className="text-xs leading-5 text-slate-500">
+          Intent controls Wall visibility. Sections place this exact copy on your public Wall.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">Visibility</p>
+        <div className="grid gap-2 sm:grid-cols-4">
+          {INTENT_OPTIONS.map((option) => {
+            const selected = intent === option;
+            const pending = pendingIntent === option;
+            return (
+              <button
+                key={option}
+                type="button"
+                disabled={disabled}
+                onClick={() => handleIntentChange(option)}
+                className={cx(
+                  "rounded-full border px-3 py-2 text-xs font-medium transition",
+                  selected
+                    ? "border-slate-950 bg-slate-950 text-white"
+                    : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50",
+                  disabled ? "cursor-not-allowed opacity-70" : "",
+                )}
+              >
+                {pending ? "Saving..." : getVaultIntentLabel(option)}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-slate-500">{getVaultIntentHelper(intent)}</p>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">Sections</p>
+          {sections.length > 0 ? (
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-600">
+              {assignedCount} selected
+            </span>
+          ) : null}
+        </div>
+
+        {sections.length === 0 ? (
+          <div className="rounded-[1rem] border border-dashed border-slate-300 bg-slate-50 px-4 py-4 text-xs leading-6 text-slate-600">
+            <p>Not in any sections yet.</p>
+            <p className="mt-1">{WALL_SECTION_HELPER_COPY}</p>
+            <Link
+              href="/account"
+              className="mt-3 inline-flex rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Create section
+            </Link>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {sections.map((section) => {
+              const pending = pendingSectionId === section.id;
+              return (
+                <button
+                  key={section.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => handleSectionToggle(section)}
+                  className={cx(
+                    "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition",
+                    section.is_member
+                      ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+                      : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50",
+                    disabled ? "cursor-not-allowed opacity-70" : "",
+                  )}
+                >
+                  <span>{section.name}</span>
+                  <span className="text-[10px] uppercase tracking-[0.14em]">
+                    {pending ? "Saving" : section.is_member ? "Added" : "Add"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {!isActive ? (
+        <p className="text-xs text-slate-500">This copy is archived. Curation is historical.</p>
+      ) : null}
+
+      {statusMessage?.message ? (
+        <p className={`text-xs ${statusTone === "success" ? "text-emerald-700" : "text-rose-700"}`}>
+          {statusMessage.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/vault/vaultCurationOwnership.test.mjs
+++ b/apps/web/src/components/vault/vaultCurationOwnership.test.mjs
@@ -49,6 +49,20 @@ test("grouped card page keeps copy-management path", () => {
   assert.match(groupedPage, /Open copy/);
 });
 
+test("grouped card copy rows render exact-copy curation controls", () => {
+  const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const copyControls = readSource("components", "vault", "VaultManageCopyCurationControls.tsx");
+
+  assert.match(groupedPage, /getOwnerWallSectionMemberships\(user\.id, copy\.instance_id\)/);
+  assert.match(groupedPage, /VaultManageCopyCurationControls/);
+  assert.match(groupedPage, /instanceId=\{copy\.instance_id\}/);
+  assert.match(groupedPage, /initialIntent=\{copy\.intent\}/);
+  assert.match(copyControls, /saveVaultItemInstanceIntentAction/);
+  assert.match(copyControls, /assignWallSectionMembershipAction/);
+  assert.match(copyControls, /removeWallSectionMembershipAction/);
+  assert.match(copyControls, /vault_item_instances\.id/);
+});
+
 test("GVVI page renders exact-copy section membership controls", () => {
   const gvviPage = readSource("app", "vault", "gvvi", "[gvvi_id]", "page.tsx");
   const sectionCard = readSource("components", "vault", "VaultInstanceSectionMembershipCard.tsx");
@@ -79,15 +93,18 @@ test("legacy grouped compatibility data does not appear as section UI", () => {
   assert.match(sharedCards, /Legacy grouped wall_category must not surface as the section system/);
 });
 
-test("exact-copy curation remains available only on GVVI surfaces", () => {
+test("exact-copy curation remains exact-copy scoped on GVVI and grouped copy rows", () => {
   const groupedPanel = readSource("components", "vault", "VaultManageCardSettingsPanel.tsx");
   const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const copyControls = readSource("components", "vault", "VaultManageCopyCurationControls.tsx");
   const gvviPage = readSource("app", "vault", "gvvi", "[gvvi_id]", "page.tsx");
   const settingsCard = readSource("components", "vault", "VaultInstanceSettingsCard.tsx");
   const assignAction = readSource("lib", "wallSections", "assignWallSectionMembershipAction.ts");
   const removeAction = readSource("lib", "wallSections", "removeWallSectionMembershipAction.ts");
 
-  assert.doesNotMatch(`${groupedPanel}\n${groupedPage}`, /assignWallSectionMembershipAction|removeWallSectionMembershipAction|saveVaultItemInstanceIntentAction/);
+  assert.doesNotMatch(groupedPanel, /assignWallSectionMembershipAction|removeWallSectionMembershipAction|saveVaultItemInstanceIntentAction/);
+  assert.match(groupedPage, /copy\.instance_id/);
+  assert.match(copyControls, /instanceId/);
   assert.match(gvviPage, /VaultInstanceSettingsCard/);
   assert.match(settingsCard, /saveVaultItemInstanceIntentAction/);
   assert.match(assignAction, /vault_item_instance_id/);

--- a/test/wall_section_membership_assignment_test.dart
+++ b/test/wall_section_membership_assignment_test.dart
@@ -18,6 +18,12 @@ void main() {
   final pageSource = File(
     'apps/web/src/app/vault/gvvi/[gvvi_id]/page.tsx',
   ).readAsStringSync();
+  final groupedCardPageSource = File(
+    'apps/web/src/app/vault/card/[cardId]/page.tsx',
+  ).readAsStringSync();
+  final groupedCopyControlsSource = File(
+    'apps/web/src/components/vault/VaultManageCopyCurationControls.tsx',
+  ).readAsStringSync();
   final migrationSource = File(
     'supabase/migrations/20260422133000_wall_sections_data_model_v1.sql',
   ).readAsStringSync();
@@ -104,6 +110,38 @@ void main() {
     expect(componentSource, contains('Wall visibility follows copy intent'));
     expect(componentSource, contains('Create section'));
     expect(componentSource, isNot(contains('/section/')));
+  });
+
+  test('grouped card copy rows expose exact-copy membership UI only', () {
+    expect(
+      groupedCardPageSource,
+      contains('getOwnerWallSectionMemberships(user.id, copy.instance_id)'),
+    );
+    expect(groupedCardPageSource, contains('VaultManageCopyCurationControls'));
+    expect(groupedCardPageSource, contains('instanceId={copy.instance_id}'));
+    expect(groupedCardPageSource, contains('initialIntent={copy.intent}'));
+    expect(
+      groupedCopyControlsSource,
+      contains('Grouped card row curation is exact-copy only'),
+    );
+    expect(
+      groupedCopyControlsSource,
+      contains('saveVaultItemInstanceIntentAction'),
+    );
+    expect(
+      groupedCopyControlsSource,
+      contains('assignWallSectionMembershipAction'),
+    );
+    expect(
+      groupedCopyControlsSource,
+      contains('removeWallSectionMembershipAction'),
+    );
+    expect(
+      groupedCopyControlsSource,
+      isNot(contains('saveSharedCardWallCategoryAction')),
+    );
+    expect(groupedCopyControlsSource, isNot(contains('shared_cards')));
+    expect(groupedCopyControlsSource, isNot(contains('legacy_vault_item_id')));
   });
 
   test('actions revalidate owner readback surfaces', () {


### PR DESCRIPTION
## Summary
- adds inline exact-copy curation controls to the web grouped Vault card page
- lets owners set copy intent and assign/remove custom sections without opening each GVVI page
- keeps grouped card surfaces non-authoritative by routing writes through vault_item_instances.id actions only

## Validation
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- npm run web:build:strict
- node apps/web/src/components/vault/vaultCurationOwnership.test.mjs
- flutter test test/wall_section_membership_assignment_test.dart test/grouped_vault_management_mobile_test.dart
- full pre-commit shipcheck
- full pre-push shipcheck