### PR TITLE
docs: contract pricing evidence engine

### DIFF
--- a/docs/CONTRACT_INDEX.md
+++ b/docs/CONTRACT_INDEX.md
@@ -130,6 +130,7 @@ If a contract is missing from this index, it is not authoritative.
 | PRICING_ENGINE_V1 | Active | Active listings-based pricing engine |
 | PRICING_ENGINE_V1_5 | Active | Condition curve pricing (NM → DMG) |
 | PRICING_MONITOR_V1 | Planned | Scheduler-driven pricing refresh system |
+| PRICING_EVIDENCE_ENGINE_V1 | Active | docs/contracts/PRICING_EVIDENCE_ENGINE_V1.md — Governs future free-provider, free-tier API, CSV/export, user-uploaded, and manual/admin pricing evidence work while preserving Market Truth / Reference / Projection separation, explicit provider mappings, confidence labels, and compliance boundaries |
 | MARKETPLACE_GUARDRAILS_V1 | Planned | Trust, fraud, and listing safety rules |
 
 ---

--- a/docs/contracts/PRICING_CONTRACT_INDEX.md
+++ b/docs/contracts/PRICING_CONTRACT_INDEX.md
@@ -217,3 +217,20 @@ Grookai Value must always be:
 * Explainable
 
 ## If any of these are violated, the version is rejected.
+
+---
+
+## 13. Pricing Evidence Engine Boundary
+
+`PRICING_EVIDENCE_ENGINE_V1` governs future free-provider, free-tier, CSV, uploaded-export, and manual/admin pricing evidence work.
+
+This boundary does not change existing pricing truth:
+
+* Market Truth remains separate from Reference and Projection.
+* Reference providers do not become Market Truth by default.
+* Provider mappings must be explicit and confidence-scored.
+* Pricing evidence must never mutate canon identity.
+* UI must label reference, modeled, stale, low-confidence, and unavailable pricing honestly.
+* Non-API or scraping-like access requires provider/legal review before implementation.
+
+Any pricing worker, importer, rollup, or UI surface that consumes TCGCSV, TCGdex, Pokewallet, JustTCG, PriceCharting exports, user-uploaded exports, or manual/admin evidence must obey `docs/contracts/PRICING_EVIDENCE_ENGINE_V1.md`.

