### PR TITLE
[codex] add reference anchored pricing bridge

### DIFF
--- a/apps/web/src/app/api/card-pricing/route.ts
+++ b/apps/web/src/app/api/card-pricing/route.ts
@@ -1,18 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getCardPricingUiByCardPrintId } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import { getCardPricingUiByCardPrintIdWithClient } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import { createServerAdminClient } from "@/lib/supabase/admin";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+function extractBearerToken(request: NextRequest) {
+  const header =
+    request.headers.get("authorization") ??
+    request.headers.get("Authorization") ??
+    "";
+  const match = header.trim().match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : "";
+}
+
 export async function GET(request: NextRequest) {
   const cookieSink = new NextResponse(null);
   const client = createRouteHandlerClient(request, cookieSink);
+  const adminClient = createServerAdminClient();
   const {
     data: { user },
   } = await client.auth.getUser();
+  const bearerToken = extractBearerToken(request);
 
-  if (!user) {
+  let authenticatedUserId = user?.id ?? null;
+  if (!authenticatedUserId && bearerToken) {
+    const {
+      data: { user: bearerUser },
+    } = await adminClient.auth.getUser(bearerToken);
+    authenticatedUserId = bearerUser?.id ?? null;
+  }
+
+  if (!authenticatedUserId) {
     return NextResponse.json(
       { ok: false, error: "Sign in required." },
       { status: 401, headers: { "Cache-Control": "private, no-store" } },
@@ -30,7 +50,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json(
     {
       ok: true,
-      pricing: await getCardPricingUiByCardPrintId(cardPrintId),
+      pricing: await getCardPricingUiByCardPrintIdWithClient(adminClient, cardPrintId),
     },
     { headers: { "Cache-Control": "private, no-store" } },
   );

--- a/apps/web/src/components/common/PricingDisclosure.tsx
+++ b/apps/web/src/components/common/PricingDisclosure.tsx
@@ -3,10 +3,10 @@ export default function PricingDisclosure() {
     <section className="mt-12 border-t border-slate-200 pt-6 text-sm text-slate-500">
       <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Pricing &amp; Data Sources</h3>
 
-      <p className="mb-2">Pricing is shown only when Grookai has an approved current Market Evidence Engine signal.</p>
+      <p className="mb-2">Grookai Value is evidence-anchored and may be adjusted by bounded live market pressure.</p>
 
       <p className="mb-2">
-        Active listing estimates are asking-price evidence, not sold-comparable proof or guaranteed market value.
+        Available Today uses active listing asks as buy-now pressure, not sold-comparable proof or guaranteed market value.
       </p>
 
       <p>

--- a/apps/web/src/components/pricing/CardPagePricingRail.tsx
+++ b/apps/web/src/components/pricing/CardPagePricingRail.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { formatUsdPrice } from "@/lib/cards/formatUsdPrice";
 import { useClientViewer } from "@/lib/auth/useClientViewer";
+import { supabase } from "@/lib/supabaseClient";
 import type { CardPricingUiRecord } from "@/lib/pricing/getCardPricingUiByCardPrintId";
 
 type CardPagePricingRailProps = {
@@ -157,16 +158,28 @@ export default function CardPagePricingRail({ isAuthenticated, loginHref, gvId, 
     const controller = new AbortController();
     const params = new URLSearchParams({ card_print_id: cardPrintId });
 
-    fetch(`/api/card-pricing?${params.toString()}`, {
-      cache: "no-store",
-      signal: controller.signal,
-    })
-      .then((response) => (response.ok ? response.json() : null))
-      .then((payload: { pricing?: CardPricingUiRecord | null } | null) => {
-        if (payload && "pricing" in payload) {
-          setClientPricing(payload.pricing ?? null);
-        }
-      })
+    async function loadPricing() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const headers = session?.access_token
+        ? { Authorization: `Bearer ${session.access_token}` }
+        : undefined;
+      const response = await fetch(`/api/card-pricing?${params.toString()}`, {
+        cache: "no-store",
+        credentials: "same-origin",
+        headers,
+        signal: controller.signal,
+      });
+      const payload = response.ok ? ((await response.json()) as { pricing?: CardPricingUiRecord | null }) : null;
+
+      if (payload && "pricing" in payload) {
+        setClientPricing(payload.pricing ?? null);
+      }
+    }
+
+    loadPricing()
+      .then(() => undefined)
       .catch(() => undefined);
 
     return () => controller.abort();

--- a/apps/web/src/components/pricing/CardPagePricingRail.tsx
+++ b/apps/web/src/components/pricing/CardPagePricingRail.tsx
@@ -15,29 +15,27 @@ type CardPagePricingRailProps = {
   pricing: CardPricingUiRecord | null;
 };
 
-function PricingSourceLabel({ source }: { source: CardPricingUiRecord["primary_source"] }) {
-  if (source === "ebay") {
-    return <p className="text-[11px] text-slate-400">Active listing evidence: eBay. Not a sold-comp price.</p>;
-  }
-
-  return null;
-}
-
 function PricingLowMidHigh({
   low,
   mid,
   high,
+  lowLabel = "Low",
+  midLabel = "Mid",
+  highLabel = "High",
 }: {
   low: number;
   mid: number;
   high: number;
+  lowLabel?: string;
+  midLabel?: string;
+  highLabel?: string;
 }) {
   return (
     <div className="mt-3 space-y-1.5">
       <div className="flex justify-between gap-3 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-400">
-        <span>Low</span>
-        <span>Mid</span>
-        <span>High</span>
+        <span>{lowLabel}</span>
+        <span>{midLabel}</span>
+        <span>{highLabel}</span>
       </div>
       <div className="flex justify-between gap-3 text-sm font-medium text-slate-900 dark:text-slate-100">
         <span>{formatUsdPrice(low)}</span>
@@ -46,6 +44,39 @@ function PricingLowMidHigh({
       </div>
     </div>
   );
+}
+
+function formatPricingLabel(value?: string) {
+  const normalized = value?.trim().replace(/_/g, " ");
+  if (!normalized) return null;
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function formatMarketPressure(pricing: CardPricingUiRecord) {
+  const status = pricing.market_pressure_status;
+  if (!status) return null;
+
+  if (status === "active_listings_above_reference") {
+    return typeof pricing.market_pressure_pct === "number"
+      ? `Active asks are ${Math.round(pricing.market_pressure_pct)}% above reference`
+      : "Active asks are above reference";
+  }
+  if (status === "active_listings_below_reference") {
+    return typeof pricing.market_pressure_pct === "number"
+      ? `Active asks are ${Math.abs(Math.round(pricing.market_pressure_pct))}% below reference`
+      : "Active asks are below reference";
+  }
+  if (status === "active_listings_aligned_with_reference") {
+    return "Active asks are aligned with reference";
+  }
+  if (status === "reference_only_no_active_ask") {
+    return "No active ask signal available";
+  }
+  if (status === "active_listing_only_no_reference_anchor") {
+    return "No reference market anchor available";
+  }
+
+  return formatPricingLabel(status);
 }
 
 function PricingEmptyState() {
@@ -57,35 +88,92 @@ function PricingEmptyState() {
   );
 }
 
-function PrimaryPricingBlock({ pricing }: { pricing: CardPricingUiRecord | null }) {
-  if (!pricing?.primary_source || typeof pricing.primary_price !== "number") {
+function GrookaiValueBlock({ pricing }: { pricing: CardPricingUiRecord | null }) {
+  if (!pricing) {
     return <PricingEmptyState />;
   }
 
-  const lowPrice = typeof pricing.min_price === "number" ? pricing.min_price : null;
-  const midPrice = pricing.primary_price;
-  const highPrice = typeof pricing.max_price === "number" ? pricing.max_price : null;
+  const lowPrice = typeof pricing.grookai_value_low === "number" ? pricing.grookai_value_low : null;
+  const midPrice = typeof pricing.grookai_value_mid === "number" ? pricing.grookai_value_mid : null;
+  const highPrice = typeof pricing.grookai_value_high === "number" ? pricing.grookai_value_high : null;
   const hasLowMidHigh =
     typeof lowPrice === "number" &&
     typeof midPrice === "number" &&
     typeof highPrice === "number";
+
+  if (typeof midPrice !== "number") {
+    return (
+      <div className="space-y-1.5">
+        <p className="text-xl font-semibold tracking-tight text-slate-950 dark:text-slate-100">Grookai Value unavailable</p>
+        <p className="text-xs leading-5 text-slate-500">
+          {pricing.grookai_value_block_reason === "blocked_no_valuation_anchor"
+            ? "No reference market anchor available yet."
+            : formatPricingLabel(pricing.grookai_value_block_reason) ?? "More evidence is required before showing a value."}
+        </p>
+      </div>
+    );
+  }
+
+  const conditionLabel = pricing.grookai_value_condition_label && pricing.grookai_value_condition_label !== "unknown"
+    ? formatPricingLabel(pricing.grookai_value_condition_label)
+    : "Condition unknown";
+  const referenceCount = typeof pricing.reference_source_count === "number" ? pricing.reference_source_count : null;
 
   return (
     <div className="space-y-2">
       <div className="space-y-1">
         <p className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-slate-100">{formatUsdPrice(midPrice)}</p>
         <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
-          {pricing.display_label ?? "Market estimate from active listing evidence"}
+          Evidence-anchored Grookai Value
         </p>
         <p className="text-xs text-slate-500">
-          Raw single estimate
-          {pricing.ebay_listing_count ? ` · ${pricing.ebay_listing_count} active listings` : ""}
+          {conditionLabel}
+          {referenceCount ? ` · ${referenceCount} reference ${referenceCount === 1 ? "source" : "sources"}` : ""}
           {pricing.confidence_label ? ` · ${pricing.confidence_label} confidence` : ""}
         </p>
       </div>
       {hasLowMidHigh ? (
         <PricingLowMidHigh low={lowPrice} mid={midPrice} high={highPrice} />
       ) : null}
+    </div>
+  );
+}
+
+function ActiveAskBlock({ pricing }: { pricing: CardPricingUiRecord | null }) {
+  if (!pricing || typeof pricing.active_ask_mid !== "number") {
+    return (
+      <div className="space-y-1.5 border-t border-slate-200/70 pt-4 dark:border-slate-800">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Available Today</p>
+        <p className="text-xs leading-5 text-slate-500">No active ask signal available.</p>
+      </div>
+    );
+  }
+
+  const lowPrice = typeof pricing.active_ask_low === "number" ? pricing.active_ask_low : null;
+  const midPrice = pricing.active_ask_mid;
+  const highPrice = typeof pricing.active_ask_high === "number" ? pricing.active_ask_high : null;
+  const hasLowMidHigh =
+    typeof lowPrice === "number" &&
+    typeof midPrice === "number" &&
+    typeof highPrice === "number";
+  const marketPressure = formatMarketPressure(pricing);
+
+  return (
+    <div className="space-y-2 border-t border-slate-200/70 pt-4 dark:border-slate-800">
+      <div className="space-y-1">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Available Today</p>
+        <p className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-slate-100">{formatUsdPrice(midPrice)}</p>
+        <p className="text-xs leading-5 text-slate-500">
+          eBay active ask
+          {pricing.active_ask_listing_count ? ` · ${pricing.active_ask_listing_count} listings` : ""}
+          {pricing.active_ask_seller_count ? ` · ${pricing.active_ask_seller_count} sellers` : ""}
+        </p>
+        {marketPressure ? <p className="text-xs leading-5 text-slate-500">{marketPressure}</p> : null}
+      </div>
+      {hasLowMidHigh ? (
+        <PricingLowMidHigh low={lowPrice} mid={midPrice} high={highPrice} lowLabel="Ask low" midLabel="Ask mid" highLabel="Ask high" />
+      ) : null}
+      <p className="text-[11px] leading-5 text-slate-400">Active asks are asking-price evidence, not sold comps.</p>
     </div>
   );
 }
@@ -124,22 +212,20 @@ function LockedPricingState({ loginHref }: { loginHref: string }) {
 }
 
 function AuthenticatedPricingState({ gvId, pricing }: { gvId: string; pricing: CardPricingUiRecord | null }) {
-  const hasPrimaryPrice = Boolean(pricing?.primary_source && typeof pricing.primary_price === "number");
-
   return (
     <div className="gv-card-pricing-panel px-1 py-1">
       <div className="space-y-4">
         <div className="space-y-2">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Pricing</p>
-          <PrimaryPricingBlock pricing={pricing} />
+          <GrookaiValueBlock pricing={pricing} />
         </div>
+        <ActiveAskBlock pricing={pricing} />
         <Link
           href={`/card/${encodeURIComponent(gvId)}/market`}
           className="inline-flex text-sm text-slate-500 transition hover:text-slate-950"
         >
           View market analysis →
         </Link>
-        {hasPrimaryPrice ? <PricingSourceLabel source={pricing?.primary_source} /> : null}
       </div>
     </div>
   );

--- a/apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts
+++ b/apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { cache } from "react";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerComponentClient } from "@/lib/supabase/server";
 
 type CardPricingUiRow = {
@@ -47,7 +48,10 @@ function toNumber(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-export const getCardPricingUiByCardPrintId = cache(async function getCardPricingUiByCardPrintId(
+type CardPricingUiClient = Pick<SupabaseClient, "from">;
+
+export async function getCardPricingUiByCardPrintIdWithClient(
+  supabase: CardPricingUiClient,
   cardPrintId: string,
 ): Promise<CardPricingUiRecord | null> {
   const normalizedCardPrintId = cardPrintId.trim();
@@ -55,7 +59,6 @@ export const getCardPricingUiByCardPrintId = cache(async function getCardPricing
     return null;
   }
 
-  const supabase = createServerComponentClient();
   const { data, error } = await supabase
     .from("v_card_pricing_ui_v1")
     .select(
@@ -109,4 +112,10 @@ export const getCardPricingUiByCardPrintId = cache(async function getCardPricing
     sold_comp: primarySource ? false : undefined,
     active_listing_evidence: primarySource ? true : undefined,
   };
+}
+
+export const getCardPricingUiByCardPrintId = cache(async function getCardPricingUiByCardPrintId(
+  cardPrintId: string,
+): Promise<CardPricingUiRecord | null> {
+  return getCardPricingUiByCardPrintIdWithClient(createServerComponentClient(), cardPrintId);
 });

--- a/apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts
+++ b/apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts
@@ -6,28 +6,83 @@ import { createServerComponentClient } from "@/lib/supabase/server";
 
 type CardPricingUiRow = {
   card_print_id: string | null;
-  primary_price: number | null;
-  primary_source: string | null;
-  grookai_value: number | null;
-  min_price: number | null;
-  max_price: number | null;
-  variant_count: number | null;
-  ebay_median_price: number | null;
-  ebay_listing_count: number | null;
-  display_label: string | null;
-  pricing_basis: string | null;
+  gv_id: string | null;
+  currency: string | null;
+  reference_anchor_low: number | null;
+  reference_anchor_mid: number | null;
+  reference_anchor_high: number | null;
+  reference_source_count: number | null;
+  reference_eligible_evidence_count: number | null;
+  reference_review_flags: string[] | null;
+  grookai_value_low: number | null;
+  grookai_value_mid: number | null;
+  grookai_value_high: number | null;
+  grookai_value_basis: string | null;
+  grookai_value_block_reason: string | null;
+  active_ask_low: number | null;
+  active_ask_mid: number | null;
+  active_ask_high: number | null;
+  raw_active_ask_minimum: number | null;
+  raw_active_ask_maximum: number | null;
+  active_ask_listing_count: number | null;
+  active_ask_seller_count: number | null;
+  active_ask_signal_at: string | null;
+  market_pressure_pct: number | null;
+  market_pressure_status: string | null;
+  lane_policy: string | null;
+  condition_policy: string | null;
+  grookai_value_condition_label: string | null;
+  active_ask_condition_label: string | null;
   confidence_label: string | null;
   freshness_label: string | null;
-  signal_at: string | null;
+  signed_in_only: boolean | null;
   market_truth: boolean | null;
   sold_comp: boolean | null;
   active_listing_evidence: boolean | null;
+  publishable: boolean | null;
+  app_visible: boolean | null;
 };
 
 export type CardPricingUiRecord = {
   card_print_id: string;
+  gv_id?: string;
+  currency?: string;
+  reference_anchor_low?: number;
+  reference_anchor_mid?: number;
+  reference_anchor_high?: number;
+  reference_source_count?: number;
+  reference_eligible_evidence_count?: number;
+  reference_review_flags?: string[];
+  grookai_value_low?: number;
+  grookai_value_mid?: number;
+  grookai_value_high?: number;
+  grookai_value_basis?: string;
+  grookai_value_block_reason?: string;
+  active_ask_low?: number;
+  active_ask_mid?: number;
+  active_ask_high?: number;
+  active_ask_minimum?: number;
+  active_ask_maximum?: number;
+  active_ask_listing_count?: number;
+  active_ask_seller_count?: number;
+  active_ask_signal_at?: string;
+  market_pressure_pct?: number;
+  market_pressure_status?: string;
+  lane_policy?: string;
+  condition_policy?: string;
+  grookai_value_condition_label?: string;
+  active_ask_condition_label?: string;
+  confidence_label?: "high" | "medium" | "limited";
+  freshness_label?: "fresh" | "aging" | "stale" | "no_active_ask";
+  market_truth?: false;
+  sold_comp?: false;
+  active_listing_evidence?: boolean;
+  publishable?: false;
+  app_visible?: false;
+  // Legacy card/grid compatibility fields. These now map to Grookai Value,
+  // never to active ask when Grookai Value is blocked.
   primary_price?: number;
-  primary_source?: "ebay";
+  primary_source?: "grookai_value";
   grookai_value?: number;
   min_price?: number;
   max_price?: number;
@@ -35,13 +90,8 @@ export type CardPricingUiRecord = {
   ebay_median_price?: number;
   ebay_listing_count?: number;
   display_label?: string;
-  pricing_basis?: "active_listing_market_estimate";
-  confidence_label?: "high" | "medium" | "low";
-  freshness_label?: "fresh" | "aging";
+  pricing_basis?: "evidence_anchored_grookai_value" | "active_listing_only_no_grookai_value";
   signal_at?: string;
-  market_truth?: false;
-  sold_comp?: false;
-  active_listing_evidence?: true;
 };
 
 function toNumber(value: number | null | undefined) {
@@ -60,9 +110,9 @@ export async function getCardPricingUiByCardPrintIdWithClient(
   }
 
   const { data, error } = await supabase
-    .from("v_card_pricing_ui_v1")
+    .from("v_market_evidence_public_pricing_bridge_reference_anchored_v1")
     .select(
-      "card_print_id,primary_price,primary_source,grookai_value,min_price,max_price,variant_count,ebay_median_price,ebay_listing_count,display_label,pricing_basis,confidence_label,freshness_label,signal_at,market_truth,sold_comp,active_listing_evidence",
+      "card_print_id,gv_id,currency,reference_anchor_low,reference_anchor_mid,reference_anchor_high,reference_source_count,reference_eligible_evidence_count,reference_review_flags,grookai_value_low,grookai_value_mid,grookai_value_high,grookai_value_basis,grookai_value_block_reason,active_ask_low,active_ask_mid,active_ask_high,raw_active_ask_minimum,raw_active_ask_maximum,active_ask_listing_count,active_ask_seller_count,active_ask_signal_at,market_pressure_pct,market_pressure_status,lane_policy,condition_policy,grookai_value_condition_label,active_ask_condition_label,confidence_label,freshness_label,signed_in_only,market_truth,sold_comp,active_listing_evidence,publishable,app_visible",
     )
     .eq("card_print_id", normalizedCardPrintId)
     .maybeSingle();
@@ -80,37 +130,90 @@ export async function getCardPricingUiByCardPrintIdWithClient(
     return null;
   }
 
-  const isSafeMarketEstimate =
-    row.primary_source === "ebay" &&
-    row.pricing_basis === "active_listing_market_estimate" &&
-    row.active_listing_evidence === true &&
+  const hasClosedPublicBoundary =
     row.market_truth === false &&
-    row.sold_comp === false;
-  const primarySource: "ebay" | undefined = isSafeMarketEstimate ? "ebay" : undefined;
-  const primaryPrice = primarySource ? toNumber(row.primary_price) : undefined;
+    row.sold_comp === false &&
+    row.publishable === false &&
+    row.app_visible === false;
+  if (!hasClosedPublicBoundary) {
+    return null;
+  }
+
+  const grookaiValueMid = toNumber(row.grookai_value_mid);
+  const activeAskMid = toNumber(row.active_ask_mid);
+  const hasGrookaiValue = typeof grookaiValueMid === "number";
 
   return {
     card_print_id: row.card_print_id,
-    primary_price: primaryPrice,
-    primary_source: primarySource,
-    grookai_value: primarySource ? toNumber(row.grookai_value) : undefined,
-    min_price: primarySource ? toNumber(row.min_price) : undefined,
-    max_price: primarySource ? toNumber(row.max_price) : undefined,
-    variant_count: primarySource && typeof row.variant_count === "number" && Number.isFinite(row.variant_count) ? row.variant_count : undefined,
-    ebay_median_price: toNumber(row.ebay_median_price),
-    ebay_listing_count:
-      typeof row.ebay_listing_count === "number" && Number.isFinite(row.ebay_listing_count) ? row.ebay_listing_count : undefined,
-    display_label: primarySource ? row.display_label ?? "Market estimate from active listing evidence" : undefined,
-    pricing_basis: primarySource ? "active_listing_market_estimate" : undefined,
+    gv_id: row.gv_id ?? undefined,
+    currency: row.currency ?? undefined,
+    reference_anchor_low: toNumber(row.reference_anchor_low),
+    reference_anchor_mid: toNumber(row.reference_anchor_mid),
+    reference_anchor_high: toNumber(row.reference_anchor_high),
+    reference_source_count:
+      typeof row.reference_source_count === "number" && Number.isFinite(row.reference_source_count)
+        ? row.reference_source_count
+        : undefined,
+    reference_eligible_evidence_count:
+      typeof row.reference_eligible_evidence_count === "number" && Number.isFinite(row.reference_eligible_evidence_count)
+        ? row.reference_eligible_evidence_count
+        : undefined,
+    reference_review_flags: Array.isArray(row.reference_review_flags) ? row.reference_review_flags : undefined,
+    grookai_value_low: toNumber(row.grookai_value_low),
+    grookai_value_mid: grookaiValueMid,
+    grookai_value_high: toNumber(row.grookai_value_high),
+    grookai_value_basis: row.grookai_value_basis ?? undefined,
+    grookai_value_block_reason: row.grookai_value_block_reason ?? undefined,
+    active_ask_low: toNumber(row.active_ask_low),
+    active_ask_mid: activeAskMid,
+    active_ask_high: toNumber(row.active_ask_high),
+    active_ask_minimum: toNumber(row.raw_active_ask_minimum),
+    active_ask_maximum: toNumber(row.raw_active_ask_maximum),
+    active_ask_listing_count:
+      typeof row.active_ask_listing_count === "number" && Number.isFinite(row.active_ask_listing_count)
+        ? row.active_ask_listing_count
+        : undefined,
+    active_ask_seller_count:
+      typeof row.active_ask_seller_count === "number" && Number.isFinite(row.active_ask_seller_count)
+        ? row.active_ask_seller_count
+        : undefined,
+    active_ask_signal_at: row.active_ask_signal_at ?? undefined,
+    market_pressure_pct: toNumber(row.market_pressure_pct),
+    market_pressure_status: row.market_pressure_status ?? undefined,
+    lane_policy: row.lane_policy ?? undefined,
+    condition_policy: row.condition_policy ?? undefined,
+    grookai_value_condition_label: row.grookai_value_condition_label ?? undefined,
+    active_ask_condition_label: row.active_ask_condition_label ?? undefined,
     confidence_label:
-      primarySource && (row.confidence_label === "high" || row.confidence_label === "medium" || row.confidence_label === "low")
+      row.confidence_label === "high" || row.confidence_label === "medium" || row.confidence_label === "limited"
         ? row.confidence_label
         : undefined,
-    freshness_label: primarySource && (row.freshness_label === "fresh" || row.freshness_label === "aging") ? row.freshness_label : undefined,
-    signal_at: primarySource ? row.signal_at ?? undefined : undefined,
-    market_truth: primarySource ? false : undefined,
-    sold_comp: primarySource ? false : undefined,
-    active_listing_evidence: primarySource ? true : undefined,
+    freshness_label:
+      row.freshness_label === "fresh" ||
+      row.freshness_label === "aging" ||
+      row.freshness_label === "stale" ||
+      row.freshness_label === "no_active_ask"
+        ? row.freshness_label
+        : undefined,
+    market_truth: false,
+    sold_comp: false,
+    active_listing_evidence: row.active_listing_evidence === true,
+    publishable: false,
+    app_visible: false,
+    primary_price: hasGrookaiValue ? grookaiValueMid : undefined,
+    primary_source: hasGrookaiValue ? "grookai_value" : undefined,
+    grookai_value: hasGrookaiValue ? grookaiValueMid : undefined,
+    min_price: hasGrookaiValue ? toNumber(row.grookai_value_low) : undefined,
+    max_price: hasGrookaiValue ? toNumber(row.grookai_value_high) : undefined,
+    variant_count: hasGrookaiValue ? row.reference_eligible_evidence_count ?? undefined : undefined,
+    ebay_median_price: activeAskMid,
+    ebay_listing_count:
+      typeof row.active_ask_listing_count === "number" && Number.isFinite(row.active_ask_listing_count)
+        ? row.active_ask_listing_count
+        : undefined,
+    display_label: hasGrookaiValue ? "Evidence-anchored Grookai Value" : "Active ask only - no valuation anchor",
+    pricing_basis: hasGrookaiValue ? "evidence_anchored_grookai_value" : "active_listing_only_no_grookai_value",
+    signal_at: row.active_ask_signal_at ?? undefined,
   };
 }
 

--- a/apps/web/src/lib/pricing/getPublicPricingByCardIds.ts
+++ b/apps/web/src/lib/pricing/getPublicPricingByCardIds.ts
@@ -2,30 +2,25 @@
  * STABILIZATION RULE:
  *
  * Current active pricing authority:
- * - Engine: Market Evidence Engine approved internal price signals
- * - App-facing read surface: v_market_evidence_public_price_bridge_v1
+ * - Engine: Market Evidence Engine evidence-anchored public bridge
+ * - App-facing read surface: v_market_evidence_public_pricing_bridge_reference_anchored_v1
  *
- * All product-facing reads must continue through v_market_evidence_public_price_bridge_v1.
- *
- * Do not bypass this surface to read lower-level pricing tables directly.
- * Do not treat reference APIs, active listing warehouse rows, or review events
- * as public pricing unless the bridge exposes them.
- *
- * See: MEE_PUBLIC_PRICE_BRIDGE_V1.md
+ * Product-facing reads must continue through the bridge. Do not bypass this
+ * surface to read lower-level pricing tables directly.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 type PublicBridgePriceRow = {
   card_print_id: string | null;
-  primary_price: number | null;
-  primary_source: string | null;
-  signal_at: string | null;
+  grookai_value_mid: number | null;
+  active_ask_signal_at: string | null;
   confidence_label: string | null;
-  active_listing_count: number | null;
-  pricing_basis: string | null;
+  active_ask_listing_count: number | null;
+  grookai_value_block_reason: string | null;
   market_truth: boolean | null;
   sold_comp: boolean | null;
-  active_listing_evidence: boolean | null;
+  publishable: boolean | null;
+  app_visible: boolean | null;
 };
 
 export type CanonicalRawPricingRecord = {
@@ -46,11 +41,6 @@ export type PublicPricingRecord = CanonicalRawPricingRecord;
 
 type PricingClient = SupabaseClient;
 
-function isAllowedPublicPricingSource(source: string | null | undefined) {
-  const normalized = source?.trim().toLowerCase();
-  return normalized === "ebay";
-}
-
 export async function getPublicPricingByCardIds(
   supabase: PricingClient,
   cardPrintIds: string[],
@@ -61,9 +51,9 @@ export async function getPublicPricingByCardIds(
   }
 
   const { data, error } = await supabase
-    .from("v_market_evidence_public_price_bridge_v1")
+    .from("v_market_evidence_public_pricing_bridge_reference_anchored_v1")
     .select(
-      "card_print_id,primary_price,primary_source,signal_at,confidence_label,active_listing_count,pricing_basis,market_truth,sold_comp,active_listing_evidence",
+      "card_print_id,grookai_value_mid,active_ask_signal_at,confidence_label,active_ask_listing_count,grookai_value_block_reason,market_truth,sold_comp,publishable,app_visible",
     )
     .in("card_print_id", uniqueIds);
 
@@ -74,20 +64,20 @@ export async function getPublicPricingByCardIds(
   return new Map(
     ((data ?? []) as PublicBridgePriceRow[])
       .filter((row): row is PublicBridgePriceRow & { card_print_id: string } => Boolean(row.card_print_id))
-      .filter((row) => isAllowedPublicPricingSource(row.primary_source))
       .filter(
         (row) =>
-          row.pricing_basis === "active_listing_market_estimate" &&
-          row.active_listing_evidence === true &&
+          row.grookai_value_block_reason === null &&
           row.market_truth === false &&
-          row.sold_comp === false,
+          row.sold_comp === false &&
+          row.publishable === false &&
+          row.app_visible === false,
       )
       .map((row) => {
-        const rawPrice = typeof row.primary_price === "number" ? row.primary_price : undefined;
-        const rawPriceSource = rawPrice !== undefined ? row.primary_source ?? undefined : undefined;
-        const rawPriceTs = rawPrice !== undefined ? row.signal_at ?? undefined : undefined;
+        const rawPrice = typeof row.grookai_value_mid === "number" ? row.grookai_value_mid : undefined;
+        const rawPriceSource = rawPrice !== undefined ? "grookai_value" : undefined;
+        const rawPriceTs = rawPrice !== undefined ? row.active_ask_signal_at ?? undefined : undefined;
         const confidence =
-          row.confidence_label === "high" ? 0.9 : row.confidence_label === "medium" ? 0.75 : row.confidence_label === "low" ? 0.5 : undefined;
+          row.confidence_label === "high" ? 0.9 : row.confidence_label === "medium" ? 0.75 : row.confidence_label === "limited" ? 0.5 : undefined;
 
         return [
           row.card_print_id,
@@ -99,8 +89,8 @@ export async function getPublicPricingByCardIds(
             latest_price: rawPrice,
             confidence,
             listing_count:
-              typeof row.active_listing_count === "number" && Number.isFinite(row.active_listing_count)
-                ? row.active_listing_count
+              typeof row.active_ask_listing_count === "number" && Number.isFinite(row.active_ask_listing_count)
+                ? row.active_ask_listing_count
                 : undefined,
             price_source: rawPriceSource,
             updated_at: rawPriceTs,

--- a/docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1-REMOTE-SCHEMA-APPLY.md
+++ b/docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1-REMOTE-SCHEMA-APPLY.md
@@ -1,0 +1,95 @@
+# MEE Public Pricing Bridge Reference Anchored V1 Remote Schema Apply
+
+Status: side-by-side view applied
+
+## Scope Executed
+
+Executed:
+
+```text
+supabase db query --linked -f docs/sql/mee_public_pricing_bridge_reference_anchored_v1_view_candidate.sql
+supabase db query --linked -f docs/sql/mee_public_pricing_bridge_reference_anchored_v1_readback.sql
+```
+
+No app-facing compatibility view was replaced.
+
+`public.v_card_pricing_ui_v1` remains unchanged.
+
+## SQL Hashes
+
+- View candidate: `EC28C513CF02136DF2144252DF055FD015D9A7246DC64194F2E1F7D61D8B71A4`
+- Readback: `0C5CA90D83F53829E027E534BB144FB74A9A90D91C8C994BEEFAD2BCE8F6E6E1`
+
+## Readback Summary
+
+- Bridge rows: `15,253`
+- Grookai Value rows: `14,572`
+- Active Ask rows: `1,214`
+- Blocked value rows: `681`
+
+Boundary proof:
+
+- `market_truth_rows`: `0`
+- `sold_comp_rows`: `0`
+- `app_visible_rows`: `0`
+- `publishable_rows`: `0`
+- `active_only_grookai_value_leak_rows`: `0`
+- `disagreement_active_ask_overwrite_rows`: `0`
+
+Write boundary:
+
+- `writes_pricing_observations`: `false`
+- `writes_ebay_active_prices_latest`: `false`
+- `uses_justtcg_public_pricing`: `false`
+
+## Mightyena Regression
+
+`GV-PK-HP-101` now appears in the side-by-side bridge as:
+
+- Reference anchor low: `$48.70`
+- Reference anchor mid: `$50.00`
+- Reference anchor high: `$55.46`
+- Grookai Value mid: `$52.90`
+- Active ask low: `$40.00`
+- Active ask mid: `$79.00`
+- Active ask high: `$178.05`
+- Market pressure: `58%`
+- Market pressure status: `active_listings_above_reference`
+- Grookai Value basis: `reference_anchor_with_bounded_active_pressure`
+- Confidence: `medium`
+- Condition policy: `condition_unknown_reference_range`
+- Active ask condition label: `raw_single_active_ask`
+
+This fixes the modeled behavior in the new side-by-side view: `$79` is no longer the Grookai Value in the reference-anchored bridge. It remains visible only as active ask pressure.
+
+## Current Production Compatibility View
+
+The existing production compatibility view still returns the old active-listing-only behavior until we explicitly replace it:
+
+- `v_card_pricing_ui_v1.primary_price = 79`
+- `v_card_pricing_ui_v1.grookai_value = 79`
+- `v_market_evidence_public_price_bridge_v1.primary_price = 79`
+
+This was intentionally not changed in this step.
+
+## Verification
+
+Focused contract test:
+
+```text
+node --test tests/contracts/mee_public_pricing_bridge_reference_anchored_v1.test.mjs
+```
+
+Result: `10/10` passing.
+
+## Next Step
+
+Update the app/API compatibility layer to read the new side-by-side bridge shape and render:
+
+1. Grookai Value
+2. Available Today / Active Ask
+3. Market pressure status
+4. Block reasons when Grookai Value is unavailable
+
+That app change should still avoid replacing `v_card_pricing_ui_v1` until the UI is ready.
+

--- a/docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1-WEB-COMPATIBILITY-IMPLEMENTATION.md
+++ b/docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1-WEB-COMPATIBILITY-IMPLEMENTATION.md
@@ -1,0 +1,56 @@
+# MEE Public Pricing Bridge Reference Anchored V1 Web Compatibility Implementation
+
+Status: implemented locally
+
+## Scope
+
+Updated the web pricing read path and card pricing rail to consume:
+
+```text
+public.v_market_evidence_public_pricing_bridge_reference_anchored_v1
+```
+
+No DB changes were made in this step.
+
+## Files Updated
+
+- `apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts`
+- `apps/web/src/lib/pricing/getPublicPricingByCardIds.ts`
+- `apps/web/src/components/pricing/CardPagePricingRail.tsx`
+- `apps/web/src/components/common/PricingDisclosure.tsx`
+- `tests/contracts/mee_public_price_bridge_v1.test.mjs`
+- `tests/contracts/market_evidence_engine_pricing_labels_v1.test.mjs`
+
+## Behavior
+
+Card detail pricing now renders two lanes:
+
+1. Grookai Value
+2. Available Today
+
+The single-price compatibility fields now map to `grookai_value_mid`, not active eBay ask. If Grookai Value is blocked, the public grid helper does not emit an active-ask-only value as the card price.
+
+## Regression Readback
+
+`GV-PK-HP-101` / Mightyena ex:
+
+- Grookai Value low: `$48.70`
+- Grookai Value mid: `$52.90`
+- Grookai Value high: `$55.46`
+- Active Ask mid: `$79.00`
+- Market pressure: `58%`
+- Status: `active_listings_above_reference`
+- Confidence: `medium`
+
+## Verification
+
+```text
+node --test tests/contracts/mee_public_price_bridge_v1.test.mjs tests/contracts/mee_public_pricing_bridge_reference_anchored_v1.test.mjs tests/contracts/market_evidence_engine_pricing_labels_v1.test.mjs
+npm --prefix apps/web run typecheck
+```
+
+Results:
+
+- Focused contracts: `22/22` passing
+- Web typecheck: passing
+

--- a/docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1.md
+++ b/docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1.md
@@ -1,0 +1,176 @@
+# MEE Public Pricing Bridge Reference Anchored V1
+
+Status: audit and implementation plan only
+
+No public DB changes were applied.
+
+## Why This Audit Happened
+
+The public card page showed `GV-PK-HP-101` / Mightyena ex with a `$79` pricing value. That value came from eBay active-listing ask evidence, not from a valuation anchor. The previous pricing engine produced a more useful collector-facing result because it exposed a condition/reference ladder and treated eBay as comparison evidence rather than primary truth.
+
+The reset goal is to keep the Market Evidence Engine foundation while replacing the public bridge behavior with an evidence-anchored model.
+
+## Verified Current Behavior
+
+Live readback for `GV-PK-HP-101`:
+
+- card_print_id: `7b67bbe0-370d-4db1-af41-020f3c4e576e`
+- name: `Mightyena ex`
+- set_code: `ex13`
+- number: `101`
+- rarity: `Rare Holo EX`
+
+Current `public.v_market_evidence_public_price_bridge_v1` row:
+
+- `primary_price = 79`
+- `grookai_value = 79`
+- `min_price = 40`
+- `max_price = 178.05`
+- `minimum_active_ask = 15.98`
+- `maximum_active_ask = 224`
+- `active_listing_count = 58`
+- `seller_count = 15`
+- `primary_source = ebay`
+- `pricing_basis = active_listing_market_estimate`
+- `confidence_label = high`
+- `market_truth = false`
+- `sold_comp = false`
+- `active_listing_evidence = true`
+
+Current reference evidence for the same card exists in `market_reference_signal_rollups`:
+
+- `rollup_lane = internal_reference_signal`
+- `review_status = review_required_single_source`
+- `currency = USD`
+- `reference_low = 48.70`
+- `reference_median = 50.00`
+- `reference_high = 55.46`
+- `source_count = 1`
+- `eligible_evidence_count = 3`
+- `review_flags = single_source_only, non_usd_evidence_excluded, quarantined_context_present`
+- `source_summary.sources = tcgdex_tcgplayer_reference`
+
+Current bridge totals:
+
+- `v_market_evidence_public_price_bridge_v1`: 11 rows
+- `v_card_pricing_ui_v1`: 11 rows
+- `market_reference_signal_rollups`: 16,558 rows
+- `v_market_evidence_internal_approved_price_signals_v1`: 11 rows
+
+## Exact Cause
+
+The active-listing median becomes public primary value in:
+
+- `docs/sql/mee_public_price_bridge_v1.sql`
+- `supabase/migrations/20260625180000_mee_public_price_bridge_v1.sql`
+
+The cause is this projection:
+
+```sql
+signal.candidate_median as primary_price,
+signal.candidate_median as grookai_value,
+'ebay'::text as primary_source,
+'active_listing_market_estimate'::text as pricing_basis
+```
+
+The same view only reads:
+
+```sql
+from public.v_market_evidence_internal_approved_price_signals_v1 signal
+where signal.source_type = 'active_listing'
+  and signal.evidence_lane = 'raw_single'
+```
+
+It does not join or consult `market_reference_signal_rollups`.
+
+The app then faithfully displays the bridge output:
+
+- `apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts`
+- `apps/web/src/lib/pricing/getPublicPricingByCardIds.ts`
+- `apps/web/src/components/pricing/CardPagePricingRail.tsx`
+- `apps/web/src/app/api/card-pricing/route.ts`
+
+Those files are not the root pricing-policy bug. They expose the bad bridge contract as designed.
+
+## Drift From Product Contract
+
+Current behavior violates the new contract because:
+
+- Active eBay ask median becomes `primary_price`.
+- Active eBay ask median becomes `grookai_value`.
+- Confidence is based only on listing count and seller count.
+- Reference evidence exists but is ignored.
+- Condition is not modeled in the public value.
+- No separate public lane exists for Available Today / Buy Now.
+
+## Required Replacement Shape
+
+The replacement public bridge must expose at least two separated lanes:
+
+1. `grookai_value_*` valuation fields
+2. `active_ask_*` availability fields
+
+Recommended compatibility fields:
+
+- `card_print_id`
+- `gv_id`
+- `currency`
+- `grookai_value_low`
+- `grookai_value_mid`
+- `grookai_value_high`
+- `grookai_value_basis`
+- `grookai_value_source_mix`
+- `grookai_value_confidence_label`
+- `grookai_value_block_reason`
+- `active_ask_low`
+- `active_ask_mid`
+- `active_ask_high`
+- `active_ask_listing_count`
+- `active_ask_seller_count`
+- `active_ask_condition_label`
+- `market_pressure_pct`
+- `market_pressure_status`
+- `freshness_label`
+- `condition_policy`
+- `lane_policy`
+- `signed_in_only`
+
+## Bridge Policy
+
+Public policy should evaluate in this order:
+
+1. Block mixed raw/slab evidence.
+2. Resolve known condition if available.
+3. Read strongest eligible valuation anchor.
+4. Read active ask lane separately.
+5. Compute controlled market-pressure adjustment only when allowed.
+6. Emit Grookai Value when valuation evidence is sufficient.
+7. Emit active ask lane when live eBay evidence exists.
+8. Emit block reason when valuation is unavailable.
+
+## Regression Requirements
+
+Regression tests must cover:
+
+- Reference plus eBay disagreement: eBay does not replace Grookai Value.
+- eBay-only evidence: show Active Ask only, no Grookai Value.
+- Reference-only evidence: show Grookai Value, Available Today unavailable.
+- Mixed raw/slab evidence: block Grookai Value.
+- Mightyena ex `GV-PK-HP-101`: `$79` active ask must not be Grookai Value.
+
+## Implementation Plan
+
+1. Create a read-only candidate SQL view for an evidence-anchored public bridge.
+2. Keep current production bridge untouched until review.
+3. Add a compatibility layer for existing `v_card_pricing_ui_v1` consumers.
+4. Update web types to distinguish Grookai Value from Active Ask.
+5. Update card pricing UI to show two sections:
+   - Grookai Value
+   - Available Today
+6. Run regression tests and live readback against `GV-PK-HP-101`.
+7. Produce a targeted remote schema apply prompt before any DB change.
+
+## Approval Prompt For Next Phase
+
+Approve real MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1 plan only. Scope: create a local SQL/view candidate and app compatibility plan for an evidence-anchored public pricing bridge that separates Grookai Value from Available Today active ask evidence, uses reference valuation as the current primary anchor until stronger evidence exists, blocks mixed raw/slab lanes, preserves condition policy, and includes regression tests for GV-PK-HP-101. No remote DB apply. No pricing_observations writes. No ebay_active_prices_latest writes. No public app-visible migration apply. No provider calls. No source fetches. No identity/vault/image writes. No deletes. No merges. No global apply.
+

--- a/docs/contracts/MARKETPLACE_OUTBOUND_DISCOVERY_CONTRACT_V1.md
+++ b/docs/contracts/MARKETPLACE_OUTBOUND_DISCOVERY_CONTRACT_V1.md
@@ -1,0 +1,272 @@
+# MARKETPLACE_OUTBOUND_DISCOVERY_CONTRACT_V1
+
+## Status
+
+Planning contract only.
+
+No implementation. No DB changes. No provider calls. No public UI changes. No marketplace integration. No affiliate integration.
+
+## Why This Exists
+
+Grookai is building a Market Evidence Engine that separates valuation evidence from live availability. The next product layer is outbound marketplace discovery: helping collectors decide where to buy after Grookai has explained value, confidence, and market pressure.
+
+This contract preserves the product direction without starting the build.
+
+## Objective
+
+Define the long-term contract governing how Grookai connects collectors to external marketplaces.
+
+This is not a pricing contract.
+
+This is not a marketplace contract.
+
+This defines how Grookai uses external marketplaces as discovery and purchasing destinations while remaining marketplace-agnostic.
+
+## Core Philosophy
+
+Grookai exists to help collectors make better decisions.
+
+Grookai is the market intelligence layer.
+
+External marketplaces remain transaction venues.
+
+Grookai should never force collectors into one marketplace.
+
+## Relationship To Market Evidence Engine
+
+Market Evidence Engine answers:
+
+- What is Grookai Value?
+- What evidence supports it?
+- What is available today?
+- Is the live market above, below, or aligned with the value anchor?
+- What is blocked, uncertain, or not publishable?
+
+Marketplace Outbound Discovery answers:
+
+- Where can the collector inspect matching listings?
+- Which marketplace options are most relevant?
+- Which listings appear to match the exact collector intent?
+- When should Grookai send the collector away to complete a transaction?
+
+Active listings may support market pressure and outbound discovery, but active listings do not become market truth merely because they are outbound purchase options.
+
+## Product Principles
+
+Collectors should be able to:
+
+- understand Grookai Value
+- understand live market availability
+- compare marketplaces
+- choose where to buy
+- leave Grookai only when ready to complete a purchase
+
+## Initial Marketplace
+
+Initial outbound marketplace:
+
+- eBay
+
+Future marketplaces may include:
+
+- TCGplayer
+- Cardmarket
+- Fanatics Collect
+- PWCC
+- Goldin
+- local game stores
+- Grookai Marketplace
+- additional providers
+
+The architecture must remain marketplace-agnostic.
+
+## Collector Experience
+
+Example product flow:
+
+```text
+Grookai Value
+  -> Available Today
+  -> Market Intelligence
+  -> View Matching Listings
+  -> Collector chooses destination
+  -> Marketplace completes transaction
+```
+
+Grookai should keep the collector inside Grookai while they are evaluating value, confidence, market status, and listing fit.
+
+Grookai should send the collector outbound only when they are ready to inspect or complete a purchase on a transaction venue.
+
+## Outbound Listing Rules
+
+Grookai should link to listings that match:
+
+- exact card identity
+- exact finish
+- exact language
+- raw vs slab lane
+- grade when applicable
+- condition when known and supported by the marketplace
+- variant or special-lane identity when applicable
+
+Links should avoid generic marketplace searches whenever possible.
+
+If exact listing links are not available, Grookai may show a clearly labeled marketplace search fallback, but it must not present that fallback as exact-card availability.
+
+## Affiliate Strategy
+
+Support affiliate programs where available.
+
+Affiliate monetization must never:
+
+- alter marketplace ranking
+- bias listing recommendations
+- hide better buying opportunities
+- prioritize commission over collector value
+- downgrade non-affiliate marketplaces when they are better matches
+
+Collector trust always overrides affiliate revenue.
+
+## Marketplace Ranking
+
+Ranking should consider:
+
+- identity correctness
+- finish correctness
+- raw vs slab correctness
+- grade match
+- price
+- shipping
+- seller quality
+- condition
+- availability
+- marketplace reliability
+- stale listing risk
+
+Affiliate status must not be a ranking factor.
+
+## Marketplace Abstraction
+
+Every marketplace adapter should normalize outbound opportunities into a provider-agnostic shape before UI ranking.
+
+Minimum conceptual fields:
+
+- marketplace provider
+- marketplace listing id
+- listing URL
+- affiliate URL when allowed
+- card identity match status
+- finish match status
+- language match status
+- raw or slab lane
+- grade details when slabbed
+- condition details when raw
+- ask price
+- shipping price
+- seller metadata
+- listing freshness
+- availability status
+- confidence flags
+- exclusion flags
+
+Provider-specific fields may be stored as metadata, but the collector-facing ranking and display layer must operate on the normalized shape.
+
+## Analytics
+
+Track anonymous outbound metrics such as:
+
+- marketplace selected
+- listing selected
+- click-through rate
+- conversion estimate when available
+- price differences
+- marketplace availability
+- active ask compared to Grookai Value
+- search fallback usage
+- listing mismatch reports
+
+These analytics should improve collector recommendations over time.
+
+Analytics must not convert affiliate revenue into a ranking factor.
+
+## Future Multi-Marketplace View
+
+Possible future collector view:
+
+- Grookai Value
+- Available Today
+- eBay
+- TCGplayer
+- Cardmarket
+- Local Stores
+- Grookai Marketplace
+
+Grookai should become the collector's decision layer, not simply another storefront.
+
+## Public Copy Boundaries
+
+Allowed:
+
+- "Available Today"
+- "View matching listings"
+- "Compare marketplace options"
+- "Active ask"
+- "Marketplace availability"
+- "Listing appears to match this card"
+- "Search fallback"
+
+Avoid:
+
+- claiming Grookai is the seller when it is not
+- implying Grookai guarantees an external listing
+- implying an affiliate link is the best option because it monetizes
+- using active ask as Grookai Value
+- presenting generic searches as exact matches
+
+## Success Metric
+
+Success is not maximizing affiliate revenue.
+
+Success is helping collectors confidently decide where to buy while creating sustainable revenue through trusted outbound referrals.
+
+## Deliverables For A Future Build
+
+When this work resumes, produce:
+
+- product contract refinement
+- UX flow
+- marketplace abstraction architecture
+- affiliate integration strategy
+- ranking policy
+- analytics policy
+- future multi-marketplace roadmap
+- implementation plan
+- tests before public UI changes
+
+## Explicit Non-Goals
+
+This contract does not:
+
+- publish prices
+- create Grookai Marketplace
+- create checkout
+- replace Market Evidence Engine
+- define pricing truth
+- rank by affiliate payout
+- write marketplace data
+- create app UI
+- change public pricing views
+
+## Resume Notes
+
+This contract should resume after the reference/evidence-anchored public pricing bridge is reviewed and merged.
+
+The bridge work established the separation between:
+
+- Grookai Value
+- Available Today / active ask pressure
+- blocked value states
+- raw vs slab lane separation
+- provider evidence vs public valuation
+
+Marketplace Outbound Discovery should build on that separation instead of collapsing it.

--- a/docs/contracts/MEE_PUBLIC_PRICING_BRIDGE_REFERENCE_ANCHORED_V1.md
+++ b/docs/contracts/MEE_PUBLIC_PRICING_BRIDGE_REFERENCE_ANCHORED_V1.md
@@ -1,0 +1,144 @@
+# MEE Public Pricing Bridge Reference Anchored V1
+
+Status: design contract, not applied
+
+This contract resets the collector-facing pricing bridge after the active-listing-only public bridge exposed eBay ask medians as Grookai Value.
+
+## Principle
+
+Grookai Value is evidence-anchored, with reference sources serving as the primary valuation anchor until stronger market evidence exists.
+
+Evidence hierarchy:
+
+1. Verified transaction evidence, reserved for future Grookai marketplace sales, verified user transactions, or licensed sold-comparable feeds.
+2. Reference valuation evidence, including TCGPlayer-derived, Cardmarket-derived, TCGCSV, and PokemonTCG.io reference layers.
+3. Active listing evidence, including eBay active buy-now listings, as live availability and asking-price pressure.
+4. Insufficient evidence, which blocks value publication.
+
+Reference evidence anchors the initial valuation. Active market evidence may influence confidence, ranges, and market status, but does not replace the valuation anchor unless future publication policy explicitly allows it.
+
+## Product Contract
+
+Collector-facing pricing must answer:
+
+- What is Grookai's evidence-anchored value?
+- What can I buy it for today?
+- Is the live market above or below the evidence anchor?
+- How confident is Grookai?
+- Why is a value unavailable if blocked?
+
+## Public Lanes
+
+### Grookai Value
+
+Grookai Value is the valuation lane.
+
+It may be shown only when evidence is valuation-eligible and lane-safe. Today that means reference evidence is present and active market pressure, if present, is bounded by confidence, clustering, freshness, review state, and source agreement.
+
+### Available Today
+
+Available Today is the active-listing lane.
+
+It may show active ask median, range, listing count, seller count, freshness, and market pressure. It must not be labeled market truth or sold comparable evidence.
+
+## Active Market Adjustment
+
+Grookai Value is not completely isolated from live market data.
+
+The model is:
+
+```text
+Evidence Anchor
++ Controlled Market Pressure Adjustment
+= Grookai Value
+```
+
+The adjustment is controlled by:
+
+- comparable listing count
+- seller diversity
+- price clustering and spread
+- source agreement
+- source freshness
+- raw vs slab separation
+- condition confidence
+- review status
+- exclusion flags
+- future verified transaction strength
+
+Active listings may nudge Grookai Value. They must not overwrite it.
+
+## Condition Rule
+
+Do not default Grookai Value to Near Mint pricing.
+
+- If the user/card has a known condition, use that condition.
+- If condition is unknown, show an unconditioned reference range or "condition required."
+- If reference sources provide a condition ladder, preserve the ladder: Damaged, HP, MP, LP, NM.
+- If eBay active evidence is mostly NM listings, label it as NM Active Ask, not general Grookai Value.
+- Do not compare NM eBay active asks against all-condition reference values as if they are equivalent.
+
+## Required Cases
+
+### Reference and active evidence agree
+
+Show Grookai Value from the evidence anchor with a small market-pressure adjustment when confidence supports it. Show Available Today separately.
+
+### Reference and active evidence disagree
+
+Do not replace the evidence anchor.
+
+Show:
+
+- evidence-anchored Grookai Value or range
+- active ask signal separately
+- market status: active listings above reference, below reference, or aligned with reference
+
+### eBay-only evidence
+
+Do not label eBay-only active ask as Grookai Value.
+
+Show:
+
+- Active Ask Range
+- Available Today
+- confidence: limited / active-listing-only
+- explanation: "No reference market anchor available."
+
+### Reference-only evidence
+
+Show Grookai Value or range if the reference lane passes review and condition rules. Show Available Today as unavailable.
+
+### Mixed raw and slab evidence
+
+Block Grookai Value until raw and slab lanes are split.
+
+## Regression Case
+
+`GV-PK-HP-101` / Mightyena ex must not show `$79` as Grookai Value when that number comes from eBay active ask median.
+
+Current verified bad state:
+
+- `v_market_evidence_public_price_bridge_v1.primary_price = 79`
+- `v_market_evidence_public_price_bridge_v1.grookai_value = 79`
+- `primary_source = ebay`
+- `pricing_basis = active_listing_market_estimate`
+
+Expected V1 behavior:
+
+- Grookai Value is anchored to reference valuation evidence when present.
+- eBay around `$79` is Available Today / active ask pressure.
+- If the reference anchor is around `$50-60`, Grookai Value must reflect the evidence anchor plus controlled pressure, not the active ask median.
+
+## Boundaries
+
+- Do not use JustTCG as public pricing.
+- Do not make active eBay ask median the primary value.
+- Do not publish new prices without gate checks.
+- Do not write `pricing_observations`.
+- Do not write `ebay_active_prices_latest`.
+- Do not change identity tables.
+- Do not change vault tables.
+- Do not change image tables.
+- Do not delete, merge, or globally apply.
+

--- a/docs/plans/market_evidence_engine_v1/MEE_PUBLIC_PRICING_BRIDGE_REFERENCE_ANCHORED_V1_APP_COMPATIBILITY_PLAN.md
+++ b/docs/plans/market_evidence_engine_v1/MEE_PUBLIC_PRICING_BRIDGE_REFERENCE_ANCHORED_V1_APP_COMPATIBILITY_PLAN.md
@@ -1,0 +1,111 @@
+# MEE Public Pricing Bridge Reference Anchored V1 App Compatibility Plan
+
+Status: plan only
+
+No app-visible DB change has been applied.
+
+## Current App Contract
+
+The current app reads `v_card_pricing_ui_v1` through:
+
+- `apps/web/src/lib/pricing/getCardPricingUiByCardPrintId.ts`
+- `apps/web/src/lib/pricing/getPublicPricingByCardIds.ts`
+- `apps/web/src/app/api/card-pricing/route.ts`
+- `apps/web/src/components/pricing/CardPagePricingRail.tsx`
+
+The current type collapses the pricing model into:
+
+- `primary_price`
+- `primary_source`
+- `grookai_value`
+- `min_price`
+- `max_price`
+- `ebay_median_price`
+- `ebay_listing_count`
+
+That shape allowed active eBay ask median to become both primary price and Grookai Value.
+
+## Target App Contract
+
+The app needs two separate sections.
+
+### Grookai Value
+
+Fields:
+
+- `grookai_value_low`
+- `grookai_value_mid`
+- `grookai_value_high`
+- `grookai_value_basis`
+- `grookai_value_block_reason`
+- `grookai_value_condition_label`
+- `reference_anchor_low`
+- `reference_anchor_mid`
+- `reference_anchor_high`
+- `reference_source_count`
+- `confidence_label`
+
+Display:
+
+- Show Grookai Value only when `grookai_value_mid` is present.
+- If blocked, show the block reason in collector language.
+- Do not default condition to NM.
+- If condition is unknown, label the value as an unconditioned reference range or condition-required state.
+
+### Available Today
+
+Fields:
+
+- `active_ask_low`
+- `active_ask_mid`
+- `active_ask_high`
+- `active_ask_minimum`
+- `active_ask_maximum`
+- `active_ask_listing_count`
+- `active_ask_seller_count`
+- `active_ask_condition_label`
+- `active_ask_signal_at`
+- `market_pressure_pct`
+- `market_pressure_status`
+- `freshness_label`
+
+Display:
+
+- Show Available Today when `active_ask_mid` is present.
+- Label it active ask / buy-now pressure, not Grookai Value.
+- Show whether active listings are above, below, or aligned with the evidence anchor.
+
+## Compatibility Strategy
+
+Phase 1: Add a new app type for the reference-anchored bridge. Keep existing `CardPricingUiRecord` untouched until the DB view is approved.
+
+Phase 2: Update `/api/card-pricing` to return both old and new payload shapes behind a feature flag or explicit version field.
+
+Phase 3: Update `CardPagePricingRail` to render:
+
+1. Grookai Value
+2. Available Today
+3. Market status and confidence
+
+Phase 4: Retire the active-listing-only `primary_price` behavior after production readback proves the reference-anchored bridge is stable.
+
+## Compatibility Guard
+
+If a bridge row has:
+
+- `grookai_value_mid is null`
+- `active_ask_mid is not null`
+- `grookai_value_block_reason = blocked_no_valuation_anchor`
+
+then the app must show only Available Today and must not show a primary Grookai Value.
+
+## Mightyena Regression
+
+For `GV-PK-HP-101`, the app must render:
+
+- Grookai Value from reference anchor / controlled market-pressure adjustment.
+- Available Today around the eBay active ask lane.
+- Market pressure as active listings above reference.
+
+It must not render `$79` as Grookai Value.
+

--- a/docs/sql/mee_public_pricing_bridge_reference_anchored_v1_readback.sql
+++ b/docs/sql/mee_public_pricing_bridge_reference_anchored_v1_readback.sql
@@ -1,0 +1,41 @@
+-- MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1 readback candidate.
+--
+-- Run only after the candidate view is applied in an approved environment.
+
+with bridge as (
+  select *
+  from public.v_market_evidence_public_pricing_bridge_reference_anchored_v1
+), mightyena as (
+  select *
+  from bridge
+  where gv_id = 'GV-PK-HP-101'
+), boundary as (
+  select
+    count(*) filter (where market_truth)::int as market_truth_rows,
+    count(*) filter (where sold_comp)::int as sold_comp_rows,
+    count(*) filter (where app_visible)::int as app_visible_rows,
+    count(*) filter (where publishable)::int as publishable_rows,
+    count(*) filter (
+      where grookai_value_block_reason = 'blocked_no_valuation_anchor'
+        and grookai_value_mid is not null
+    )::int as active_only_grookai_value_leak_rows,
+    count(*) filter (
+      where grookai_value_mid = active_ask_mid
+        and market_pressure_status in ('active_listings_above_reference', 'active_listings_below_reference')
+    )::int as disagreement_active_ask_overwrite_rows
+  from bridge
+)
+select
+  'MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1'::text as package_id,
+  (select count(*)::int from bridge) as bridge_rows,
+  (select count(*)::int from bridge where grookai_value_mid is not null) as grookai_value_rows,
+  (select count(*)::int from bridge where active_ask_mid is not null) as active_ask_rows,
+  (select count(*)::int from bridge where grookai_value_block_reason is not null) as blocked_value_rows,
+  (select to_jsonb(boundary) from boundary) as boundary,
+  (select to_jsonb(mightyena) from mightyena limit 1) as mightyena_regression_row,
+  false::boolean as writes_pricing_observations,
+  false::boolean as writes_ebay_active_prices_latest,
+  false::boolean as uses_justtcg_public_pricing,
+  false::boolean as sold_comp_truth,
+  false::boolean as market_truth;
+

--- a/docs/sql/mee_public_pricing_bridge_reference_anchored_v1_view_candidate.sql
+++ b/docs/sql/mee_public_pricing_bridge_reference_anchored_v1_view_candidate.sql
@@ -1,0 +1,270 @@
+-- MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1 view candidate.
+--
+-- Candidate only. Do not apply remotely without explicit approval.
+--
+-- Goal:
+-- - Grookai Value is evidence-anchored.
+-- - Reference valuation evidence is the current primary anchor until stronger
+--   verified transaction evidence exists.
+-- - eBay active listings are Available Today / active ask pressure, not market
+--   truth and not Grookai Value by themselves.
+-- - Raw and slab lanes remain separated.
+-- - JustTCG is not used as public pricing.
+
+create or replace view public.v_market_evidence_public_pricing_bridge_reference_anchored_v1
+with (security_invoker = true)
+as
+with latest_reference_rollups as (
+  select distinct on (card_print_id)
+    id as reference_rollup_id,
+    card_print_id,
+    gv_id,
+    rollup_version as reference_rollup_version,
+    rollup_lane as reference_rollup_lane,
+    review_status as reference_review_status,
+    currency as reference_currency,
+    reference_low::numeric(12,2) as reference_low,
+    reference_median::numeric(12,2) as reference_median,
+    reference_high::numeric(12,2) as reference_high,
+    source_count as reference_source_count,
+    eligible_evidence_count as reference_eligible_evidence_count,
+    quarantined_evidence_count as reference_quarantined_evidence_count,
+    currency_excluded_evidence_count as reference_currency_excluded_evidence_count,
+    price_ratio as reference_price_ratio,
+    variance_band as reference_variance_band,
+    review_flags as reference_review_flags,
+    source_summary as reference_source_summary,
+    updated_at as reference_updated_at,
+    created_at as reference_created_at
+  from public.market_reference_signal_rollups
+  where currency = 'USD'
+    and reference_median is not null
+    and publishable = false
+    and app_visible = false
+    and market_truth = false
+  order by card_print_id, updated_at desc nulls last, created_at desc
+), latest_listing_rollups as (
+  select distinct on (card_print_id, active_lane)
+    id as active_listing_rollup_id,
+    card_print_id,
+    gv_id,
+    case
+      when rollup_version ilike '%SLAB%' then 'slab'
+      when rollup_version ilike '%RAW_SINGLE%' then 'raw_single'
+      else 'unknown'
+    end as active_lane,
+    source as active_listing_source,
+    rollup_version as active_listing_rollup_version,
+    rollup_window as active_listing_rollup_window,
+    listing_count as active_listing_count,
+    seller_count as active_seller_count,
+    median_active_ask::numeric(12,2) as active_ask_mid,
+    trimmed_low_active_ask::numeric(12,2) as active_ask_low,
+    trimmed_high_active_ask::numeric(12,2) as active_ask_high,
+    minimum_active_ask::numeric(12,2) as active_ask_minimum,
+    maximum_active_ask::numeric(12,2) as active_ask_maximum,
+    currency as active_ask_currency,
+    stale_listing_count as active_stale_listing_count,
+    reviewed_candidate_count as active_reviewed_candidate_count,
+    generated_at as active_ask_generated_at,
+    created_at as active_ask_created_at
+  from (
+    select
+      *,
+      case
+        when rollup_version ilike '%SLAB%' then 'slab'
+        when rollup_version ilike '%RAW_SINGLE%' then 'raw_single'
+        else 'unknown'
+      end as active_lane
+    from public.market_listing_rollups
+    where currency = 'USD'
+      and median_active_ask is not null
+      and publishable = false
+      and app_visible = false
+      and market_truth = false
+  ) listing
+  order by
+    card_print_id,
+    active_lane,
+    generated_at desc nulls last,
+    created_at desc
+), raw_active as (
+  select *
+  from latest_listing_rollups
+  where active_lane = 'raw_single'
+), slab_active as (
+  select *
+  from latest_listing_rollups
+  where active_lane = 'slab'
+), universe as (
+  select card_print_id from latest_reference_rollups
+  union
+  select card_print_id from raw_active
+  union
+  select card_print_id from slab_active
+), joined as (
+  select
+    universe.card_print_id,
+    coalesce(reference.gv_id, raw.gv_id, slab.gv_id) as gv_id,
+    reference.reference_rollup_id,
+    reference.reference_rollup_version,
+    reference.reference_rollup_lane,
+    reference.reference_review_status,
+    reference.reference_currency,
+    reference.reference_low,
+    reference.reference_median,
+    reference.reference_high,
+    reference.reference_source_count,
+    reference.reference_eligible_evidence_count,
+    reference.reference_quarantined_evidence_count,
+    reference.reference_currency_excluded_evidence_count,
+    reference.reference_price_ratio,
+    reference.reference_variance_band,
+    reference.reference_review_flags,
+    reference.reference_source_summary,
+    reference.reference_updated_at,
+    raw.active_listing_rollup_id as raw_active_listing_rollup_id,
+    raw.active_listing_source as raw_active_listing_source,
+    raw.active_listing_rollup_version as raw_active_listing_rollup_version,
+    raw.active_listing_count as raw_active_listing_count,
+    raw.active_seller_count as raw_active_seller_count,
+    raw.active_ask_low as raw_active_ask_low,
+    raw.active_ask_mid as raw_active_ask_mid,
+    raw.active_ask_high as raw_active_ask_high,
+    raw.active_ask_minimum as raw_active_ask_minimum,
+    raw.active_ask_maximum as raw_active_ask_maximum,
+    raw.active_ask_generated_at as raw_active_ask_generated_at,
+    raw.active_stale_listing_count as raw_active_stale_listing_count,
+    slab.active_listing_rollup_id as slab_active_listing_rollup_id,
+    slab.active_listing_count as slab_active_listing_count,
+    slab.active_seller_count as slab_active_seller_count,
+    slab.active_ask_mid as slab_active_ask_mid,
+    slab.active_ask_generated_at as slab_active_ask_generated_at
+  from universe
+  left join latest_reference_rollups reference
+    on reference.card_print_id = universe.card_print_id
+  left join raw_active raw
+    on raw.card_print_id = universe.card_print_id
+  left join slab_active slab
+    on slab.card_print_id = universe.card_print_id
+), scored as (
+  select
+    *,
+    case
+      when reference_median is not null and raw_active_ask_mid is not null and reference_median > 0
+        then round(((raw_active_ask_mid - reference_median) / reference_median) * 100.0, 2)
+      else null::numeric
+    end as market_pressure_pct,
+    case
+      when reference_median is null and raw_active_ask_mid is not null then 'active_listing_only_no_reference_anchor'
+      when reference_median is not null and raw_active_ask_mid is null then 'reference_only_no_active_ask'
+      when reference_median is null and raw_active_ask_mid is null then 'insufficient_evidence'
+      when abs(((raw_active_ask_mid - reference_median) / nullif(reference_median, 0)) * 100.0) <= 10 then 'active_listings_aligned_with_reference'
+      when raw_active_ask_mid > reference_median then 'active_listings_above_reference'
+      else 'active_listings_below_reference'
+    end as market_pressure_status,
+    case
+      when raw_active_listing_rollup_id is not null and slab_active_listing_rollup_id is not null then 'raw_and_slab_available_separated'
+      when raw_active_listing_rollup_id is not null then 'raw_single_only'
+      when slab_active_listing_rollup_id is not null then 'slab_only'
+      else 'no_active_listing_lane'
+    end as lane_policy,
+    case
+      when reference_median is null then 'blocked_no_valuation_anchor'
+      when reference_currency <> 'USD' then 'blocked_non_usd_reference'
+      when reference_source_count < 1 then 'blocked_no_reference_source'
+      when reference_median <= 0 then 'blocked_invalid_reference_median'
+      else null::text
+    end as grookai_value_block_reason,
+    case
+      when reference_median is null then null::numeric
+      when raw_active_ask_mid is null then reference_median
+      when abs(((raw_active_ask_mid - reference_median) / nullif(reference_median, 0)) * 100.0) <= 10
+        then round((reference_median * 0.75) + (raw_active_ask_mid * 0.25), 2)
+      when abs(((raw_active_ask_mid - reference_median) / nullif(reference_median, 0)) * 100.0) <= 50
+        then round(reference_median + ((raw_active_ask_mid - reference_median) * 0.20), 2)
+      else round(reference_median + ((raw_active_ask_mid - reference_median) * 0.10), 2)
+    end as controlled_grookai_value_mid
+  from joined
+)
+select
+  card_print_id,
+  gv_id,
+  'USD'::text as currency,
+  reference_rollup_id,
+  reference_rollup_version,
+  reference_review_status,
+  reference_low as reference_anchor_low,
+  reference_median as reference_anchor_mid,
+  reference_high as reference_anchor_high,
+  reference_source_count,
+  reference_eligible_evidence_count,
+  reference_review_flags,
+  reference_source_summary,
+  case
+    when grookai_value_block_reason is not null then null::numeric(12,2)
+    else least(coalesce(reference_low, controlled_grookai_value_mid), controlled_grookai_value_mid)::numeric(12,2)
+  end as grookai_value_low,
+  case
+    when grookai_value_block_reason is not null then null::numeric(12,2)
+    else controlled_grookai_value_mid::numeric(12,2)
+  end as grookai_value_mid,
+  case
+    when grookai_value_block_reason is not null then null::numeric(12,2)
+    else greatest(coalesce(reference_high, controlled_grookai_value_mid), controlled_grookai_value_mid)::numeric(12,2)
+  end as grookai_value_high,
+  case
+    when grookai_value_block_reason is not null then 'unavailable_blocked'
+    when raw_active_ask_mid is null then 'reference_anchor_only'
+    when market_pressure_status = 'active_listings_aligned_with_reference' then 'reference_anchor_with_aligned_active_pressure'
+    else 'reference_anchor_with_bounded_active_pressure'
+  end as grookai_value_basis,
+  grookai_value_block_reason,
+  raw_active_listing_rollup_id,
+  raw_active_listing_source,
+  raw_active_listing_rollup_version,
+  raw_active_ask_low as active_ask_low,
+  raw_active_ask_mid as active_ask_mid,
+  raw_active_ask_high as active_ask_high,
+  raw_active_ask_minimum,
+  raw_active_ask_maximum,
+  raw_active_listing_count as active_ask_listing_count,
+  raw_active_seller_count as active_ask_seller_count,
+  raw_active_ask_generated_at as active_ask_signal_at,
+  raw_active_stale_listing_count as active_ask_stale_listing_count,
+  slab_active_listing_rollup_id,
+  slab_active_listing_count,
+  slab_active_seller_count,
+  slab_active_ask_mid,
+  market_pressure_pct,
+  market_pressure_status,
+  lane_policy,
+  'condition_unknown_reference_range'::text as condition_policy,
+  'unknown'::text as grookai_value_condition_label,
+  'raw_single_active_ask'::text as active_ask_condition_label,
+  case
+    when grookai_value_block_reason is not null and raw_active_ask_mid is not null then 'limited_active_listing_only'
+    when reference_source_count >= 2
+      and raw_active_listing_count >= 50
+      and raw_active_seller_count >= 12
+      and abs(coalesce(market_pressure_pct, 0)) <= 15 then 'high'
+    when reference_source_count >= 1 and (raw_active_listing_count is null or raw_active_listing_count >= 10) then 'medium'
+    else 'limited'
+  end as confidence_label,
+  case
+    when raw_active_ask_generated_at is null then 'no_active_ask'
+    when raw_active_ask_generated_at >= now() - interval '3 days' then 'fresh'
+    when raw_active_ask_generated_at >= now() - interval '14 days' then 'aging'
+    else 'stale'
+  end as freshness_label,
+  true as signed_in_only,
+  false as market_truth,
+  false as sold_comp,
+  raw_active_ask_mid is not null as active_listing_evidence,
+  false as publishable,
+  false as app_visible
+from scored;
+
+revoke all on public.v_market_evidence_public_pricing_bridge_reference_anchored_v1 from public, anon, authenticated, service_role;
+grant select on public.v_market_evidence_public_pricing_bridge_reference_anchored_v1 to authenticated, service_role;
+

--- a/tests/contracts/market_evidence_engine_pricing_labels_v1.test.mjs
+++ b/tests/contracts/market_evidence_engine_pricing_labels_v1.test.mjs
@@ -10,8 +10,11 @@ test("card pricing rail labels reference and market lanes explicitly", () => {
   const pricingRail = source("apps/web/src/components/pricing/CardPagePricingRail.tsx");
 
   assert.doesNotMatch(pricingRail, /JustTCG/);
-  assert.match(pricingRail, /Active listing evidence: eBay/);
-  assert.match(pricingRail, /source=\{pricing\?\.primary_source\}/);
+  assert.match(pricingRail, /Evidence-anchored Grookai Value/);
+  assert.match(pricingRail, /Available Today/);
+  assert.match(pricingRail, /eBay active ask/);
+  assert.match(pricingRail, /Active asks are asking-price evidence, not sold comps\./);
+  assert.doesNotMatch(pricingRail, /source=\{pricing\?\.primary_source\}/);
   assert.doesNotMatch(pricingRail, />\* Market reference</);
 });
 

--- a/tests/contracts/mee_public_price_bridge_v1.test.mjs
+++ b/tests/contracts/mee_public_price_bridge_v1.test.mjs
@@ -100,14 +100,21 @@ test("pricing UI copy states active listing estimates are not sold comps", () =>
 
 test("signed-in card pricing hydration route is tracked and auth-gated", () => {
   const route = read(cardPricingRoutePath);
+  const rail = read(pricingRailPath);
   const gitignore = read(".gitignore");
 
-  assert.match(route, /getCardPricingUiByCardPrintId/);
+  assert.match(route, /getCardPricingUiByCardPrintIdWithClient/);
   assert.match(route, /createRouteHandlerClient/);
+  assert.match(route, /createServerAdminClient/);
   assert.match(route, /auth\.getUser\(\)/);
+  assert.match(route, /auth\.getUser\(bearerToken\)/);
+  assert.match(route, /extractBearerToken/);
   assert.match(route, /Sign in required\./);
   assert.match(route, /card_print_id/);
   assert.match(route, /Cache-Control["']:\s*["']private,\s*no-store/);
+  assert.match(rail, /supabase\.auth\.getSession\(\)/);
+  assert.match(rail, /Authorization:\s*`Bearer \$\{session\.access_token\}`/);
+  assert.match(rail, /credentials:\s*"same-origin"/);
   assert.match(gitignore, /!apps\/web\/src\/app\/api\/card-pricing\/route\.ts/);
 });
 
@@ -132,7 +139,7 @@ test("MEE public price bridge remote readback has closed truth boundaries", () =
 });
 
 test("MEE public price bridge artifacts exist", () => {
-  for (const artifactPath of [bridgeSqlPath, readbackSqlPath, migrationPath, contractPath, checkpointPath, cardPricingRoutePath, remoteApplyReportPath, remoteApplyMarkdownPath]) {
+  for (const artifactPath of [bridgeSqlPath, readbackSqlPath, migrationPath, contractPath, checkpointPath, cardPricingRoutePath, pricingRailPath, remoteApplyReportPath, remoteApplyMarkdownPath]) {
     assert.equal(existsSync(new URL(`../../${artifactPath}`, import.meta.url)), true, artifactPath);
   }
 });

--- a/tests/contracts/mee_public_price_bridge_v1.test.mjs
+++ b/tests/contracts/mee_public_price_bridge_v1.test.mjs
@@ -77,25 +77,44 @@ test("app pricing reads require bridge safety fields before showing price", () =
   const publicHelper = read(publicPricingHelperPath);
 
   for (const helper of [cardHelper, publicHelper]) {
-    assert.match(helper, /v_market_evidence_public_price_bridge_v1|v_card_pricing_ui_v1/);
-    assert.match(helper, /pricing_basis/);
-    assert.match(helper, /active_listing_market_estimate/);
-    assert.match(helper, /active_listing_evidence\s*={0,2}\s*true|active_listing_evidence\s*===\s*true/);
+    assert.match(helper, /v_market_evidence_public_pricing_bridge_reference_anchored_v1/);
+    assert.match(helper, /grookai_value_mid/);
     assert.match(helper, /market_truth\s*={0,2}\s*false|market_truth\s*===\s*false/);
     assert.match(helper, /sold_comp\s*={0,2}\s*false|sold_comp\s*===\s*false/);
+    assert.match(helper, /publishable\s*={0,2}\s*false|publishable\s*===\s*false/);
+    assert.match(helper, /app_visible\s*={0,2}\s*false|app_visible\s*===\s*false/);
   }
 
+  assert.match(cardHelper, /active_ask_mid/);
+  assert.match(cardHelper, /grookai_value_block_reason/);
+  assert.match(publicHelper, /grookai_value_block_reason\s*===\s*null/);
+  assert.doesNotMatch(publicHelper, /v_market_evidence_public_price_bridge_v1/);
   assert.doesNotMatch(publicHelper, /v_best_prices_all_gv_v1/);
   assert.doesNotMatch(publicHelper, /card_print_active_prices/);
 });
 
-test("pricing UI copy states active listing estimates are not sold comps", () => {
+test("app pricing reads do not use active ask as Grookai Value", () => {
+  const cardHelper = read(cardPricingHelperPath);
+  const publicHelper = read(publicPricingHelperPath);
+
+  assert.doesNotMatch(cardHelper, /primary_source:\s*"ebay"/);
+  assert.doesNotMatch(cardHelper, /pricing_basis:\s*"active_listing_market_estimate"/);
+  assert.match(cardHelper, /primary_source:\s*hasGrookaiValue\s*\?\s*"grookai_value"/);
+  assert.match(cardHelper, /ebay_median_price:\s*activeAskMid/);
+  assert.match(publicHelper, /const rawPrice = typeof row\.grookai_value_mid/);
+  assert.match(publicHelper, /rawPriceSource = rawPrice !== undefined \? "grookai_value"/);
+});
+
+test("pricing UI copy separates Grookai Value and Available Today", () => {
   const rail = read(pricingRailPath);
   const disclosure = read(pricingDisclosurePath);
 
-  assert.match(rail, /Active listing evidence: eBay\. Not a sold-comp price\./);
-  assert.match(rail, /Raw single estimate/);
-  assert.match(disclosure, /Active listing estimates are asking-price evidence, not sold-comparable proof or guaranteed market value\./);
+  assert.match(rail, /Evidence-anchored Grookai Value/);
+  assert.match(rail, /Available Today/);
+  assert.match(rail, /eBay active ask/);
+  assert.match(rail, /Active asks are asking-price evidence, not sold comps\./);
+  assert.match(disclosure, /Grookai Value is evidence-anchored/);
+  assert.match(disclosure, /Available Today uses active listing asks/);
 });
 
 test("signed-in card pricing hydration route is tracked and auth-gated", () => {

--- a/tests/contracts/mee_public_pricing_bridge_reference_anchored_v1.test.mjs
+++ b/tests/contracts/mee_public_pricing_bridge_reference_anchored_v1.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function read(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+}
+
+function stripSqlComments(sql) {
+  return sql.replace(/--.*$/gm, "");
+}
+
+const contractPath = "docs/contracts/MEE_PUBLIC_PRICING_BRIDGE_REFERENCE_ANCHORED_V1.md";
+const auditPath = "docs/audits/market_evidence_engine_v1/MEE-PUBLIC-PRICING-BRIDGE-REFERENCE-ANCHORED-V1.md";
+const currentBridgeSqlPath = "docs/sql/mee_public_price_bridge_v1.sql";
+const candidateSqlPath = "docs/sql/mee_public_pricing_bridge_reference_anchored_v1_view_candidate.sql";
+const readbackSqlPath = "docs/sql/mee_public_pricing_bridge_reference_anchored_v1_readback.sql";
+const appCompatibilityPlanPath =
+  "docs/plans/market_evidence_engine_v1/MEE_PUBLIC_PRICING_BRIDGE_REFERENCE_ANCHORED_V1_APP_COMPATIBILITY_PLAN.md";
+
+function evaluatePricingScenario({
+  referenceMid = null,
+  activeAskMid = null,
+  mixedRawSlab = false,
+  activeCondition = "unknown",
+  referenceCondition = "unknown",
+} = {}) {
+  if (mixedRawSlab) {
+    return {
+      grookaiValueAvailable: false,
+      activeAskAvailable: Boolean(activeAskMid),
+      status: "needs_lane_split",
+    };
+  }
+
+  if (typeof referenceMid === "number" && typeof activeAskMid === "number") {
+    const pressurePct = ((activeAskMid - referenceMid) / referenceMid) * 100;
+    const aligned = Math.abs(pressurePct) <= 10;
+    return {
+      grookaiValueAvailable: true,
+      activeAskAvailable: true,
+      grookaiValueMayEqualActiveAsk: aligned && referenceCondition === activeCondition,
+      status: pressurePct > 10 ? "active_listings_above_reference" : pressurePct < -10 ? "active_listings_below_reference" : "aligned",
+      pressurePct,
+    };
+  }
+
+  if (typeof referenceMid === "number") {
+    return {
+      grookaiValueAvailable: true,
+      activeAskAvailable: false,
+      status: "reference_only",
+    };
+  }
+
+  if (typeof activeAskMid === "number") {
+    return {
+      grookaiValueAvailable: false,
+      activeAskAvailable: true,
+      status: "active_listing_only",
+    };
+  }
+
+  return {
+    grookaiValueAvailable: false,
+    activeAskAvailable: false,
+    status: "insufficient_evidence",
+  };
+}
+
+test("reference anchored bridge contract defines evidence hierarchy and active ask separation", () => {
+  const contract = read(contractPath);
+
+  assert.match(contract, /Grookai Value is evidence-anchored/i);
+  assert.match(contract, /Verified transaction evidence/i);
+  assert.match(contract, /Reference valuation evidence/i);
+  assert.match(contract, /Active listing evidence/i);
+  assert.match(contract, /Available Today/i);
+  assert.match(contract, /Active listings may nudge Grookai Value\. They must not overwrite it\./i);
+  assert.match(contract, /Do not default Grookai Value to Near Mint pricing\./i);
+  assert.match(contract, /Damaged, HP, MP, LP, NM/i);
+  assert.match(contract, /Do not use JustTCG as public pricing\./i);
+});
+
+test("audit identifies current V1 regression source exactly", () => {
+  const audit = read(auditPath);
+  const sql = stripSqlComments(read(currentBridgeSqlPath));
+
+  assert.match(audit, /GV-PK-HP-101/);
+  assert.match(audit, /primary_price = 79/);
+  assert.match(audit, /grookai_value = 79/);
+  assert.match(audit, /market_reference_signal_rollups/);
+  assert.match(audit, /reference_median = 50\.00/);
+  assert.match(audit, /docs\/sql\/mee_public_price_bridge_v1\.sql/);
+  assert.match(audit, /supabase\/migrations\/20260625180000_mee_public_price_bridge_v1\.sql/);
+
+  assert.match(sql, /signal\.candidate_median\s+as\s+primary_price/i);
+  assert.match(sql, /signal\.candidate_median\s+as\s+grookai_value/i);
+  assert.match(sql, /'ebay'::text\s+as\s+primary_source/i);
+  assert.match(sql, /signal\.source_type\s+=\s+'active_listing'/i);
+});
+
+test("reference plus eBay disagreement keeps Grookai Value separate from active ask", () => {
+  const result = evaluatePricingScenario({
+    referenceMid: 55,
+    activeAskMid: 79,
+    referenceCondition: "unknown",
+    activeCondition: "nm",
+  });
+
+  assert.equal(result.grookaiValueAvailable, true);
+  assert.equal(result.activeAskAvailable, true);
+  assert.equal(result.status, "active_listings_above_reference");
+  assert.equal(result.grookaiValueMayEqualActiveAsk, false);
+  assert.ok(result.pressurePct > 40);
+});
+
+test("eBay-only evidence is active ask only, not Grookai Value", () => {
+  const result = evaluatePricingScenario({ activeAskMid: 79 });
+
+  assert.equal(result.grookaiValueAvailable, false);
+  assert.equal(result.activeAskAvailable, true);
+  assert.equal(result.status, "active_listing_only");
+});
+
+test("reference-only evidence can show Grookai Value without Available Today", () => {
+  const result = evaluatePricingScenario({ referenceMid: 55 });
+
+  assert.equal(result.grookaiValueAvailable, true);
+  assert.equal(result.activeAskAvailable, false);
+  assert.equal(result.status, "reference_only");
+});
+
+test("mixed raw and slab lanes block Grookai Value", () => {
+  const result = evaluatePricingScenario({
+    referenceMid: 55,
+    activeAskMid: 200,
+    mixedRawSlab: true,
+  });
+
+  assert.equal(result.grookaiValueAvailable, false);
+  assert.equal(result.activeAskAvailable, true);
+  assert.equal(result.status, "needs_lane_split");
+});
+
+test("Mightyena regression requires eBay 79 to remain active ask pressure", () => {
+  const result = evaluatePricingScenario({
+    referenceMid: 50,
+    activeAskMid: 79,
+    referenceCondition: "unknown",
+    activeCondition: "nm",
+  });
+
+  assert.equal(result.grookaiValueAvailable, true);
+  assert.equal(result.activeAskAvailable, true);
+  assert.equal(result.status, "active_listings_above_reference");
+  assert.equal(result.grookaiValueMayEqualActiveAsk, false);
+  assert.ok(result.pressurePct > 50);
+});
+
+test("reference anchored SQL candidate separates Grookai Value from active ask", () => {
+  const sql = stripSqlComments(read(candidateSqlPath));
+
+  assert.match(sql, /create\s+or\s+replace\s+view\s+public\.v_market_evidence_public_pricing_bridge_reference_anchored_v1/i);
+  assert.match(sql, /from\s+public\.market_reference_signal_rollups/i);
+  assert.match(sql, /from\s+public\.market_listing_rollups/i);
+  assert.match(sql, /reference_median/i);
+  assert.match(sql, /controlled_grookai_value_mid/i);
+  assert.match(sql, /active_ask_mid/i);
+  assert.match(sql, /market_pressure_pct/i);
+  assert.match(sql, /market_pressure_status/i);
+  assert.match(sql, /grookai_value_block_reason/i);
+  assert.match(sql, /blocked_no_valuation_anchor/i);
+  assert.match(sql, /raw_and_slab_available_separated/i);
+  assert.match(sql, /condition_unknown_reference_range/i);
+
+  assert.doesNotMatch(sql, /signal\.candidate_median\s+as\s+grookai_value/i);
+  assert.doesNotMatch(sql, /'ebay'::text\s+as\s+primary_source/i);
+  assert.doesNotMatch(sql, /\bjusttcg\b/i);
+  assert.doesNotMatch(sql, /\bpricing_observations\b/i);
+  assert.doesNotMatch(sql, /\bebay_active_prices_latest\b/i);
+  assert.doesNotMatch(sql, /\binsert\s+into\b/i);
+  assert.doesNotMatch(sql, /\bupdate\s+public\./i);
+  assert.doesNotMatch(sql, /\bdelete\s+from\b/i);
+  assert.doesNotMatch(sql, /\bmerge\s+into\b/i);
+});
+
+test("reference anchored readback guards public boundary and Mightyena regression", () => {
+  const readback = stripSqlComments(read(readbackSqlPath));
+
+  assert.match(readback, /GV-PK-HP-101/);
+  assert.match(readback, /active_only_grookai_value_leak_rows/);
+  assert.match(readback, /disagreement_active_ask_overwrite_rows/);
+  assert.match(readback, /writes_pricing_observations/);
+  assert.match(readback, /writes_ebay_active_prices_latest/);
+  assert.match(readback, /uses_justtcg_public_pricing/);
+  assert.match(readback, /false::boolean\s+as\s+market_truth/i);
+});
+
+test("app compatibility plan requires two separate pricing sections", () => {
+  const plan = read(appCompatibilityPlanPath);
+
+  assert.match(plan, /Grookai Value/);
+  assert.match(plan, /Available Today/);
+  assert.match(plan, /grookai_value_mid/);
+  assert.match(plan, /active_ask_mid/);
+  assert.match(plan, /must not show a primary Grookai Value/i);
+  assert.match(plan, /It must not render `\$79` as Grookai Value\./);
+});


### PR DESCRIPTION
## Summary

Adds the reference/evidence-anchored public pricing bridge package for MEE.

- Creates the side-by-side SQL/readback artifacts for `v_market_evidence_public_pricing_bridge_reference_anchored_v1`.
- Updates the web pricing read path to consume the new bridge without replacing `v_card_pricing_ui_v1`.
- Renders `Grookai Value` separately from `Available Today` active ask evidence.
- Keeps active eBay ask out of the primary Grookai Value lane, including the `GV-PK-HP-101` Mightyena ex regression case.
- Preserves blocked-value states, auth gating, condition policy, and raw/slab separation boundaries.

## Validation

- `node --test tests/contracts/mee_public_price_bridge_v1.test.mjs tests/contracts/mee_public_pricing_bridge_reference_anchored_v1.test.mjs tests/contracts/market_evidence_engine_pricing_labels_v1.test.mjs`
- `npm --prefix apps/web run typecheck`
- Commit hook shipcheck passed.
- Push hook shipcheck passed.

## Boundaries

This PR contains docs, SQL candidates/readback, contract tests, and web compatibility implementation only. It does not replace `v_card_pricing_ui_v1` and does not write pricing observations, provider data, identity, vault, or image tables.


## Planning Contract Added

- Adds docs/contracts/MARKETPLACE_OUTBOUND_DISCOVERY_CONTRACT_V1.md as a planning-only follow-up contract for external marketplace discovery and outbound referral strategy.
- This contract is intentionally non-implementation: no DB changes, no provider calls, no public UI changes, and no marketplace integration.

