### PR TITLE
fix: route mobile public wall management to copies

### DIFF
--- a/lib/screens/vault/vault_manage_card_screen.dart
+++ b/lib/screens/vault/vault_manage_card_screen.dart
@@ -75,7 +75,6 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
   Set<String> _selectedCopyIds = const <String>{};
   String? _bulkSectionId;
   bool _loading = true;
-  bool _intentSaving = false;
   bool _bulkCopySaving = false;
   String? _copyIntentSavingId;
   String? _copySectionSavingKey;
@@ -433,97 +432,6 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
     }
   }
 
-  Future<void> _saveIntent(String nextIntent) async {
-    final data = _data;
-    final normalizedNextIntent = normalizeVaultIntentValue(nextIntent);
-    if (data == null || _intentSaving || normalizedNextIntent == data.intent) {
-      return;
-    }
-
-    setState(() {
-      _intentSaving = true;
-    });
-
-    try {
-      final savedIntent = await VaultCardService.saveVaultItemIntent(
-        client: _client,
-        vaultItemId: data.vaultItemId,
-        intent: normalizedNextIntent,
-      );
-
-      if (!mounted) {
-        return;
-      }
-
-      final updatedCopies = data.copies
-          .map(
-            (copy) => VaultManageCardCopy(
-              instanceId: copy.instanceId,
-              gvviId: copy.gvviId,
-              conditionLabel: copy.conditionLabel,
-              intent: savedIntent,
-              note: copy.note,
-              createdAt: copy.createdAt,
-              grader: copy.grader,
-              grade: copy.grade,
-              certNumber: copy.certNumber,
-              isGraded: copy.isGraded,
-            ),
-          )
-          .toList(growable: false);
-
-      setState(() {
-        _data = VaultManageCardData(
-          vaultItemId: data.vaultItemId,
-          cardPrintId: data.cardPrintId,
-          gvId: data.gvId,
-          name: data.name,
-          setName: data.setName,
-          setCode: data.setCode,
-          number: data.number,
-          rarity: data.rarity,
-          imageUrl: data.imageUrl,
-          canonicalImageUrl: data.canonicalImageUrl,
-          representativeImageUrl: data.representativeImageUrl,
-          imageStatus: data.imageStatus,
-          imageNote: data.imageNote,
-          variantKey: data.variantKey,
-          printedIdentityModifier: data.printedIdentityModifier,
-          setIdentityModel: data.setIdentityModel,
-          totalCopies: data.totalCopies,
-          rawCount: data.rawCount,
-          slabCount: data.slabCount,
-          inPlayCount: savedIntent == 'hold' ? 0 : updatedCopies.length,
-          intent: savedIntent,
-          isShared: data.isShared,
-          wallCategory: data.wallCategory,
-          publicNote: data.publicNote,
-          publicSlug: data.publicSlug,
-          priceDisplayMode: data.priceDisplayMode,
-          primarySharedGvviId: data.primarySharedGvviId,
-          askingPriceAmount: data.askingPriceAmount,
-          askingPriceCurrency: data.askingPriceCurrency,
-          publicProfileEnabled: data.publicProfileEnabled,
-          vaultSharingEnabled: data.vaultSharingEnabled,
-          copies: updatedCopies,
-        );
-      });
-      _showStatus('Intent saved.');
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-
-      _showStatus(error.toString().replaceFirst('Exception: ', ''));
-    } finally {
-      if (mounted) {
-        setState(() {
-          _intentSaving = false;
-        });
-      }
-    }
-  }
-
   Future<void> _saveCopyIntent(
     VaultManageCardCopy copy,
     String nextIntent,
@@ -696,6 +604,20 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
           : const <String>{};
       _statusMessage = null;
     });