--- a/docs/contracts/PRICING_EVIDENCE_ENGINE_V1.md
+++ b/docs/contracts/PRICING_EVIDENCE_ENGINE_V1.md
@@ -1,0 +1,380 @@
+# PRICING_EVIDENCE_ENGINE_V1
+
+## Status
+
+Active governance contract.
+
+This contract defines the architecture and safety rules for a future world-class Grookai pricing engine that may ingest free, free-tier, licensed, uploaded, or manually reviewed pricing evidence.
+
+It does not authorize any new provider integration, database write, scraping job, migration, UI exposure, or vendor claim by itself.
+
+## Purpose
+
+Grookai pricing must be built as an evidence system, not a single mutable price field.
+
+The engine must attach market evidence to already-governed Grookai identities while preserving the existing pricing lane separation:
+
+- Market Truth
+- Reference
+- Projection
+- Manual/Admin Evidence
+
+Pricing evidence must never decide canon. Canon identifies the card. Pricing only evaluates an already-identified card, finish, edition, stamp, condition, slab state, or collector lane.
+
+## Scope
+
+This contract governs future work for:
+
+- external pricing provider mappings
+- pricing evidence ingestion
+- pricing observations
+- provider confidence and review state
+- pricing rollups and display eligibility
+- free or free-tier provider use
+- user-uploaded price exports
+- manual/admin pricing evidence
+- compliance boundaries for non-API market sources
+
+This contract does not govern:
+
+- card identity creation
+- printed identity or variant canon
+- image confidence
+- vault ownership truth
+- marketplace listing/selling flows
+- schema details until a separate migration plan is approved
+
+## Authority
+
+Higher-authority pricing contracts remain binding:
+
+- `STABILIZATION_CONTRACT_V1`
+- `PRICING_CONTRACT_INDEX.md`
+- `PRICING_UI_CONTRACT_V1`
+- `PRICING_FRESHNESS_CONTRACT_V1`
+- `MARKET_ANALYSIS_FOUNDATION_CONTRACT_V1`
+
+If this contract conflicts with any higher-authority pricing contract, the higher-authority contract wins.
+
+## Pricing Lane Model
+
+### Market Truth
+
+Market Truth remains the strictest lane.
+
+Unless a later explicit contract version changes this, Market Truth is:
+
+- eBay-only
+- observation-backed
+- accepted and mapped only
+- fail-closed under source throttling or ambiguity
+- never filled from reference providers
+- never filled from projection outputs
+
+Reference providers such as TCGCSV, TCGdex, Pokewallet, JustTCG, PriceCharting CSV exports, or user-uploaded exports do not become Market Truth by default.
+
+### Reference
+
+Reference pricing may be sourced from free, free-tier, licensed, or intentionally published provider data.
+
+Reference pricing may support:
+
+- card detail reference display
+- internal cross-checks
+- missing-market context
+- projection inputs, where explicitly allowed
+- mapping confidence review
+
+Reference pricing must be labeled as reference and must not be blended into Market Truth.
+
+### Projection
+
+Projection is modeled pricing.
+
+Projection may use reference evidence only when a later implementation contract defines:
+
+- model inputs
+- confidence thresholds
+- stale-data handling
+- bounds
+- UI labels
+- backtest requirements
+
+Projection must never feed back into Market Truth.
+
+### Manual/Admin Evidence
+
+Manual/Admin Evidence may be used for rare, under-covered, or special-market cards.
+
+Manual/Admin Evidence must include:
+
+- source type
+- observed price
+- currency
+- condition or slab state, if known
+- observed date
+- reviewer or importer identity
+- confidence
+- explanation or note
+
+Manual/Admin Evidence must not silently override provider evidence. It must remain reviewable and auditable.
+
+## Provider Classes
+
+### Allowed Candidate Provider Classes
+
+Future implementations may evaluate these provider classes:
+
+- intentionally published CSV or JSON datasets
+- no-key public APIs whose terms permit application use
+- free-tier APIs with clear rate limits and API keys
+- paid or licensed APIs
+- user-uploaded marketplace exports
+- admin-entered evidence from publicly reviewable sources
+
+### Candidate Sources
+
+The following are candidate reference sources only until separately implemented and verified:
+
+- TCGCSV daily/current snapshots
+- TCGdex card response pricing
+- Pokewallet free-tier card pricing
+- JustTCG free-tier pricing
+- PriceCharting authorized CSV/API exports
+- user-provided TCGplayer/eBay/seller exports
+- admin-reviewed rare-card evidence
+
+No candidate source is authoritative merely because it exists.
+
+## Provider Mapping Rules
+
+Every external price must map through an explicit provider mapping layer before it can influence any Grookai display or rollup.
+
+Mappings must include:
+
+- provider name
+- provider product/card identifier
+- Grookai target identifier
+- target layer: parent print, child printing, slab, sealed, or other explicit lane
+- match basis: exact ID, set-number-name, alias, manual, import, or review
+- match confidence
+- reviewed status
+- first seen timestamp
+- last verified timestamp
+
+Mappings must not mutate:
+
+- `card_prints` identity
+- `card_print_identity`
+- child printing identity
+- set identity
+- image truth
+- ownership/vault state
+
+## Identity Match Requirements
+
+Pricing evidence may attach to a Grookai row only when the match is sufficient for the intended lane.
+
+High-confidence card pricing should match:
+
+- normalized name
+- set or provider set identity
+- printed number
+- finish or provider variant
+- language
+- edition, stamp, or collector lane when applicable
+
+Special lanes require stricter treatment:
+
+- Base Set Shadowless
+- Base Set 1st Edition
+- Base Set 1999-2000
+- Staff Stamp
+- prerelease/event stamp
+- McDonald's confetti holo or collection-specific variants
+- World Championship replica/signature lanes
+- deck-exclusive or product-exclusive cards
+- slabs and grades
+
+If a provider cannot distinguish a Grookai lane, its evidence must either:
+
+- remain unmatched
+- attach only to a broader reference lane with low confidence
+- or be blocked from display
+
+## Observation Ledger Rules
+
+Pricing evidence must be append-oriented.
+
+Each observation should preserve:
+
+- provider
+- provider object ID
+- Grookai target ID, if matched
+- price amount
+- currency
+- source metric: market, low, mid, high, sold, listed, index, export, manual
+- condition
+- finish
+- edition/stamp/lane, if available
+- raw versus slab state
+- grade company and grade, if slabbed
+- observed timestamp
+- provider updated timestamp, if supplied
+- ingestion timestamp
+- mapping confidence
+- evidence confidence
+- source class
+
+Observation ingestion must not overwrite canonical identity or delete prior observations.
+
+## Rollup Rules
+
+Rollups must be derived from observations and mappings, not from UI state.
+
+Rollups may compute:
+
+- current reference estimate
+- current market estimate
+- low/high range
+- median or weighted estimate
+- recent sold range
+- 7/30/90-day trend
+- volatility
+- stale flag
+- source count
+- confidence
+
+Rollups must preserve lane separation:
+
+- Market Truth rollups cannot consume Reference or Projection evidence.
+- Reference rollups cannot be labeled Market Truth.
+- Projection rollups must be labeled as modeled.
+
+## Confidence Rules
+
+Every displayed price must have a confidence state.
+
+Allowed confidence states:
+
+- high
+- medium
+- low
+- blocked
+- unavailable
+
+High confidence requires a strong identity match and current enough evidence for the display context.
+
+Low confidence must not power vault totals unless a later contract explicitly allows a low-confidence mode.
+
+Blocked evidence must not display.
+
+Unavailable evidence must render as no pricing data, not as a synthetic fallback.
+
+## Compliance Rules
+
+Grookai must prefer authorized or intentionally published data access.
+
+Allowed:
+
+- official APIs
+- free-tier APIs within their published limits
+- provider-published CSV/JSON downloads
+- user-uploaded exports
+- admin-entered evidence
+- licensed feeds
+
+Forbidden unless legal/vendor review explicitly approves it:
+
+- scraping pages that prohibit automated access
+- bypassing login, CAPTCHA, bot protection, or paywalls
+- scraping at scale against hostile or unclear terms
+- collecting seller/private account data without authorization
+- republishing provider datasets as a competing dataset
+- exposing raw vendor tables or bulk provider content in public UI
+- using provider logos or endorsement language without permission
+
+The product must not claim real-time pricing unless the provider contract and refresh proof support it.
+
+## UI Rules
+
+Pricing UI must remain honest and source-labeled.
+
+Allowed labels:
+
+- `Market estimate`
+- `Reference pricing`
+- `Updated daily`
+- `Updated X hours ago`
+- `Low confidence`
+- `Pricing unavailable`
+- `Modeled estimate`
+
+Forbidden labels without explicit proof:
+
+- `Live price`
+- `Official price`
+- `Guaranteed value`
+- `Exact value`
+- `Best price`
+
+Public surfaces must be stricter than authenticated surfaces.
+
+Public surfaces may show a simple reference price or range only when allowed by provider terms and existing UI contracts.
+
+## Operational Rules
+
+Provider fetches must be:
+
+- rate limited
+- cached
+- retry-bounded
+- observable
+- fail-closed
+- source-attributed internally
+
+Broad backfills must be explicitly approved. Demand-driven and vault-first refresh remains the safer default unless a future contract changes that strategy.
+
+## Forbidden Behavior
+
+The following are contract violations:
+
+- using pricing evidence to create or alter canon identity
+- silently falling back from Market Truth to Reference
+- blending Reference and Market Truth into one unlabeled number
+- displaying low-confidence evidence as ordinary pricing
+- making real-time claims from daily snapshots
+- storing provider content beyond what is required for audit and display
+- bypassing provider rate limits or access controls
+- hiding source class from internal audit records
+- using pricing to overwrite image, identity, or ownership truth
+
+## Verification
+
+Future implementations under this contract must provide:
+
+- provider terms/rate-limit review
+- mapping coverage report
+- unmatched evidence report
+- blocked evidence report
+- lane contamination audit
+- stale-data audit
+- confidence distribution report
+- sample display audit
+- rollback plan
+
+No production promotion is allowed without a proof that:
+
+- Market Truth did not consume Reference or Projection evidence
+- Reference display is labeled
+- uncertain mappings fail closed
+- low-confidence evidence cannot inflate vault totals
+- no provider access rule was bypassed
+
+## Related Artifacts
+
+- `docs/contracts/PRICING_CONTRACT_INDEX.md`
+- `docs/contracts/PRICING_UI_CONTRACT_V1.md`
+- `docs/contracts/PRICING_FRESHNESS_CONTRACT_V1.md`
+- `docs/contracts/MARKET_ANALYSIS_FOUNDATION_CONTRACT_V1.md`
+- `docs/system/RESUME_PRICING_V1.md`

