### PR TITLE
feat: add web bulk copy management

### DIFF
--- a/apps/web/src/app/vault/card/[cardId]/page.tsx
+++ b/apps/web/src/app/vault/card/[cardId]/page.tsx
@@ -3,28 +3,19 @@ import { notFound, redirect } from "next/navigation";
 import PublicCardImage from "@/components/PublicCardImage";
 import ShareCardButton from "@/components/ShareCardButton";
 import TrackPageEvent from "@/components/telemetry/TrackPageEvent";
-import VaultManageCopyCurationControls from "@/components/vault/VaultManageCopyCurationControls";
+import VaultManageCardCopiesBulkSection from "@/components/vault/VaultManageCardCopiesBulkSection";
 import VaultManageCardSettingsPanel from "@/components/vault/VaultManageCardSettingsPanel";
-import OwnedObjectRemoveAction from "@/components/vault/OwnedObjectRemoveAction";
 import PageSection from "@/components/layout/PageSection";
 import SectionHeader from "@/components/layout/SectionHeader";
 import { resolveDisplayIdentity } from "@/lib/cards/resolveDisplayIdentity";
 import {
   formatVaultCardValue,
-  formatVaultCopyDate,
-  formatVaultCopyIdentityLabel,
   formatVaultSecondaryContext,
-  getVaultCopyIntentBadgeClassName,
-  getVaultCopyVisibilityBadgeClassName,
-  getVaultCopyVisibilityLabel,
   getVaultMessageSignalLabel,
   getVaultPrimaryActionLabel,
-  VaultFieldLabel,
-  VaultInsetCard,
   VaultPrimaryStateBadge,
   VaultStatPill,
 } from "@/components/vault/VaultCardPrimitives";
-import { getVaultIntentLabel } from "@/lib/network/intent";
 import { createServerComponentClient } from "@/lib/supabase/server";
 import { getOwnerVaultItems } from "@/lib/vault/getOwnerVaultItems";
 import { getOwnerWallSectionMemberships } from "@/lib/wallSections/getOwnerWallSectionMemberships";
