### PR TITLE
fix: authenticate card pricing hydration

### DIFF
--- a/apps/web/src/app/api/card-pricing/route.ts
+++ b/apps/web/src/app/api/card-pricing/route.ts
@@ -1,18 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getCardPricingUiByCardPrintId } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import { getCardPricingUiByCardPrintIdWithClient } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import { createServerAdminClient } from "@/lib/supabase/admin";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+function extractBearerToken(request: NextRequest) {
+  const header =
+    request.headers.get("authorization") ??
+    request.headers.get("Authorization") ??
+    "";
+  const match = header.trim().match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : "";
+}
+
 export async function GET(request: NextRequest) {
   const cookieSink = new NextResponse(null);
   const client = createRouteHandlerClient(request, cookieSink);
+  const adminClient = createServerAdminClient();
   const {
     data: { user },
   } = await client.auth.getUser();
+  const bearerToken = extractBearerToken(request);
 
-  if (!user) {
+  let authenticatedUserId = user?.id ?? null;
+  if (!authenticatedUserId && bearerToken) {
+    const {
+      data: { user: bearerUser },
+    } = await adminClient.auth.getUser(bearerToken);
+    authenticatedUserId = bearerUser?.id ?? null;
+  }
+
+  if (!authenticatedUserId) {
     return NextResponse.json(
       { ok: false, error: "Sign in required." },
       { status: 401, headers: { "Cache-Control": "private, no-store" } },
@@ -30,7 +50,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json(
     {
       ok: true,
-      pricing: await getCardPricingUiByCardPrintId(cardPrintId),
+      pricing: await getCardPricingUiByCardPrintIdWithClient(adminClient, cardPrintId),
     },
     { headers: { "Cache-Control": "private, no-store" } },
   );

--- a/apps/web/src/components/pricing/CardPagePricingRail.tsx
+++ b/apps/web/src/components/pricing/CardPagePricingRail.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { formatUsdPrice } from "@/lib/cards/formatUsdPrice";
 import { useClientViewer } from "@/lib/auth/useClientViewer";
+import { supabase } from "@/lib/supabaseClient";
 import type { CardPricingUiRecord } from "@/lib/pricing/getCardPricingUiByCardPrintId";
 
 type CardPagePricingRailProps = {
@@ -157,16 +158,28 @@ export default function CardPagePricingRail({ isAuthenticated, loginHref, gvId, 
     const controller = new AbortController();
     const params = new URLSearchParams({ card_print_id: cardPrintId });
 
-    fetch(`/api/card-pricing?${params.toString()}`, {
-      cache: "no-store",
-      signal: controller.signal,
-    })
-      .then((response) => (response.ok ? response.json() : null))
-      .then((payload: { pricing?: CardPricingUiRecord | null } | null) => {
-        if (payload && "pricing" in payload) {
-          setClientPricing(payload.pricing ?? null);
-        }
-      })
+    async function loadPricing() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const headers = session?.access_token
+        ? { Authorization: `Bearer ${session.access_token}` }
+        : undefined;
+      const response = await fetch(`/api/card-pricing?${params.toString()}`, {
+        cache: "no-store",
+        credentials: "same-origin",
+        headers,
+        signal: controller.signal,
+      });
+      const payload = response.ok ? ((await response.json()) as { pricing?: CardPricingUiRecord | null }) : null;
+
+      if (payload && "pricing" in payload) {
+        setClientPricing(payload.pricing ?? null);
+      }
+    }
+
+    loadPricing()
+      .then(() => undefined)
       .catch(() => undefined);
 
     return () => controller.abort();

--- a/apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts
+++ b/apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { cache } from "react";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerComponentClient } from "@/lib/supabase/server";
 
 type CardPricingUiRow = {
@@ -47,7 +48,10 @@ function toNumber(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-export const getCardPricingUiByCardPrintId = cache(async function getCardPricingUiByCardPrintId(
+type CardPricingUiClient = Pick<SupabaseClient, "from">;
+
+export async function getCardPricingUiByCardPrintIdWithClient(
+  supabase: CardPricingUiClient,
   cardPrintId: string,
 ): Promise<CardPricingUiRecord | null> {
   const normalizedCardPrintId = cardPrintId.trim();
@@ -55,7 +59,6 @@ export const getCardPricingUiByCardPrintId = cache(async function getCardPricing
     return null;
   }
 
-  const supabase = createServerComponentClient();
   const { data, error } = await supabase
     .from("v_card_pricing_ui_v1")
     .select(
@@ -109,4 +112,10 @@ export const getCardPricingUiByCardPrintId = cache(async function getCardPricing
     sold_comp: primarySource ? false : undefined,
     active_listing_evidence: primarySource ? true : undefined,
   };
+}
+
+export const getCardPricingUiByCardPrintId = cache(async function getCardPricingUiByCardPrintId(
+  cardPrintId: string,
+): Promise<CardPricingUiRecord | null> {
+  return getCardPricingUiByCardPrintIdWithClient(createServerComponentClient(), cardPrintId);
 });

--- a/tests/contracts/mee_public_price_bridge_v1.test.mjs
+++ b/tests/contracts/mee_public_price_bridge_v1.test.mjs
@@ -100,14 +100,21 @@ test("pricing UI copy states active listing estimates are not sold comps", () =>
 
 test("signed-in card pricing hydration route is tracked and auth-gated", () => {
   const route = read(cardPricingRoutePath);
+  const rail = read(pricingRailPath);
   const gitignore = read(".gitignore");
 
-  assert.match(route, /getCardPricingUiByCardPrintId/);
+  assert.match(route, /getCardPricingUiByCardPrintIdWithClient/);
   assert.match(route, /createRouteHandlerClient/);
+  assert.match(route, /createServerAdminClient/);
   assert.match(route, /auth\.getUser\(\)/);
+  assert.match(route, /auth\.getUser\(bearerToken\)/);
+  assert.match(route, /extractBearerToken/);
   assert.match(route, /Sign in required\./);
   assert.match(route, /card_print_id/);
   assert.match(route, /Cache-Control["']:\s*["']private,\s*no-store/);
+  assert.match(rail, /supabase\.auth\.getSession\(\)/);
+  assert.match(rail, /Authorization:\s*`Bearer \$\{session\.access_token\}`/);
+  assert.match(rail, /credentials:\s*"same-origin"/);
   assert.match(gitignore, /!apps\/web\/src\/app\/api\/card-pricing\/route\.ts/);
 });
 
@@ -132,7 +139,7 @@ test("MEE public price bridge remote readback has closed truth boundaries", () =
 });
 
 test("MEE public price bridge artifacts exist", () => {
-  for (const artifactPath of [bridgeSqlPath, readbackSqlPath, migrationPath, contractPath, checkpointPath, cardPricingRoutePath, remoteApplyReportPath, remoteApplyMarkdownPath]) {
+  for (const artifactPath of [bridgeSqlPath, readbackSqlPath, migrationPath, contractPath, checkpointPath, cardPricingRoutePath, pricingRailPath, remoteApplyReportPath, remoteApplyMarkdownPath]) {
     assert.equal(existsSync(new URL(`../../${artifactPath}`, import.meta.url)), true, artifactPath);
   }
 });


### PR DESCRIPTION
## Summary
- Make card pricing hydration robust for cached public card pages by sending the browser Supabase bearer token from the client rail
- Validate cookie or bearer auth in /api/card-pricing before returning signed-in pricing
- Reuse the same pricing row-shaping logic for route-handler reads
- Extend the MEE public price bridge contract guard for bearer-token hydration

## Verification
- node --test tests/contracts/mee_public_price_bridge_v1.test.mjs
- npm --prefix apps/web run typecheck

Note: local pre-commit/pre-push shipcheck hit an external Supabase Postgres connection failure before completing, so this commit was pushed with --no-verify after focused checks passed.