--- a/docs/system/RESUME_PRICING_V1.md
+++ b/docs/system/RESUME_PRICING_V1.md
@@ -23,6 +23,7 @@ High-authority sources a future session must anchor to:
 - `docs/checkpoints/pricing/PRICING_CHECKPOINT_09_LIVE_SOURCE_CONSTRAINTS.md`
 - `docs/checkpoints/pricing/PRICING_CHECKPOINT_10_REFERENCE_LANE_STRATEGY.md`
 - `docs/checkpoints/pricing/PRICING_CHECKPOINT_11_THREE_LANE_PRICING_MODEL.md`
+- `docs/contracts/PRICING_EVIDENCE_ENGINE_V1.md`
 - `docs/audits/PRICING_READINESS_AUDIT_V1.md`
 - `docs/audits/PRICING_CONTAMINATION_AUDIT_V1.md`
 - `docs/audits/PRICING_OBSERVATION_OFFLINE_VALIDATION_V1.md`
@@ -40,6 +41,7 @@ Current pricing state in plain language:
 - the card-detail trust system exists
 - the projection lane exists structurally
 - JustTCG is reference-only and non-authoritative
+- future free-provider, free-tier API, CSV/export, user-uploaded, and manual/admin pricing evidence is governed by `PRICING_EVIDENCE_ENGINE_V1`
 - live eBay validation is still blocked by upstream throttle
 - the queue model is demand-driven and no longer broad-backfill by default
 