@@ -223,71 +214,18 @@ export default async function VaultManageCardPage({
               description="Choose the exact copy you want to inspect, edit, or remove."
             />
 
-            <div className="space-y-3">
-              {item.copy_items.map((copy) => {
-                const copyHref = copy.gv_vi_id ? `/vault/gvvi/${encodeURIComponent(copy.gv_vi_id)}` : null;
-                const createdAt = formatVaultCopyDate(copy.created_at);
-
-                return (
-                  <VaultInsetCard key={copy.instance_id} className="space-y-3">
-                    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                      <div className="min-w-0 space-y-2">
-                        <p className="text-sm font-medium text-slate-900">{formatVaultCopyIdentityLabel(copy)}</p>
-                        <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em]">
-                          <span
-                            className={`inline-flex rounded-full border px-2 py-0.5 ${getVaultCopyIntentBadgeClassName(copy.intent)}`}
-                          >
-                            {getVaultIntentLabel(copy.intent)}
-                          </span>
-                          <span
-                            className={`inline-flex rounded-full border px-2 py-0.5 ${getVaultCopyVisibilityBadgeClassName(copy.intent)}`}
-                          >
-                            {getVaultCopyVisibilityLabel(copy.intent)}
-                          </span>
-                        </div>
-                        <div className="flex flex-wrap gap-2 text-xs text-slate-500">
-                          <span>{copy.gv_vi_id ?? "GVVI pending"}</span>
-                          {createdAt ? <span>{createdAt}</span> : null}
-                        </div>
-                        {copy.notes ? <p className="text-xs leading-5 text-slate-500">{copy.notes}</p> : null}
-                      </div>
-
-                      <div className="flex flex-wrap items-center gap-2">
-                        {copyHref ? (
-                          <Link
-                            href={copyHref}
-                            className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
-                          >
-                            Open copy
-                          </Link>
-                        ) : (
-                          <span className="text-xs font-medium text-slate-400">Copy unavailable</span>
-                        )}
-                        <OwnedObjectRemoveAction
-                          instanceId={copy.instance_id}
-                          label={copy.is_graded ? "Remove slab" : "Remove copy"}
-                          buttonClassName="inline-flex items-center justify-center rounded-full border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-700 transition hover:border-rose-300 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                        />
-                      </div>
-                    </div>
-                    <VaultManageCopyCurationControls
-                      instanceId={copy.instance_id}
-                      gvviId={copy.gv_vi_id}
-                      initialIntent={copy.intent}
-                      membershipModel={
-                        sectionMembershipByInstanceId.get(copy.instance_id) ?? {
-                          instanceId: copy.instance_id,
-                          sections: [],
-                          loadError: "Section assignments could not be loaded.",
-                        }
-                      }
-                      publicWallHref={publicProfileHref}
-                      isActive
-                    />
-                  </VaultInsetCard>
-                );
-              })}
-            </div>
+            <VaultManageCardCopiesBulkSection
+              copies={item.copy_items}
+              membershipModels={item.copy_items.map(
+                (copy) =>
+                  sectionMembershipByInstanceId.get(copy.instance_id) ?? {
+                    instanceId: copy.instance_id,
+                    sections: [],
+                    loadError: "Section assignments could not be loaded.",
+                  },
+              )}
+              publicWallHref={publicProfileHref}
+            />
           </PageSection>
         </div>
       </div>

--- a/apps/web/src/components/vault/VaultManageCardCopiesBulkSection.tsx
+++ b/apps/web/src/components/vault/VaultManageCardCopiesBulkSection.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import OwnedObjectRemoveAction from "@/components/vault/OwnedObjectRemoveAction";
+import VaultManageCopyCurationControls from "@/components/vault/VaultManageCopyCurationControls";
+import {
+  formatVaultCopyDate,
+  formatVaultCopyIdentityLabel,
+  getVaultCopyIntentBadgeClassName,
+  getVaultCopyVisibilityBadgeClassName,
+  getVaultCopyVisibilityLabel,
+  VaultInsetCard,
+} from "@/components/vault/VaultCardPrimitives";
+import type { VaultCardInstanceData } from "@/components/vault/VaultCardTile";
+import { getVaultIntentLabel, type VaultIntent } from "@/lib/network/intent";
+import { saveVaultItemInstancesIntentBulkAction } from "@/lib/network/saveVaultItemInstancesIntentBulkAction";
+import { bulkWallSectionMembershipAction } from "@/lib/wallSections/bulkWallSectionMembershipAction";
+import type {
+  OwnerWallSectionMembership,
+  OwnerWallSectionMembershipModel,
+} from "@/lib/wallSections/wallSectionTypes";
+
+const INTENT_OPTIONS: VaultIntent[] = ["hold", "showcase", "trade", "sell"];
+
+function dedupeSections(models: OwnerWallSectionMembershipModel[]): OwnerWallSectionMembership[] {
+  const byId = new Map<string, OwnerWallSectionMembership>();
+
+  for (const model of models) {
+    for (const section of model.sections) {
+      if (!byId.has(section.id)) {
+        byId.set(section.id, section);
+      }
+    }
+  }
+
+  return Array.from(byId.values()).sort((left, right) => left.position - right.position || left.name.localeCompare(right.name));
+}
+
+export default function VaultManageCardCopiesBulkSection({
+  copies,
+  membershipModels,
+  publicWallHref,
+}: {
+  copies: VaultCardInstanceData[];
+  membershipModels: OwnerWallSectionMembershipModel[];
+  publicWallHref: string | null;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [selectedInstanceIds, setSelectedInstanceIds] = useState<string[]>([]);
+  const [selectedSectionId, setSelectedSectionId] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const selectedSet = useMemo(() => new Set(selectedInstanceIds), [selectedInstanceIds]);
+  const sectionOptions = useMemo(() => dedupeSections(membershipModels), [membershipModels]);
+  const allSelected = copies.length > 0 && selectedInstanceIds.length === copies.length;
+  const membershipByInstanceId = useMemo(
+    () => new Map(membershipModels.map((model) => [model.instanceId, model] as const)),
+    [membershipModels],
+  );
+
+  function toggleInstance(instanceId: string) {
+    setMessage(null);
+    setSelectedInstanceIds((current) =>
+      current.includes(instanceId) ? current.filter((value) => value !== instanceId) : [...current, instanceId],
+    );
+  }
+
+  function toggleAll() {
+    setMessage(null);
+    setSelectedInstanceIds(allSelected ? [] : copies.map((copy) => copy.instance_id));
+  }
+
+  function runBulkIntent(intent: VaultIntent) {
+    const instanceIds = selectedInstanceIds;
+    startTransition(async () => {
+      const result = await saveVaultItemInstancesIntentBulkAction({
+        instanceIds,
+        intent,
+      });
+      setMessage(result.message);
+      if (result.ok) {
+        router.refresh();
+      }
+    });
+  }
+
+  function runBulkSection(mode: "add" | "remove") {
+    const instanceIds = selectedInstanceIds;
+    const sectionId = selectedSectionId;
+    startTransition(async () => {
+      const result = await bulkWallSectionMembershipAction({
+        instanceIds,
+        sectionId,
+        mode,
+      });
+      setMessage(result.message);
+      if (result.ok) {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-[14px] border border-slate-200 bg-slate-50/90 px-3.5 py-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              className="h-4 w-4 rounded border-slate-300 text-slate-950"
+              aria-label={allSelected ? "Clear selected copies" : "Select all copies"}
+            />
+            <span>{selectedInstanceIds.length > 0 ? `${selectedInstanceIds.length} selected` : "Select copies"}</span>
+          </label>
+
+          {selectedInstanceIds.length > 0 ? (
+            <div className="flex flex-col gap-2 xl:flex-row xl:items-center">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Bulk actions</span>
+                {INTENT_OPTIONS.map((intent) => (
+                  <button
+                    key={intent}
+                    type="button"
+                    onClick={() => runBulkIntent(intent)}
+                    disabled={isPending}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {getVaultIntentLabel(intent)}
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  value={selectedSectionId}
+                  onChange={(event) => setSelectedSectionId(event.target.value)}
+                  disabled={isPending || sectionOptions.length === 0}
+                  className="min-h-8 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  aria-label="Choose wall section for selected copies"
+                >
+                  <option value="">Choose section</option>
+                  {sectionOptions.map((section) => (
+                    <option key={section.id} value={section.id}>
+                      {section.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => runBulkSection("add")}
+                  disabled={isPending || !selectedSectionId}
+                  className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Add to section
+                </button>
+                <button
+                  type="button"
+                  onClick={() => runBulkSection("remove")}
+                  disabled={isPending || !selectedSectionId}
+                  className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Remove from section
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+        {message ? <p className="mt-2 text-xs font-medium text-slate-500">{message}</p> : null}
+      </div>
+
+      {copies.map((copy) => {
+        const copyHref = copy.gv_vi_id ? `/vault/gvvi/${encodeURIComponent(copy.gv_vi_id)}` : null;
+        const createdAt = formatVaultCopyDate(copy.created_at);
+        const membershipModel =
+          membershipByInstanceId.get(copy.instance_id) ?? {
+            instanceId: copy.instance_id,
+            sections: [],
+            loadError: "Section assignments could not be loaded.",
+          };
+
+        return (
+          <VaultInsetCard key={copy.instance_id} className="space-y-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0 space-y-2">
+                <label className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={selectedSet.has(copy.instance_id)}
+                    onChange={() => toggleInstance(copy.instance_id)}
+                    className="mt-0.5 h-4 w-4 rounded border-slate-300 text-slate-950"
+                    aria-label={`Select ${formatVaultCopyIdentityLabel(copy)}`}
+                  />
+                  <span className="min-w-0 space-y-2">
+                    <span className="block text-sm font-medium text-slate-900">{formatVaultCopyIdentityLabel(copy)}</span>
+                    <span className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em]">
+                      <span
+                        className={`inline-flex rounded-full border px-2 py-0.5 ${getVaultCopyIntentBadgeClassName(copy.intent)}`}
+                      >
+                        {getVaultIntentLabel(copy.intent)}
+                      </span>
+                      <span
+                        className={`inline-flex rounded-full border px-2 py-0.5 ${getVaultCopyVisibilityBadgeClassName(copy.intent)}`}
+                      >
+                        {getVaultCopyVisibilityLabel(copy.intent)}
+                      </span>
+                    </span>
+                  </span>
+                </label>
+                <div className="flex flex-wrap gap-2 pl-7 text-xs text-slate-500">
+                  <span>{copy.gv_vi_id ?? "GVVI pending"}</span>
+                  {createdAt ? <span>{createdAt}</span> : null}
+                </div>
+                {copy.notes ? <p className="pl-7 text-xs leading-5 text-slate-500">{copy.notes}</p> : null}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2 pl-7 lg:pl-0">
+                {copyHref ? (
+                  <Link
+                    href={copyHref}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                  >
+                    Open copy
+                  </Link>
+                ) : (
+                  <span className="text-xs font-medium text-slate-400">Copy unavailable</span>
+                )}
+                <OwnedObjectRemoveAction
+                  instanceId={copy.instance_id}
+                  label={copy.is_graded ? "Remove slab" : "Remove copy"}
+                  buttonClassName="inline-flex items-center justify-center rounded-full border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-700 transition hover:border-rose-300 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+            </div>
+            {/* LOCK: Bulk copy management writes only exact-copy instance IDs. */}
+            <VaultManageCopyCurationControls
+              instanceId={copy.instance_id}
+              gvviId={copy.gv_vi_id}
+              initialIntent={copy.intent}
+              membershipModel={membershipModel}
+              publicWallHref={publicWallHref}
+              isActive
+            />
+          </VaultInsetCard>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/vault/vaultCurationOwnership.test.mjs
+++ b/apps/web/src/components/vault/vaultCurationOwnership.test.mjs
@@ -41,29 +41,66 @@ test("grouped card page no longer renders add or remove Wall controls", () => {
 test("grouped card page keeps copy-management path", () => {
   const groupedPanel = readSource("components", "vault", "VaultManageCardSettingsPanel.tsx");
   const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const bulkCopies = readSource("components", "vault", "VaultManageCardCopiesBulkSection.tsx");
 
   assert.match(groupedPanel, /Manage copies/);
   assert.match(groupedPanel, /Organize this card from its exact copies below\./);
   assert.match(groupedPanel, /Wall and section placement is managed per copy\./);
   assert.match(groupedPage, /id="manage-card-copies"/);
-  assert.match(groupedPage, /Open copy/);
+  assert.match(bulkCopies, /Open copy/);
 });
 
 test("grouped card copy rows render exact-copy curation controls", () => {
   const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const bulkCopies = readSource("components", "vault", "VaultManageCardCopiesBulkSection.tsx");
   const copyControls = readSource("components", "vault", "VaultManageCopyCurationControls.tsx");
 
   assert.match(groupedPage, /getOwnerWallSectionMemberships\(user\.id, copy\.instance_id\)/);
-  assert.match(groupedPage, /VaultManageCopyCurationControls/);
-  assert.match(groupedPage, /instanceId=\{copy\.instance_id\}/);
-  assert.match(groupedPage, /gvviId=\{copy\.gv_vi_id\}/);
-  assert.match(groupedPage, /initialIntent=\{copy\.intent\}/);
+  assert.match(groupedPage, /VaultManageCardCopiesBulkSection/);
+  assert.match(groupedPage, /membershipModels=\{item\.copy_items\.map/);
+  assert.match(bulkCopies, /VaultManageCopyCurationControls/);
+  assert.match(bulkCopies, /instanceId=\{copy\.instance_id\}/);
+  assert.match(bulkCopies, /gvviId=\{copy\.gv_vi_id\}/);
+  assert.match(bulkCopies, /initialIntent=\{copy\.intent\}/);
+  assert.match(bulkCopies, /Bulk copy management writes only exact-copy instance IDs/);
   assert.match(groupedPage, /publicWallHref=\{publicProfileHref\}/);
   assert.match(copyControls, /saveVaultItemInstanceIntentAction/);
   assert.match(copyControls, /createWallSectionAction/);
   assert.match(copyControls, /assignWallSectionMembershipAction/);
   assert.match(copyControls, /removeWallSectionMembershipAction/);
   assert.match(copyControls, /vault_item_instances\.id/);
+});
+
+test("grouped card copy rows expose exact-copy bulk management only", () => {
+  const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const bulkCopies = readSource("components", "vault", "VaultManageCardCopiesBulkSection.tsx");
+  const bulkIntentAction = readSource("lib", "network", "saveVaultItemInstancesIntentBulkAction.ts");
+  const bulkSectionAction = readSource("lib", "wallSections", "bulkWallSectionMembershipAction.ts");
+
+  assert.match(groupedPage, /VaultManageCardCopiesBulkSection/);
+  assert.match(bulkCopies, /selectedInstanceIds/);
+  assert.match(bulkCopies, /saveVaultItemInstancesIntentBulkAction/);
+  assert.match(bulkCopies, /bulkWallSectionMembershipAction/);
+  assert.match(bulkCopies, /Bulk actions/);
+  assert.match(bulkCopies, /Add to section/);
+  assert.match(bulkCopies, /Remove from section/);
+
+  assert.match(bulkIntentAction, /\.from\("vault_item_instances"\)/);
+  assert.match(bulkIntentAction, /\.update\(\{\s*intent: nextIntent/s);
+  assert.match(bulkIntentAction, /\.eq\("user_id", user\.id\)/);
+  assert.match(bulkIntentAction, /\.is\("archived_at", null\)/);
+  assert.match(bulkIntentAction, /\.in\("id", normalizedInstanceIds\)/);
+  assert.match(bulkIntentAction, /assertVaultIntentProof/);
+  assert.doesNotMatch(bulkIntentAction, /\.from\("vault_items"\)/);
+  assert.doesNotMatch(bulkIntentAction, /\.from\("shared_cards"\)/);
+
+  assert.match(bulkSectionAction, /\.from\("wall_section_memberships"\)/);
+  assert.match(bulkSectionAction, /vault_item_instance_id/);
+  assert.match(bulkSectionAction, /\.from\("vault_item_instances"\)/);
+  assert.match(bulkSectionAction, /\.from\("wall_sections"\)/);
+  assert.match(bulkSectionAction, /assertWallSectionMembershipProof/);
+  assert.doesNotMatch(bulkSectionAction, /\.from\("vault_items"\)/);
+  assert.doesNotMatch(bulkSectionAction, /\.from\("shared_cards"\)/);
 });
 
 test("grouped card copy rows can create and immediately assign a section", () => {
@@ -128,6 +165,7 @@ test("legacy grouped compatibility data does not appear as section UI", () => {
 test("exact-copy curation remains exact-copy scoped on GVVI and grouped copy rows", () => {
   const groupedPanel = readSource("components", "vault", "VaultManageCardSettingsPanel.tsx");
   const groupedPage = readSource("app", "vault", "card", "[cardId]", "page.tsx");
+  const bulkCopies = readSource("components", "vault", "VaultManageCardCopiesBulkSection.tsx");
   const copyControls = readSource("components", "vault", "VaultManageCopyCurationControls.tsx");
   const gvviPage = readSource("app", "vault", "gvvi", "[gvvi_id]", "page.tsx");
   const settingsCard = readSource("components", "vault", "VaultInstanceSettingsCard.tsx");
@@ -136,6 +174,7 @@ test("exact-copy curation remains exact-copy scoped on GVVI and grouped copy row
 
   assert.doesNotMatch(groupedPanel, /assignWallSectionMembershipAction|removeWallSectionMembershipAction|saveVaultItemInstanceIntentAction/);
   assert.match(groupedPage, /copy\.instance_id/);
+  assert.match(bulkCopies, /copy\.instance_id/);
   assert.match(copyControls, /instanceId/);
   assert.match(gvviPage, /VaultInstanceSettingsCard/);
   assert.match(settingsCard, /saveVaultItemInstanceIntentAction/);

--- a/apps/web/src/lib/network/saveVaultItemInstancesIntentBulkAction.ts
+++ b/apps/web/src/lib/network/saveVaultItemInstancesIntentBulkAction.ts
@@ -1,0 +1,141 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { assertVaultIntentProof } from "@/lib/contracts/ownershipMutationGuards";
+import { normalizeVaultIntent, type VaultIntent } from "@/lib/network/intent";
+import { createServerComponentClient } from "@/lib/supabase/server";
+import { normalizeVaultItemInstanceId } from "@/lib/wallSections/wallSectionTypes";
+
+const BULK_COPY_LIMIT = 100;
+
+export type SaveVaultItemInstancesIntentBulkInput = {
+  instanceIds: string[];
+  intent: VaultIntent;
+};
+
+export type SaveVaultItemInstancesIntentBulkResult =
+  | {
+      ok: true;
+      instanceIds: string[];
+      intent: VaultIntent;
+      message: string;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+type OwnedInstanceRow = {
+  id: string | null;
+  user_id: string | null;
+  gv_vi_id: string | null;
+  archived_at: string | null;
+};
+
+function normalizeBulkInstanceIds(values: unknown[]): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeVaultItemInstanceId(value))
+        .filter((value): value is string => value.length > 0),
+    ),
+  );
+}
+
+export async function saveVaultItemInstancesIntentBulkAction(
+  input: SaveVaultItemInstancesIntentBulkInput,
+): Promise<SaveVaultItemInstancesIntentBulkResult> {
+  const client = createServerComponentClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+
+  if (!user) {
+    return {
+      ok: false,
+      message: "Sign in required.",
+    };
+  }
+
+  const normalizedInstanceIds = normalizeBulkInstanceIds(input.instanceIds ?? []);
+  const nextIntent = normalizeVaultIntent(input.intent);
+
+  if (normalizedInstanceIds.length === 0 || !nextIntent) {
+    return {
+      ok: false,
+      message: "Choose at least one copy and a valid intent.",
+    };
+  }
+
+  if (normalizedInstanceIds.length > BULK_COPY_LIMIT) {
+    return {
+      ok: false,
+      message: `Choose ${BULK_COPY_LIMIT} copies or fewer at a time.`,
+    };
+  }
+
+  // LOCK: Bulk intent authority is exact-copy only (vault_item_instances.id).
+  // LOCK: Do not write grouped vault_items or shared_cards from bulk copy actions.
+  const { data: ownedRows, error: ownedError } = await client
+    .from("vault_item_instances")
+    .select("id,user_id,gv_vi_id,archived_at")
+    .eq("user_id", user.id)
+    .is("archived_at", null)
+    .in("id", normalizedInstanceIds);
+
+  const ownedInstances = (ownedRows ?? []) as OwnedInstanceRow[];
+  if (
+    ownedError ||
+    ownedInstances.length !== normalizedInstanceIds.length ||
+    ownedInstances.some((row) => !row.id || row.user_id !== user.id || row.archived_at)
+  ) {
+    return {
+      ok: false,
+      message: "One or more selected copies could not be updated.",
+    };
+  }
+
+  const { data: updatedRows, error: updateError } = await client
+    .from("vault_item_instances")
+    .update({
+      intent: nextIntent,
+    })
+    .eq("user_id", user.id)
+    .is("archived_at", null)
+    .in("id", normalizedInstanceIds)
+    .select("id,intent,gv_vi_id");
+
+  if (updateError || (updatedRows ?? []).length !== normalizedInstanceIds.length) {
+    return {
+      ok: false,
+      message: "Selected copies could not be updated.",
+    };
+  }
+
+  await Promise.all(
+    normalizedInstanceIds.map((instanceId) =>
+      assertVaultIntentProof({
+        instanceId,
+        userId: user.id,
+        expectedIntent: nextIntent,
+      }),
+    ),
+  );
+
+  revalidatePath("/vault");
+  revalidatePath("/network");
+  for (const row of ownedInstances) {
+    const gvviId = typeof row.gv_vi_id === "string" ? row.gv_vi_id.trim() : "";
+    if (gvviId) {
+      revalidatePath(`/vault/gvvi/${gvviId}`);
+      revalidatePath(`/gvvi/${gvviId}`);
+    }
+  }
+
+  return {
+    ok: true,
+    instanceIds: normalizedInstanceIds,
+    intent: nextIntent,
+    message: `${normalizedInstanceIds.length} ${normalizedInstanceIds.length === 1 ? "copy" : "copies"} updated.`,
+  };
+}

--- a/apps/web/src/lib/wallSections/bulkWallSectionMembershipAction.ts
+++ b/apps/web/src/lib/wallSections/bulkWallSectionMembershipAction.ts
@@ -1,0 +1,224 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { assertWallSectionMembershipProof } from "@/lib/contracts/ownershipMutationGuards";
+import { createServerComponentClient } from "@/lib/supabase/server";
+import { revalidateOwnerWallSectionPaths } from "@/lib/wallSections/revalidateWallSectionPaths";
+import {
+  isWallSectionSystemId,
+  normalizeVaultItemInstanceId,
+  normalizeWallSectionId,
+} from "@/lib/wallSections/wallSectionTypes";
+
+const BULK_COPY_LIMIT = 100;
+
+export type BulkWallSectionMembershipMode = "add" | "remove";
+
+export type BulkWallSectionMembershipInput = {
+  sectionId: string;
+  instanceIds: string[];
+  mode: BulkWallSectionMembershipMode;
+};
+
+export type BulkWallSectionMembershipResult =
+  | {
+      ok: true;
+      sectionId: string;
+      instanceIds: string[];
+      mode: BulkWallSectionMembershipMode;
+      message: string;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+type OwnedSectionRow = {
+  id: string | null;
+  user_id: string | null;
+};
+
+type OwnedInstanceRow = {
+  id: string | null;
+  user_id: string | null;
+  gv_vi_id: string | null;
+  archived_at: string | null;
+};
+
+type MembershipRow = {
+  section_id: string | null;
+  vault_item_instance_id: string | null;
+};
+
+function normalizeBulkInstanceIds(values: unknown[]): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeVaultItemInstanceId(value))
+        .filter((value): value is string => value.length > 0),
+    ),
+  );
+}
+
+export async function bulkWallSectionMembershipAction(
+  input: BulkWallSectionMembershipInput,
+): Promise<BulkWallSectionMembershipResult> {
+  const client = createServerComponentClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+
+  if (!user) {
+    return {
+      ok: false,
+      message: "Sign in required.",
+    };
+  }
+
+  const sectionId = normalizeWallSectionId(input.sectionId);
+  const normalizedInstanceIds = normalizeBulkInstanceIds(input.instanceIds ?? []);
+  const mode: BulkWallSectionMembershipMode = input.mode === "remove" ? "remove" : "add";
+
+  if (!sectionId || isWallSectionSystemId(sectionId)) {
+    return {
+      ok: false,
+      message: "Choose a custom section.",
+    };
+  }
+
+  if (normalizedInstanceIds.length === 0) {
+    return {
+      ok: false,
+      message: "Choose at least one copy.",
+    };
+  }
+
+  if (normalizedInstanceIds.length > BULK_COPY_LIMIT) {
+    return {
+      ok: false,
+      message: `Choose ${BULK_COPY_LIMIT} copies or fewer at a time.`,
+    };
+  }
+
+  const [{ data: sectionRow, error: sectionError }, { data: instanceRows, error: instanceError }] =
+    await Promise.all([
+      client
+        .from("wall_sections")
+        .select("id,user_id")
+        .eq("id", sectionId)
+        .eq("user_id", user.id)
+        .maybeSingle(),
+      client
+        .from("vault_item_instances")
+        .select("id,user_id,gv_vi_id,archived_at")
+        .eq("user_id", user.id)
+        .is("archived_at", null)
+        .in("id", normalizedInstanceIds),
+    ]);
+
+  const section = (sectionRow ?? null) as OwnedSectionRow | null;
+  const ownedInstances = (instanceRows ?? []) as OwnedInstanceRow[];
+
+  if (sectionError || !section?.id || section.user_id !== user.id) {
+    return {
+      ok: false,
+      message: "You can only manage your own sections.",
+    };
+  }
+
+  if (
+    instanceError ||
+    ownedInstances.length !== normalizedInstanceIds.length ||
+    ownedInstances.some((row) => !row.id || row.user_id !== user.id || row.archived_at)
+  ) {
+    return {
+      ok: false,
+      message: "You can only assign cards you own.",
+    };
+  }
+
+  if (mode === "add") {
+    const { data: existingRows, error: existingError } = await client
+      .from("wall_section_memberships")
+      .select("section_id,vault_item_instance_id")
+      .eq("section_id", sectionId)
+      .in("vault_item_instance_id", normalizedInstanceIds);
+
+    if (existingError) {
+      return {
+        ok: false,
+        message: "Selected copies could not be added to that section.",
+      };
+    }
+
+    const existingInstanceIds = new Set(
+      ((existingRows ?? []) as MembershipRow[])
+        .filter((row) => row.section_id === sectionId && typeof row.vault_item_instance_id === "string")
+        .map((row) => row.vault_item_instance_id as string),
+    );
+    const rowsToInsert = normalizedInstanceIds
+      .filter((instanceId) => !existingInstanceIds.has(instanceId))
+      .map((instanceId) => ({
+        section_id: sectionId,
+        vault_item_instance_id: instanceId,
+      }));
+
+    if (rowsToInsert.length > 0) {
+      // LOCK: Bulk section membership is exact-copy only (vault_item_instances.id).
+      // LOCK: Do not regress to grouped vault_items or shared_cards assignment.
+      const { error: insertError } = await client.from("wall_section_memberships").insert(rowsToInsert);
+
+      if (insertError && insertError.code !== "23505") {
+        return {
+          ok: false,
+          message: "Selected copies could not be added to that section.",
+        };
+      }
+    }
+  } else {
+    // LOCK: Bulk section membership is exact-copy only (vault_item_instances.id).
+    // LOCK: Do not regress to grouped vault_items or shared_cards assignment.
+    const { error: deleteError } = await client
+      .from("wall_section_memberships")
+      .delete()
+      .eq("section_id", sectionId)
+      .in("vault_item_instance_id", normalizedInstanceIds);
+
+    if (deleteError) {
+      return {
+        ok: false,
+        message: "Selected copies could not be removed from that section.",
+      };
+    }
+  }
+
+  await Promise.all(
+    normalizedInstanceIds.map((vaultItemInstanceId) =>
+      assertWallSectionMembershipProof({
+        sectionId,
+        vaultItemInstanceId,
+        userId: user.id,
+        shouldExist: mode === "add",
+      }),
+    ),
+  );
+
+  await revalidateOwnerWallSectionPaths(user.id);
+  for (const row of ownedInstances) {
+    const gvviId = typeof row.gv_vi_id === "string" ? row.gv_vi_id.trim() : "";
+    if (gvviId) {
+      revalidatePath(`/vault/gvvi/${gvviId}`);
+    }
+  }
+
+  return {
+    ok: true,
+    sectionId,
+    instanceIds: normalizedInstanceIds,
+    mode,
+    message:
+      mode === "add"
+        ? `${normalizedInstanceIds.length} ${normalizedInstanceIds.length === 1 ? "copy" : "copies"} added.`
+        : `${normalizedInstanceIds.length} ${normalizedInstanceIds.length === 1 ? "copy" : "copies"} removed.`,
+  };
+}

--- a/test/wall_section_membership_assignment_test.dart
+++ b/test/wall_section_membership_assignment_test.dart
@@ -21,8 +21,17 @@ void main() {
   final groupedCardPageSource = File(
     'apps/web/src/app/vault/card/[cardId]/page.tsx',
   ).readAsStringSync();
+  final groupedBulkCopiesSource = File(
+    'apps/web/src/components/vault/VaultManageCardCopiesBulkSection.tsx',
+  ).readAsStringSync();
   final groupedCopyControlsSource = File(
     'apps/web/src/components/vault/VaultManageCopyCurationControls.tsx',
+  ).readAsStringSync();
+  final bulkIntentSource = File(
+    'apps/web/src/lib/network/saveVaultItemInstancesIntentBulkAction.ts',
+  ).readAsStringSync();
+  final bulkSectionSource = File(
+    'apps/web/src/lib/wallSections/bulkWallSectionMembershipAction.ts',
   ).readAsStringSync();
   final migrationSource = File(
     'supabase/migrations/20260422133000_wall_sections_data_model_v1.sql',
@@ -117,10 +126,15 @@ void main() {
       groupedCardPageSource,
       contains('getOwnerWallSectionMemberships(user.id, copy.instance_id)'),
     );
-    expect(groupedCardPageSource, contains('VaultManageCopyCurationControls'));
-    expect(groupedCardPageSource, contains('instanceId={copy.instance_id}'));
-    expect(groupedCardPageSource, contains('gvviId={copy.gv_vi_id}'));
-    expect(groupedCardPageSource, contains('initialIntent={copy.intent}'));
+    expect(groupedCardPageSource, contains('VaultManageCardCopiesBulkSection'));
+    expect(groupedBulkCopiesSource, contains('VaultManageCopyCurationControls'));
+    expect(groupedBulkCopiesSource, contains('instanceId={copy.instance_id}'));
+    expect(groupedBulkCopiesSource, contains('gvviId={copy.gv_vi_id}'));
+    expect(groupedBulkCopiesSource, contains('initialIntent={copy.intent}'));
+    expect(
+      groupedBulkCopiesSource,
+      contains('Bulk copy management writes only exact-copy instance IDs'),
+    );
     expect(groupedCardPageSource, contains('publicWallHref={publicProfileHref}'));
     expect(
       groupedCopyControlsSource,
@@ -145,6 +159,36 @@ void main() {
     );
     expect(groupedCopyControlsSource, isNot(contains('shared_cards')));
     expect(groupedCopyControlsSource, isNot(contains('legacy_vault_item_id')));
+  });
+
+  test('grouped card bulk copy management writes exact-copy rows only', () {
+    expect(groupedCardPageSource, contains('VaultManageCardCopiesBulkSection'));
+    expect(groupedBulkCopiesSource, contains('selectedInstanceIds'));
+    expect(
+      groupedBulkCopiesSource,
+      contains('saveVaultItemInstancesIntentBulkAction'),
+    );
+    expect(groupedBulkCopiesSource, contains('bulkWallSectionMembershipAction'));
+    expect(groupedBulkCopiesSource, contains('Bulk actions'));
+    expect(groupedBulkCopiesSource, contains('Add to section'));
+    expect(groupedBulkCopiesSource, contains('Remove from section'));
+
+    expect(bulkIntentSource, contains('.from("vault_item_instances")'));
+    expect(bulkIntentSource, contains('intent: nextIntent'));
+    expect(bulkIntentSource, contains('.eq("user_id", user.id)'));
+    expect(bulkIntentSource, contains('.is("archived_at", null)'));
+    expect(bulkIntentSource, contains('.in("id", normalizedInstanceIds)'));
+    expect(bulkIntentSource, contains('assertVaultIntentProof'));
+    expect(bulkIntentSource, isNot(contains('.from("vault_items")')));
+    expect(bulkIntentSource, isNot(contains('.from("shared_cards")')));
+
+    expect(bulkSectionSource, contains('.from("wall_section_memberships")'));
+    expect(bulkSectionSource, contains('vault_item_instance_id'));
+    expect(bulkSectionSource, contains('.from("vault_item_instances")'));
+    expect(bulkSectionSource, contains('.from("wall_sections")'));
+    expect(bulkSectionSource, contains('assertWallSectionMembershipProof'));
+    expect(bulkSectionSource, isNot(contains('.from("vault_items")')));
+    expect(bulkSectionSource, isNot(contains('.from("shared_cards")')));
   });
 
   test('grouped card copy rows can create and assign section atomically', () {


### PR DESCRIPTION
## Summary
- add a web bulk toolbar for selecting exact vault copies on grouped card management pages
- add bulk instance-intent and wall-section membership server actions scoped to vault_item_instances.id
- add web and Flutter sentinels proving the bulk path does not write grouped vault_items or shared_cards

## Verification
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- node apps/web/src/components/vault/vaultCurationOwnership.test.mjs
- flutter test test/wall_section_membership_assignment_test.dart
- flutter test test/public_wall_sections_rendering_test.dart
- npm run web:build:strict
- npm run shipcheck