### PR TITLE
[codex] add public owner preview links

### DIFF
--- a/apps/web/src/app/vault/card/[cardId]/page.tsx
+++ b/apps/web/src/app/vault/card/[cardId]/page.tsx
@@ -56,7 +56,7 @@ export default async function VaultManageCardPage({
   }
 
   const decodedCardId = decodeURIComponent(params.cardId);
-  const { items, itemsError, publicCollectionHref } = await getOwnerVaultItems(user.id);
+  const { items, itemsError, publicProfileHref, publicCollectionHref } = await getOwnerVaultItems(user.id);
   const item = items.find((candidate) => candidate.card_id === decodedCardId);
 
   if (!item) {
@@ -272,6 +272,7 @@ export default async function VaultManageCardPage({
                     </div>
                     <VaultManageCopyCurationControls
                       instanceId={copy.instance_id}
+                      gvviId={copy.gv_vi_id}
                       initialIntent={copy.intent}
                       membershipModel={
                         sectionMembershipByInstanceId.get(copy.instance_id) ?? {
@@ -280,6 +281,7 @@ export default async function VaultManageCardPage({
                           loadError: "Section assignments could not be loaded.",
                         }
                       }
+                      publicWallHref={publicProfileHref}
                       isActive
                     />
                   </VaultInsetCard>

--- a/apps/web/src/components/vault/VaultManageCopyCurationControls.tsx
+++ b/apps/web/src/components/vault/VaultManageCopyCurationControls.tsx
@@ -25,8 +25,10 @@ const INTENT_OPTIONS: VaultIntent[] = ["hold", "trade", "sell", "showcase"];
 
 type VaultManageCopyCurationControlsProps = {
   instanceId: string;
+  gvviId: string | null;
   initialIntent: VaultIntent;
   membershipModel: OwnerWallSectionMembershipModel;
+  publicWallHref: string | null;
   isActive: boolean;
 };
 
@@ -52,8 +54,10 @@ function getCreatedSection(
 
 export default function VaultManageCopyCurationControls({
   instanceId,
+  gvviId,
   initialIntent,
   membershipModel,
+  publicWallHref,
   isActive,
 }: VaultManageCopyCurationControlsProps) {
   const router = useRouter();
@@ -85,6 +89,9 @@ export default function VaultManageCopyCurationControls({
   const assignedCount = sections.filter((section) => section.is_member).length;
   const disabled = !isActive || pendingIntent !== null || pendingSectionId !== null || creatingSection;
   const normalizedCreateName = normalizeWallSectionName(createName);
+  const visibleOnWall = intent !== "hold";
+  const publicGvviHref = visibleOnWall && gvviId ? `/gvvi/${encodeURIComponent(gvviId)}` : null;
+  const assignedSections = sections.filter((section) => section.is_member);
 
   function applyMembershipResult(result: WallSectionMembershipActionResult) {
     setStatusMessage(result);
@@ -327,6 +334,58 @@ export default function VaultManageCopyCurationControls({
         >
           Manage all sections
         </Link>
+      </div>
+
+      <div className="rounded-[1rem] border border-slate-200 bg-slate-50 px-4 py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            {/* LOCK: Owner preview links are derived from exact-copy public read surfaces only. */}
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">Public Preview</p>
+            <p className="text-xs leading-5 text-slate-600">
+              {publicWallHref
+                ? visibleOnWall
+                  ? "This copy can be checked from the public surfaces below."
+                  : "Set this copy to Trade, Sell, or Showcase to make public preview links active."
+                : "Enable your public profile and shared vault to preview this copy publicly."}
+            </p>
+          </div>
+          {!publicWallHref ? (
+            <Link
+              href="/account"
+              className="inline-flex shrink-0 rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Enable public Wall
+            </Link>
+          ) : null}
+        </div>
+
+        {publicWallHref && visibleOnWall ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link
+              href={publicWallHref}
+              className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              View Wall
+            </Link>
+            {publicGvviHref ? (
+              <Link
+                href={publicGvviHref}
+                className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
+              >
+                View public copy
+              </Link>
+            ) : null}
+            {assignedSections.map((section) => (
+              <Link
+                key={section.id}
+                href={`${publicWallHref}/section/${encodeURIComponent(section.id)}`}
+                className="rounded-full border border-emerald-200 bg-white px-3 py-1.5 text-xs font-medium text-emerald-800 transition hover:border-emerald-300 hover:bg-emerald-50"
+              >
+                {section.name}
+              </Link>
+            ))}
+          </div>
+        ) : null}
       </div>
 
       {!isActive ? (

--- a/apps/web/src/components/vault/vaultCurationOwnership.test.mjs
+++ b/apps/web/src/components/vault/vaultCurationOwnership.test.mjs
@@ -56,7 +56,9 @@ test("grouped card copy rows render exact-copy curation controls", () => {
   assert.match(groupedPage, /getOwnerWallSectionMemberships\(user\.id, copy\.instance_id\)/);
   assert.match(groupedPage, /VaultManageCopyCurationControls/);
   assert.match(groupedPage, /instanceId=\{copy\.instance_id\}/);
+  assert.match(groupedPage, /gvviId=\{copy\.gv_vi_id\}/);
   assert.match(groupedPage, /initialIntent=\{copy\.intent\}/);
+  assert.match(groupedPage, /publicWallHref=\{publicProfileHref\}/);
   assert.match(copyControls, /saveVaultItemInstanceIntentAction/);
   assert.match(copyControls, /createWallSectionAction/);
   assert.match(copyControls, /assignWallSectionMembershipAction/);
@@ -76,6 +78,21 @@ test("grouped card copy rows can create and immediately assign a section", () =>
   assert.match(copyControls, /Section created and copy added\./);
   assert.match(copyControls, /Create and add/);
   assert.match(copyControls, /Manage all sections/);
+});
+
+test("grouped card copy rows expose public owner preview links", () => {
+  const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const copyControls = readSource("components", "vault", "VaultManageCopyCurationControls.tsx");
+
+  assert.match(groupedPage, /publicProfileHref/);
+  assert.match(copyControls, /Public Preview/);
+  assert.match(copyControls, /visibleOnWall = intent !== "hold"/);
+  assert.match(copyControls, /publicGvviHref = visibleOnWall && gvviId/);
+  assert.match(copyControls, /View Wall/);
+  assert.match(copyControls, /View public copy/);
+  assert.match(copyControls, /Enable public Wall/);
+  assert.match(copyControls, /assignedSections\.map/);
+  assert.match(copyControls, /href=\{\`\$\{publicWallHref\}\/section\/\$\{encodeURIComponent\(section\.id\)\}\`\}/);
 });
 
 test("GVVI page renders exact-copy section membership controls", () => {

--- a/test/wall_section_membership_assignment_test.dart
+++ b/test/wall_section_membership_assignment_test.dart
@@ -119,7 +119,9 @@ void main() {
     );
     expect(groupedCardPageSource, contains('VaultManageCopyCurationControls'));
     expect(groupedCardPageSource, contains('instanceId={copy.instance_id}'));
+    expect(groupedCardPageSource, contains('gvviId={copy.gv_vi_id}'));
     expect(groupedCardPageSource, contains('initialIntent={copy.intent}'));
+    expect(groupedCardPageSource, contains('publicWallHref={publicProfileHref}'));
     expect(
       groupedCopyControlsSource,
       contains('Grouped card row curation is exact-copy only'),
@@ -169,6 +171,24 @@ void main() {
     );
     expect(groupedCopyControlsSource, contains('Section created and copy added.'));
     expect(groupedCopyControlsSource, contains('Create and add'));
+  });
+
+  test('grouped card copy rows expose owner public preview links', () {
+    expect(groupedCardPageSource, contains('publicProfileHref'));
+    expect(groupedCopyControlsSource, contains('Public Preview'));
+    expect(groupedCopyControlsSource, contains('visibleOnWall = intent !== "hold"'));
+    expect(
+      groupedCopyControlsSource,
+      contains('publicGvviHref = visibleOnWall && gvviId'),
+    );
+    expect(groupedCopyControlsSource, contains('View Wall'));
+    expect(groupedCopyControlsSource, contains('View public copy'));
+    expect(groupedCopyControlsSource, contains('Enable public Wall'));
+    expect(groupedCopyControlsSource, contains('assignedSections.map'));
+    expect(
+      groupedCopyControlsSource,
+      contains(r'`${publicWallHref}/section/${encodeURIComponent(section.id)}`'),
+    );
   });
 
   test('actions revalidate owner readback surfaces', () {


### PR DESCRIPTION
## Summary
- adds owner public preview links to web exact-copy curation rows
- shows Wall, public GVVI, and assigned section links when a copy is visible
- keeps preview links derived from existing exact-copy/public read surfaces without new writes

## Validation
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- npm run web:build:strict
- node apps/web/src/components/vault/vaultCurationOwnership.test.mjs
- flutter test test/wall_section_membership_assignment_test.dart test/public_wall_sections_rendering_test.dart
- full pre-commit shipcheck
- full pre-push shipcheck