### PR TITLE
docs: align MEE nightly env names

### DIFF
--- a/docs/contracts/MEE_NIGHTLY_DROPLET_WORKER_V1.md
+++ b/docs/contracts/MEE_NIGHTLY_DROPLET_WORKER_V1.md
@@ -19,8 +19,8 @@ It must not publish prices.
 ## Required Environment
 
 - `SUPABASE_URL`
-- `SUPABASE_SERVICE_ROLE_KEY`
-- `EBAY_BROWSE_TOKEN`
+- `SUPABASE_SECRET_KEY`
+- `EBAY_BROWSE_ACCESS_TOKEN`
 - `MEE_NIGHTLY_ALLOW_RUN=1`
 
 ## Lifecycle

--- a/docs/runbooks/MEE_NIGHTLY_DROPLET_WORKER_V1.md
+++ b/docs/runbooks/MEE_NIGHTLY_DROPLET_WORKER_V1.md
@@ -15,11 +15,11 @@ Create `/etc/grookai/mee-nightly.env` from:
 deploy/env/mee-nightly.env.example
 ```
 
-Fill either `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_SECRET_KEY`.
+Fill `SUPABASE_SECRET_KEY`.
 
 Fill either:
 
-- `EBAY_BROWSE_TOKEN`, or
+- `EBAY_BROWSE_ACCESS_TOKEN`, or
 - `EBAY_CLIENT_ID` and `EBAY_CLIENT_SECRET`
 
 Preferred installer:


### PR DESCRIPTION
Aligns the MEE nightly droplet worker contract and runbook with the merged installer/runtime env names: SUPABASE_SECRET_KEY and EBAY_BROWSE_ACCESS_TOKEN.\n\nVerification:\n- .\\scripts\\guard_no_legacy_keys.ps1\n- node --test tests\\contracts\\mee_nightly_droplet_worker_v1.test.mjs