+  }
+
+  void _openCopiesTab({Iterable<String>? selectedCopyIds}) {
+    final nextSelection = selectedCopyIds
+        ?.map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    setState(() {
+      if (nextSelection != null) {
+        _selectedCopyIds = nextSelection;
+      }
+      _statusMessage = null;
+    });
+    _tabController.animateTo(_ManageCardTab.copies.index);
   }
 
   Future<void> _saveSelectedCopyIntent(String nextIntent) async {
@@ -1314,6 +1236,11 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
               label: '${option.label} ${copyIntentCounts[option.value]}',
             ),
     ];
+    final privateCopyIds = data.copies
+        .where((copy) => normalizeVaultIntentValue(copy.intent) == 'hold')
+        .map((copy) => copy.instanceId)
+        .toList(growable: false);
+    final hasPrivateCopies = privateCopyIds.isNotEmpty;
 
     return _ManageSurface(
       child: Column(
@@ -1344,15 +1271,6 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
                   ],
                 ),
               ),
-              if (_intentSaving)
-                SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: colorScheme.primary,
-                  ),
-                ),
             ],
           ),
           const SizedBox(height: 10),
@@ -1381,19 +1299,42 @@ class _VaultManageCardScreenState extends State<VaultManageCardScreen>
           ),
           const SizedBox(height: 10),
           Wrap(
-            spacing: 6,
-            runSpacing: 6,
-            children: kVaultIntentOptions
-                .map(
-                  (option) => ChoiceChip(
-                    label: Text(option.label),
-                    selected: data.intent == option.value,
-                    onSelected: _intentSaving
-                        ? null
-                        : (_) => _saveIntent(option.value),
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              FilledButton.icon(
+                onPressed: data.copies.isEmpty
+                    ? null
+                    : () => _openCopiesTab(
+                        selectedCopyIds: hasPrivateCopies
+                            ? privateCopyIds
+                            : data.copies.map((copy) => copy.instanceId),
+                      ),
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size(0, 40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
                   ),
-                )
-                .toList(),
+                ),
+                icon: const Icon(Icons.library_add_check_outlined),
+                label: Text(
+                  hasPrivateCopies ? 'Select private copies' : 'Manage copies',
+                ),
+              ),
+              OutlinedButton.icon(
+                onPressed: data.copies.isEmpty
+                    ? null
+                    : () => _openCopiesTab(selectedCopyIds: const <String>[]),
+                style: OutlinedButton.styleFrom(
+                  minimumSize: const Size(0, 40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                ),
+                icon: const Icon(Icons.tune_rounded),
+                label: const Text('Open copy controls'),
+              ),
+            ],
           ),
           if (mixTags.isNotEmpty) ...[
             const SizedBox(height: 8),

--- a/lib/services/vault/vault_card_service.dart
+++ b/lib/services/vault/vault_card_service.dart
@@ -866,39 +866,6 @@ class VaultCardService {
     return true;
   }
 
-  static Future<String> saveVaultItemIntent({
-    required SupabaseClient client,
-    required String vaultItemId,
-    required String intent,
-  }) async {
-    final userId = client.auth.currentUser?.id;
-    if (userId == null || userId.isEmpty) {
-      throw Exception('Sign in required.');
-    }
-
-    final normalizedItemId = _trimmedOrNull(vaultItemId);
-    if (normalizedItemId == null) {
-      throw Exception('Vault card is missing grouped identity.');
-    }
-
-    final nextIntent = normalizeVaultIntentValue(intent);
-    // LOCK: Intent authority is instance-level (vault_item_instances.intent).
-    // LOCK: Do not write grouped intent for public discoverability.
-    final data = await client
-        .from('vault_item_instances')
-        .update({'intent': nextIntent})
-        .eq('legacy_vault_item_id', normalizedItemId)
-        .eq('user_id', userId)
-        .filter('archived_at', 'is', null)
-        .select('id,intent');
-
-    if (data.isEmpty) {
-      throw Exception('Vault intent could not be saved.');
-    }
-
-    return nextIntent;
-  }
-
   static Future<String> saveVaultItemInstanceIntent({
     required SupabaseClient client,
     required String instanceId,

--- a/test/grouped_vault_management_mobile_test.dart
+++ b/test/grouped_vault_management_mobile_test.dart
@@ -18,6 +18,30 @@ void main() {
     expect(screen, contains('data.inPlayCount > 0'));
   });
 
+  test('grouped card overview routes public management to exact copies', () {
+    final screen = File(
+      'lib/screens/vault/vault_manage_card_screen.dart',
+    ).readAsStringSync();
+    final service = File(
+      'lib/services/vault/vault_card_service.dart',
+    ).readAsStringSync();
+
+    expect(screen, contains('void _openCopiesTab'));
+    expect(
+      screen,
+      contains('_tabController.animateTo(_ManageCardTab.copies.index)'),
+    );
+    expect(screen, contains('Select private copies'));
+    expect(screen, contains('Open copy controls'));
+    expect(screen, contains('selectedCopyIds: hasPrivateCopies'));
+    expect(screen, isNot(contains('Future<void> _saveIntent')));
+    expect(screen, isNot(contains('VaultCardService.saveVaultItemIntent')));
+    expect(
+      service,
+      isNot(contains('static Future<String> saveVaultItemIntent')),
+    );
+  });
+
   test('grouped card copy rows expose exact-copy section controls', () {
     final screen = File(
       'lib/screens/vault/vault_manage_card_screen.dart',

--- a/test/intent_authority_consolidation_test.dart
+++ b/test/intent_authority_consolidation_test.dart
@@ -3,23 +3,36 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('Flutter grouped intent control updates instance intent only', () {
-    final source = File(
+  test('Flutter grouped intent control is removed from active management', () {
+    final serviceSource = File(
       'lib/services/vault/vault_card_service.dart',
     ).readAsStringSync();
+    final screenSource = File(
+      'lib/screens/vault/vault_manage_card_screen.dart',
+    ).readAsStringSync();
 
-    expect(source, contains(".from('vault_item_instances')"));
-    expect(source, contains(".eq('legacy_vault_item_id', normalizedItemId)"));
-    expect(source, contains('Do not write grouped intent'));
-    expect(source, isNot(contains('storedIntent')));
+    expect(screenSource, contains('Select private copies'));
+    expect(screenSource, contains('Open copy controls'));
     expect(
-      source,
-      isNot(contains(".select('intent')\n          .eq('id', vaultItemId)")),
+      screenSource,
+      contains('VaultCardService.saveVaultItemInstanceIntent'),
     );
     expect(
-      source,
-      isNot(contains(".from('vault_items')\n        .update({'intent':")),
+      screenSource,
+      contains('VaultCardService.saveVaultItemInstancesIntentBulk'),
     );
+    expect(screenSource, isNot(contains('Future<void> _saveIntent')));
+    expect(
+      screenSource,
+      isNot(contains('VaultCardService.saveVaultItemIntent')),
+    );
+    expect(serviceSource, contains(".from('vault_item_instances')"));
+    expect(
+      serviceSource,
+      isNot(contains('static Future<String> saveVaultItemIntent')),
+    );
+    expect(serviceSource, isNot(contains('Do not write grouped intent')));
+    expect(serviceSource, isNot(contains('storedIntent')));
   });
 
   test('web grouped intent action is fail-closed compatibility only', () {


### PR DESCRIPTION
## Summary
- remove the mobile grouped-card intent writer from the manage-card overview
- route public/Wall management to the exact-copy Copies tab, preselecting private copies when useful
- remove the unused grouped intent service method and update sentinels to keep exact-copy authority intact

## Verification
- flutter test test/grouped_vault_management_mobile_test.dart test/app_wall_sections_parity_test.dart test/wall_section_membership_assignment_test.dart
- flutter test test/intent_authority_consolidation_test.dart test/grouped_vault_management_mobile_test.dart test/app_wall_sections_parity_test.dart test/wall_section_membership_assignment_test.dart
- flutter analyze
- npm run shipcheck
- pre-commit shipcheck
- pre-push shipcheck