### PR TITLE
fix: ship card pricing hydration route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,8 @@ tmp_schema_local.sql
 *.webp
 *_report.md
 apps/web/src/app/api/*
+!apps/web/src/app/api/card-pricing/
+!apps/web/src/app/api/card-pricing/route.ts
 !apps/web/src/app/api/assistant/
 apps/web/src/app/api/assistant/*
 !apps/web/src/app/api/assistant/search-interpretation/

--- a/apps/web/src/app/api/card-pricing/route.ts
+++ b/apps/web/src/app/api/card-pricing/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCardPricingUiByCardPrintId } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(request: NextRequest) {
+  const cookieSink = new NextResponse(null);
+  const client = createRouteHandlerClient(request, cookieSink);
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { ok: false, error: "Sign in required." },
+      { status: 401, headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+
+  const cardPrintId = (request.nextUrl.searchParams.get("card_print_id") ?? "").trim();
+  if (!cardPrintId) {
+    return NextResponse.json(
+      { ok: false, error: "Missing card_print_id." },
+      { status: 400, headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      pricing: await getCardPricingUiByCardPrintId(cardPrintId),
+    },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/tests/contracts/mee_public_price_bridge_v1.test.mjs
+++ b/tests/contracts/mee_public_price_bridge_v1.test.mjs
@@ -23,6 +23,7 @@ const remoteApplyReportPath = "docs/audits/market_evidence_engine_v1/MEE-PUBLIC-
 const remoteApplyMarkdownPath = "docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICE-BRIDGE-V1-REMOTE-SCHEMA-APPLY.md";
 const cardPricingHelperPath = "apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts";
 const publicPricingHelperPath = "apps/web/src/lib/pricing/getPublicPricingByCardIds.ts";
+const cardPricingRoutePath = "apps/web/src/app/api/card-pricing/route.ts";
 const pricingRailPath = "apps/web/src/components/pricing/CardPagePricingRail.tsx";
 const pricingDisclosurePath = "apps/web/src/components/common/PricingDisclosure.tsx";
 
@@ -97,6 +98,19 @@ test("pricing UI copy states active listing estimates are not sold comps", () =>
   assert.match(disclosure, /Active listing estimates are asking-price evidence, not sold-comparable proof or guaranteed market value\./);
 });
 
+test("signed-in card pricing hydration route is tracked and auth-gated", () => {
+  const route = read(cardPricingRoutePath);
+  const gitignore = read(".gitignore");
+
+  assert.match(route, /getCardPricingUiByCardPrintId/);
+  assert.match(route, /createRouteHandlerClient/);
+  assert.match(route, /auth\.getUser\(\)/);
+  assert.match(route, /Sign in required\./);
+  assert.match(route, /card_print_id/);
+  assert.match(route, /Cache-Control["']:\s*["']private,\s*no-store/);
+  assert.match(gitignore, /!apps\/web\/src\/app\/api\/card-pricing\/route\.ts/);
+});
+
 test("MEE public price bridge remote readback has closed truth boundaries", () => {
   const report = loadJson(remoteApplyReportPath);
 
@@ -118,7 +132,7 @@ test("MEE public price bridge remote readback has closed truth boundaries", () =
 });
 
 test("MEE public price bridge artifacts exist", () => {
-  for (const artifactPath of [bridgeSqlPath, readbackSqlPath, migrationPath, contractPath, checkpointPath, remoteApplyReportPath, remoteApplyMarkdownPath]) {
+  for (const artifactPath of [bridgeSqlPath, readbackSqlPath, migrationPath, contractPath, checkpointPath, cardPricingRoutePath, remoteApplyReportPath, remoteApplyMarkdownPath]) {
     assert.equal(existsSync(new URL(`../../${artifactPath}`, import.meta.url)), true, artifactPath);
   }
 });


### PR DESCRIPTION
## Summary
- Ship the signed-in card pricing hydration API route that was previously ignored by .gitignore
- Add .gitignore exceptions so the route remains tracked
- Add a contract guard that verifies the route is auth-gated, private/no-store, and included in the price bridge artifact set

## Verification
- node --test tests/contracts/mee_public_price_bridge_v1.test.mjs
- npm --prefix apps/web run typecheck
- pre-push verification suite passed during git push