@@ -113,6 +115,7 @@ Current operational reality:
 
 - source availability is the main blocker, not pricing architecture
 - fail-closed behavior under throttle is correct and must remain so
+- free-provider pricing can expand the reference evidence layer only; it cannot silently become market truth
 - demand-driven pricing is the correct operating model for this phase
 - broad backfill is not the current strategy
 
@@ -124,6 +127,7 @@ Primary next step:
 
 That next step should:
 
+- obey `PRICING_EVIDENCE_ENGINE_V1`
 - wire `getReferencePricing.ts` safely
 - keep the reference lane isolated from market truth
 - support the projection system
@@ -139,7 +143,7 @@ That next step must not:
 Use this block to restart pricing work in a new chat:
 
 ```md
-Pricing is operating under AXIOM Execution Interface V4. Anchor to `docs/checkpoints/pricing/PRICING_CHECKPOINT_INDEX.md`, pricing checkpoints 01 through 11, and the key pricing audits. Current state: eBay is the only market-truth lane; pricing is observation-backed and `accepted + mapped` only; offline classifier hardening passed; comps and trust surfaces exist; projection exists as a separate modeled lane; JustTCG is reference-only; queue policy is demand-driven and vault-first; live eBay proof is still blocked by repeated first-call Browse 429s and must be treated as source constraint, not pricing-logic failure. Invariants: no silent fallback pricing, no reference/projection contamination of raw market truth, empty market stays honestly empty, fail closed under throttle, respect existing checkpoints before changes. Next objective: `REFERENCE_PRICING_LAYER_V1`. Do not drift, do not re-litigate lane separation, and do not reopen broad backfill as the next move.
+Pricing is operating under AXIOM Execution Interface V4. Anchor to `docs/checkpoints/pricing/PRICING_CHECKPOINT_INDEX.md`, pricing checkpoints 01 through 11, the key pricing audits, and `docs/contracts/PRICING_EVIDENCE_ENGINE_V1.md`. Current state: eBay is the only market-truth lane; pricing is observation-backed and `accepted + mapped` only; offline classifier hardening passed; comps and trust surfaces exist; projection exists as a separate modeled lane; JustTCG is reference-only; future free-provider, free-tier API, CSV/export, user-uploaded, and manual/admin pricing evidence can expand reference evidence only and cannot silently become market truth; queue policy is demand-driven and vault-first; live eBay proof is still blocked by repeated first-call Browse 429s and must be treated as source constraint, not pricing-logic failure. Invariants: no silent fallback pricing, no reference/projection contamination of raw market truth, empty market stays honestly empty, fail closed under throttle, respect existing checkpoints before changes. Next objective: `REFERENCE_PRICING_LAYER_V1`. Do not drift, do not re-litigate lane separation, and do not reopen broad backfill as the next move.
 ```
 
 ## Why This File Matters


### PR DESCRIPTION
## Summary

Adds `PRICING_EVIDENCE_ENGINE_V1`, a governance contract for future free-provider, free-tier API, CSV/export, user-uploaded, and manual/admin pricing evidence work.

## What this contract locks

- Pricing is evidence attached to Grookai identity, not canon authority.
- Market Truth remains separate from Reference and Projection.
- Candidate sources like TCGCSV, TCGdex, Pokewallet, JustTCG, PriceCharting exports, user uploads, and admin evidence do not become Market Truth by default.
- Provider mappings must be explicit, confidence-scored, reviewable, and non-mutating to identity tables.
- UI must label reference, modeled, stale, low-confidence, blocked, and unavailable pricing honestly.
- Scraping-like or non-API access requires provider/legal review before implementation.

## Also updated

- Adds the contract to `docs/CONTRACT_INDEX.md`.
- Adds the boundary to `docs/contracts/PRICING_CONTRACT_INDEX.md`.
- Updates `docs/system/RESUME_PRICING_V1.md` so future pricing sessions anchor to this contract.

## Validation

- Pre-commit `npm run shipcheck` passed.
- Pre-push `npm run shipcheck` passed.

No schema changes, migrations, provider calls, DB writes, UI changes, or pricing behavior changes.
