### PR TITLE
fix: render MEE nightly systemd repo dir

### DIFF
--- a/deploy/scripts/install-mee-nightly-systemd.sh
+++ b/deploy/scripts/install-mee-nightly-systemd.sh
@@ -80,7 +80,10 @@ npm ci
 
 node scripts/workers/mee_nightly_droplet_worker_v1.mjs --dry-run
 
-sudo cp "deploy/systemd/${SERVICE_NAME}" "/etc/systemd/system/${SERVICE_NAME}"
+tmp_service="$(mktemp)"
+sed "s#^WorkingDirectory=.*#WorkingDirectory=${REPO_DIR}#" "deploy/systemd/${SERVICE_NAME}" > "${tmp_service}"
+sudo cp "${tmp_service}" "/etc/systemd/system/${SERVICE_NAME}"
+rm -f "${tmp_service}"
 sudo cp "deploy/systemd/${TIMER_NAME}" "/etc/systemd/system/${TIMER_NAME}"
 sudo systemctl daemon-reload
 sudo systemctl enable --now "${TIMER_NAME}"

--- a/tests/contracts/mee_nightly_droplet_worker_v1.test.mjs
+++ b/tests/contracts/mee_nightly_droplet_worker_v1.test.mjs
@@ -117,6 +117,7 @@ test("MEE nightly droplet deployment templates schedule the worker at 3am window
   assert.match(installer, /env_value EBAY_CLIENT_ID/);
   assert.match(installer, /source "\$\{ENV_FILE\}"/);
   assert.match(installer, /node scripts\/workers\/mee_nightly_droplet_worker_v1\.mjs --dry-run/);
+  assert.match(installer, /sed "s#\^WorkingDirectory=\.\*#WorkingDirectory=\$\{REPO_DIR\}#"/);
   assert.match(installer, /systemctl enable --now "\$\{TIMER_NAME\}"/);
   assert.match(installer, /MEE_NIGHTLY_ALLOW_RUN=1/);
   assert.match(verifier, /journalctl -u "\$\{SERVICE_NAME\}"/);


### PR DESCRIPTION
## Summary
- Render the nightly systemd service from the installer so WorkingDirectory follows REPO_DIR
- Keep the installed timer template unchanged
- Add a contract assertion for the REPO_DIR render step

## Verification
- node --test tests/contracts/mee_nightly_droplet_worker_v1.test.mjs
- ./scripts/guard_no_legacy_keys.ps1