### PR TITLE
Tighten web search performance

### DIFF
--- a/apps/web/src/app/api/resolver/search/route.ts
+++ b/apps/web/src/app/api/resolver/search/route.ts
@@ -30,8 +30,9 @@ import type { ExploreResultCard } from "@/components/explore/exploreResultTypes"
 
 export const revalidate = 120;
 
-const DEFAULT_RESULT_LIMIT = 80;
-const MAX_RESULT_LIMIT = 80;
+const DEFAULT_RESULT_LIMIT = 48;
+const MAX_RESULT_LIMIT = 64;
+const RESOLVER_RESPONSE_TIMEOUT_MS = 4200;
 
 // LOCK: Canonical and provisional results must remain separate.
 // LOCK: Never merge provisional rows into canonical result arrays.
@@ -247,6 +248,18 @@ function buildDegradedSearchMeta(query: string): ResolverMeta {
   };
 }
 
+function buildDegradedSearchResult(
+  query: string,
+  smartSearchIntent: SmartSearchIntent,
+) {
+  return {
+    rows: [] as ExploreResultCard[],
+    meta: buildDegradedSearchMeta(query),
+    smartSearchIntent,
+    degraded: true,
+  };
+}
+
 function isTimeoutLikeError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error ?? "");
   return (
@@ -416,42 +429,15 @@ export async function GET(request: NextRequest) {
     }
 
     const includeProvisional =
+      languageScope !== "ja" &&
       !exactReleaseYear &&
       !hasSmartYearRange &&
       !exactIllustrator &&
       !effectiveSmartSearchIntent.ownedState &&
       !isIdentityFilterActive(identityFilter);
-    const [resolved, provisionalResults] = await Promise.all([
-      !query && effectiveSmartSearchIntent.ownedState === "owned" && userId
-        ? getOwnedCardPrintIdsForUser(userId).then((ownedCardPrintIds) =>
-            getExploreRowsForOwnedSmartFilterDiscovery(ownedCardPrintIds, {
-              sortMode,
-              exactSetCode,
-              exactReleaseYear,
-              exactIllustrator,
-              identityFilter,
-              releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
-              releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
-              finishKeys: effectiveSmartSearchIntent.finishKeys,
-              stampLabels: effectiveSmartSearchIntent.stampLabels,
-              imageState: effectiveSmartSearchIntent.imageState,
-              languageScope,
-            }),
-          ).then((rows) => ({
-            rows,
-            meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
-          }))
-        : shouldUseFastTextSearch
-          ? getExploreRowsForLanguageScopedTextSearch(
-              query,
-              languageScope,
-              sortMode,
-            ).then((rows) => ({
-              rows,
-              meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
-            }))
-        : shouldUseSmartFilterDiscovery
-          ? getExploreRowsForSmartFilterDiscovery({
+    const resolvedSearchPromise = !query && effectiveSmartSearchIntent.ownedState === "owned" && userId
+      ? getOwnedCardPrintIdsForUser(userId).then((ownedCardPrintIds) =>
+          getExploreRowsForOwnedSmartFilterDiscovery(ownedCardPrintIds, {
             sortMode,
             exactSetCode,
             exactReleaseYear,
@@ -463,38 +449,83 @@ export async function GET(request: NextRequest) {
             stampLabels: effectiveSmartSearchIntent.stampLabels,
             imageState: effectiveSmartSearchIntent.imageState,
             languageScope,
-          }).then((rows) => ({
+          }),
+        ).then((rows) => ({
+          rows,
+          meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
+          smartSearchIntent: effectiveSmartSearchIntent,
+          degraded: false,
+        }))
+      : shouldUseFastTextSearch
+        ? getExploreRowsForLanguageScopedTextSearch(
+            query,
+            languageScope,
+            sortMode,
+          ).then((rows) => ({
             rows,
             meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
+            smartSearchIntent: effectiveSmartSearchIntent,
+            degraded: false,
           }))
-          : shouldUseStructuredTextExpansion
-            ? getExploreRowsForSmartStructuredTextSearch(query, {
-                sortMode,
-                exactSetCode,
-                exactReleaseYear,
-                exactIllustrator,
-                identityFilter,
-                releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
-                releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
-                finishKeys: effectiveSmartSearchIntent.finishKeys,
-                stampLabels: effectiveSmartSearchIntent.stampLabels,
-                imageState: effectiveSmartSearchIntent.imageState,
-                languageScope,
-              }).then((rows) => ({
-                rows,
-                meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
-              }))
-            : resolveQueryWithMeta(query, {
-                mode: "ranked",
-                sortMode,
-                exactSetCode,
-                exactReleaseYear,
-                exactIllustrator,
-                identityFilter,
-                releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
-                releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
-                languageScope,
-              }),
+      : shouldUseSmartFilterDiscovery
+        ? getExploreRowsForSmartFilterDiscovery({
+          sortMode,
+          exactSetCode,
+          exactReleaseYear,
+          exactIllustrator,
+          identityFilter,
+          releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
+          releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
+          finishKeys: effectiveSmartSearchIntent.finishKeys,
+          stampLabels: effectiveSmartSearchIntent.stampLabels,
+          imageState: effectiveSmartSearchIntent.imageState,
+          languageScope,
+        }).then((rows) => ({
+          rows,
+          meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
+          smartSearchIntent: effectiveSmartSearchIntent,
+          degraded: false,
+        }))
+        : shouldUseStructuredTextExpansion
+          ? getExploreRowsForSmartStructuredTextSearch(query, {
+              sortMode,
+              exactSetCode,
+              exactReleaseYear,
+              exactIllustrator,
+              identityFilter,
+              releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
+              releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
+              finishKeys: effectiveSmartSearchIntent.finishKeys,
+              stampLabels: effectiveSmartSearchIntent.stampLabels,
+              imageState: effectiveSmartSearchIntent.imageState,
+              languageScope,
+            }).then((rows) => ({
+              rows,
+              meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
+              smartSearchIntent: effectiveSmartSearchIntent,
+              degraded: false,
+            }))
+          : resolveQueryWithMeta(query, {
+              mode: "ranked",
+              sortMode,
+              exactSetCode,
+              exactReleaseYear,
+              exactIllustrator,
+              identityFilter,
+              releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
+              releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
+              languageScope,
+            }).then((resolved) => ({
+              ...resolved,
+              smartSearchIntent: effectiveSmartSearchIntent,
+              degraded: false,
+            }));
+    const [resolved, provisionalResults] = await Promise.all([
+      withTimeout(
+        resolvedSearchPromise,
+        RESOLVER_RESPONSE_TIMEOUT_MS,
+        buildDegradedSearchResult(query, effectiveSmartSearchIntent),
+      ),
       includeProvisional
         ? getPublicProvisionalCardsFailClosed({
             query: rawQuery,
@@ -557,7 +588,9 @@ export async function GET(request: NextRequest) {
         meta: resolved.meta,
         limit: resultLimit,
         returned_count: limitedCanonicalResults.length,
-        source: "web_ranked_resolver_v2",
+        source: resolved.degraded
+          ? "web_ranked_resolver_v2_degraded_soft_timeout"
+          : "web_ranked_resolver_v2",
       },
       {
         headers: {

--- a/apps/web/src/components/PublicCardImage.tsx
+++ b/apps/web/src/components/PublicCardImage.tsx
@@ -12,6 +12,7 @@ type PublicCardImageProps = {
   fallbackClassName: string;
   fallbackLabel?: ReactNode;
   loading?: "eager" | "lazy";
+  priority?: boolean;
   sizes?: string;
 };
 
@@ -23,6 +24,7 @@ export default function PublicCardImage({
   fallbackClassName,
   fallbackLabel = "Image unavailable",
   loading,
+  priority = false,
   sizes = "(max-width: 640px) 42vw, (max-width: 1024px) 25vw, 220px",
 }: PublicCardImageProps) {
   const normalizedPrimary = typeof src === "string" && src.trim().length > 0 ? src.trim() : undefined;
@@ -47,7 +49,9 @@ export default function PublicCardImage({
     <Image
       src={activeSrc}
       alt={alt}
-      loading={loading}
+      loading={priority ? undefined : loading}
+      priority={priority}
+      fetchPriority={priority ? "high" : undefined}
       className={imageClassName}
       width={1200}
       height={1600}

--- a/apps/web/src/components/cards/PokemonCardGridTile.tsx
+++ b/apps/web/src/components/cards/PokemonCardGridTile.tsx
@@ -12,6 +12,7 @@ type PokemonCardGridTileProps = {
   imageHref?: string;
   imagePrefetch?: boolean;
   imageLoading?: "eager" | "lazy";
+  imagePriority?: boolean;
   imageSizes?: string;
   imageFallbackLabel?: string;
   imageClassName?: string;
@@ -87,6 +88,7 @@ function renderImage({
   imageFallbackSrc,
   imageAlt,
   imageLoading,
+  imagePriority,
   imageSizes,
   imageFallbackLabel,
   imageClassName,
@@ -97,6 +99,7 @@ function renderImage({
   imageFallbackSrc?: string;
   imageAlt: string;
   imageLoading?: "eager" | "lazy";
+  imagePriority?: boolean;
   imageSizes?: string;
   imageFallbackLabel?: string;
   imageClassName?: string;
@@ -111,6 +114,7 @@ function renderImage({
         fallbackSrc={imageFallbackSrc}
         alt={imageAlt}
         loading={imageLoading}
+        priority={imagePriority}
         sizes={imageSizes}
         imageClassName={`aspect-[3/4] w-full rounded-[20px] object-contain transition duration-200 group-hover:scale-[1.018] ${imageClassName ?? ""}`.trim()}
         fallbackClassName="flex aspect-[3/4] w-full items-center justify-center rounded-[20px] bg-white/42 px-4 text-center text-sm font-medium text-slate-400 ring-1 ring-inset ring-slate-200/40 dark:bg-white/[0.04] dark:text-slate-600 dark:ring-white/[0.05]"
@@ -162,6 +166,7 @@ export default function PokemonCardGridTile({
   imageHref,
   imagePrefetch,
   imageLoading,
+  imagePriority,
   imageSizes,
   imageFallbackLabel,
   imageClassName,
@@ -181,6 +186,7 @@ export default function PokemonCardGridTile({
     imageFallbackSrc,
     imageAlt,
     imageLoading,
+    imagePriority,
     imageSizes,
     imageFallbackLabel,
     imageClassName,

--- a/apps/web/src/components/explore/ExploreCardDetailsRow.tsx
+++ b/apps/web/src/components/explore/ExploreCardDetailsRow.tsx
@@ -61,7 +61,7 @@ export default function ExploreCardDetailsRow({ card, href, canViewPricing, sign
             fallbackClassName="flex h-14 w-10 items-center justify-center rounded-lg border border-slate-200 bg-slate-100 px-1 text-center text-[10px] text-slate-500"
           />
           <div className="min-w-0">
-            <Link href={href} className="block text-sm font-semibold text-slate-900 hover:underline dark:text-slate-100">
+            <Link href={href} prefetch={false} className="block text-sm font-semibold text-slate-900 hover:underline dark:text-slate-100">
               <span className="gv-hi-card-identity block truncate">{displayIdentity.base_name}</span>
               {identitySubtitle ? (
                 <span className="gv-hi-metadata block truncate text-xs font-medium">{identitySubtitle}</span>

--- a/apps/web/src/components/explore/ExploreCardGridItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardGridItem.tsx
@@ -23,13 +23,14 @@ type ExploreCardGridItemProps = {
   mode: "thumb" | "thumb-lg";
   canViewPricing: boolean;
   matchReason?: string;
+  imagePriority?: boolean;
 };
 
 function getPrimaryFinishLabel(card: ExploreResultCard) {
   return card.finish_label?.trim() || card.display_discriminator?.trim() || "";
 }
 
-export default function ExploreCardGridItem({ card, href, mode, canViewPricing }: ExploreCardGridItemProps) {
+export default function ExploreCardGridItem({ card, href, mode, canViewPricing, imagePriority = false }: ExploreCardGridItemProps) {
   const displayIdentity = resolveDisplayIdentity(card);
   const setLabel = card.set_name ?? "Unknown set";
   const identitySubtitle = resolveDisplayIdentitySubtitleForContext({
@@ -56,6 +57,9 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing }
       imageFallbackSrc={card.display_image_fallback_url}
       imageAlt={getCardImageAltText(displayIdentity.display_name, card)}
       imageHref={href}
+      imagePrefetch={false}
+      imageLoading={imagePriority ? "eager" : "lazy"}
+      imagePriority={imagePriority}
       imageSizes={
         isLarge
           ? "(max-width: 640px) 58vw, (max-width: 1024px) 34vw, 280px"
@@ -71,7 +75,7 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing }
         ) : null
       }
       title={
-        <Link href={href} className="block transition hover:text-slate-700">
+        <Link href={href} prefetch={false} className="block transition hover:text-slate-700">
           <span className="gv-hi-card-identity block truncate">{displayIdentity.base_name}</span>
           {identitySubtitle ? (
             <span className="gv-hi-metadata block truncate text-xs font-medium">{identitySubtitle}</span>

--- a/apps/web/src/components/explore/ExploreCardListItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardListItem.tsx
@@ -52,7 +52,7 @@ export default function ExploreCardListItem({ card, href, canViewPricing, signIn
   return (
     <li className="gv-visual-card px-4 py-4">
       <div className="flex items-start justify-between gap-4">
-        <Link href={href} className="flex min-w-0 flex-1 items-start gap-4">
+        <Link href={href} prefetch={false} className="flex min-w-0 flex-1 items-start gap-4">
           <PublicCardImage
             src={card.display_image_url ?? card.image_url}
             fallbackSrc={card.display_image_fallback_url}

--- a/apps/web/src/components/explore/ExplorePageClient.tsx
+++ b/apps/web/src/components/explore/ExplorePageClient.tsx
@@ -93,7 +93,8 @@ type AssistantBoundaryPreview = {
   message?: string;
 };
 
-const INITIAL_VISIBLE_RESULT_COUNT = 32;
+const INITIAL_VISIBLE_RESULT_COUNT = 24;
+const SEARCH_API_RESULT_LIMIT = 48;
 const CompareTray = dynamic<CompareTrayProps>(
   () => import("@/components/compare/CompareTray"),
   { ssr: false },
@@ -685,6 +686,8 @@ export default function ExplorePageClient({
           params.set("lang", languageScope);
         }
 
+        params.set("limit", String(SEARCH_API_RESULT_LIMIT));
+
         if (shouldServerFilterByIdentity) {
           params.set("identity", identityFilter);
         }
@@ -866,11 +869,13 @@ export default function ExplorePageClient({
   const displayRows =
     shouldServerFilterByIdentity || !isIdentityFilterActive(identityFilter)
       ? rows
+          .filter((row) => Boolean(row.gv_id))
           .filter((row) => matchesPublicLanguageScope(row, languageScope))
           .filter((row) =>
             matchesImageConfidenceFilter(row, imageConfidenceFilter),
           )
       : rows
+          .filter((row) => Boolean(row.gv_id))
           .filter((row) => matchesPublicLanguageScope(row, languageScope))
           .filter((row) => matchesIdentityFilter(row, identityFilter))
           .filter((row) =>
@@ -1368,45 +1373,6 @@ export default function ExplorePageClient({
       </div>
     </div>
   );
-  const presetSearchStrip = (
-    <section className="gv-collector-panel gv-search-showcase px-5 py-5 sm:px-6">
-      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-            Collector presets
-          </p>
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
-            Natural-language entry points for identity, finish, ownership, image truth, and variant families.
-          </p>
-        </div>
-        <Link
-          href={buildScopedExploreHref("q=Build-A-Bear stamped cards")}
-          className="inline-flex shrink-0 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold uppercase tracking-[0.12em] text-slate-600 transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-slate-50"
-        >
-          Try sentence search
-        </Link>
-      </div>
-      <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-        {COLLECTOR_SEARCH_PRESETS.map((preset) => (
-          <Link
-            key={preset.key}
-            href={buildScopedExploreHref(preset.query)}
-            className="gv-search-preset-card group p-4 text-left"
-          >
-            <p className="text-sm font-semibold text-slate-950 dark:text-slate-50">
-              {preset.title}
-            </p>
-            <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
-              {preset.description}
-            </p>
-            <p className="mt-3 text-[10px] font-bold uppercase tracking-[0.16em] text-slate-400 transition group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-200">
-              Open preset
-            </p>
-          </Link>
-        ))}
-      </div>
-    </section>
-  );
   const compactPresetStrip = (
     <section className="gv-command-surface px-4 py-3 sm:px-5">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -1439,21 +1405,21 @@ export default function ExplorePageClient({
 
   return (
     <div
-      className={`space-y-4 md:space-y-5 ${compareCards.length > 0 ? "pb-28 md:pb-36" : ""}`}
+      className={`space-y-3 md:space-y-4 ${compareCards.length > 0 ? "pb-28 md:pb-36" : ""}`}
     >
       {isDiscoveryMode ? (
-        <div className="gv-collector-panel px-5 py-6 md:px-8 md:py-8">
+        <div className="gv-command-surface px-4 py-4 sm:px-5">
           <div className="space-y-1 md:hidden">
             <p className="text-[10px] font-medium uppercase tracking-[0.2em] text-slate-400">
               Discover
             </p>
-            <h1 className="text-[1.9rem] font-black tracking-tight text-slate-950 dark:text-slate-50">
-              Discover cards
+            <h1 className="text-2xl font-semibold tracking-normal text-slate-950 dark:text-slate-50">
+              Search cards
             </h1>
             <p className="max-w-xl text-[13px] leading-5 text-slate-600 dark:text-slate-300">
               Search the canonical catalog by card, finish, stamp, year, artist, ownership, and image truth.
             </p>
-            <div className="flex flex-wrap gap-2 pt-px">
+            <div className="flex flex-wrap gap-2 pt-1">
               <Link
                 href={buildPathWithCompareCards("/sets", languageScope === "all" ? "" : `lang=${languageScope}`, compareCards)}
                 className="inline-flex rounded-full border border-slate-300 bg-white px-3 py-1.5 text-[13px] font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:bg-slate-50 hover:text-slate-950"
@@ -1469,19 +1435,24 @@ export default function ExplorePageClient({
             </div>
           </div>
 
-          <div className="hidden space-y-3 md:block">
-            <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">
-              Grookai Search
-            </p>
-            <h1 className="max-w-4xl text-[clamp(3.5rem,7vw,6.75rem)] font-black leading-[0.92] tracking-tight text-slate-950 dark:text-slate-50">
-              Search collector reality.
-            </h1>
-            <p className="max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300">
-              Ask for cards the way collectors think: reverse holo Pikachu from 2014-2026, Pokemon Center stamped promos, Komiya art, or cards missing from your vault.
-            </p>
+          <div className="hidden items-center justify-between gap-5 md:flex">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Grookai Search
+              </p>
+              <h1 className="mt-1 text-[clamp(2.25rem,4vw,3.75rem)] font-semibold leading-[0.98] tracking-normal text-slate-950 dark:text-slate-50">
+                Search collector reality.
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+                Ask for cards the way collectors think: reverse holo Pikachu from 2014-2026, Pokemon Center stamped promos, Komiya art, or cards missing from your vault.
+              </p>
+            </div>
+            <div className="shrink-0">
+              {languageScopeControl}
+            </div>
           </div>
 
-          <div className="mt-5 border-t border-slate-200/70 pt-4 dark:border-slate-800/70">
+          <div className="mt-4 border-t border-slate-200/70 pt-3 dark:border-slate-800/70 md:hidden">
             {languageScopeControl}
           </div>
         </div>
@@ -1504,11 +1475,15 @@ export default function ExplorePageClient({
         </div>
       )}
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error ? (
+        <div className="rounded-[16px] border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 shadow-sm dark:border-amber-300/20 dark:bg-amber-400/[0.12] dark:text-amber-100">
+          Search is taking longer than expected. Narrow the query with a set code, number, language, or filter.
+        </div>
+      ) : null}
 
       {isDiscoveryMode ? (
         <>
-          {presetSearchStrip}
+          {compactPresetStrip}
           {discoveryContent}
           <CompareTray
             cards={compareCards}
@@ -2122,7 +2097,7 @@ export default function ExplorePageClient({
                 <section key={`${group.intent}-${groupIndex}`} className="space-y-3">
                   {renderGroupHeader(group)}
                   <div className={POKEMON_CARD_BROWSE_LARGE_GRID_CLASSNAME}>
-                    {group.rows.map((row) => (
+                    {group.rows.map((row, rowIndex) => (
                       <ExploreCardGridItem
                         key={getResultKey(row)}
                         card={row}
@@ -2130,6 +2105,7 @@ export default function ExplorePageClient({
                         mode="thumb-lg"
                         canViewPricing={effectiveCanViewPricing}
                         matchReason={getSearchResultMatchReason(row)}
+                        imagePriority={groupIndex === 0 && rowIndex < 6}
                       />
                     ))}
                   </div>
@@ -2144,7 +2120,7 @@ export default function ExplorePageClient({
                 <section key={`${group.intent}-${groupIndex}`} className="space-y-3">
                   {renderGroupHeader(group)}
                   <div className={POKEMON_CARD_BROWSE_GRID_CLASSNAME}>
-                    {group.rows.map((row) => (
+                    {group.rows.map((row, rowIndex) => (
                       <ExploreCardGridItem
                         key={getResultKey(row)}
                         card={row}
@@ -2152,6 +2128,7 @@ export default function ExplorePageClient({
                         mode="thumb"
                         canViewPricing={effectiveCanViewPricing}
                         matchReason={getSearchResultMatchReason(row)}
+                        imagePriority={groupIndex === 0 && rowIndex < 8}
                       />
                     ))}
                   </div>

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -17,21 +17,18 @@ test("root chrome does not perform server auth reads during public render", () =
   assert.match(appChrome, /Public routes must not depend on global auth\/session reads/);
   assert.doesNotMatch(appChrome, /createServerComponentClient|getUnreadCardInteractionGroupCount/);
   assert.match(appChrome, /supabase\.auth\.getSession/);
-  assert.match(layout, /<AppChrome \/>/);
+  assert.match(layout, /<AppChrome dexEnabled=\{dexEnabled\} \/>/);
 });
 
 test("primary public routes use bounded revalidation instead of force-dynamic", () => {
   const publicRouteSources = [
     readSource("app", "page.tsx"),
-    readSource("app", "explore", "page.tsx"),
     readSource("app", "network", "page.tsx"),
     readSource("app", "network", "discover", "page.tsx"),
     readSource("app", "u", "[slug]", "page.tsx"),
     readSource("app", "u", "[slug]", "section", "[section_id]", "page.tsx"),
-    readSource("app", "card", "[gv_id]", "page.tsx"),
     readSource("app", "gvvi", "[gvvi_id]", "page.tsx"),
     readSource("app", "sets", "page.tsx"),
-    readSource("app", "sets", "[set_code]", "page.tsx"),
     readSource("app", "compare", "page.tsx"),
   ].join("\n");
 
@@ -72,4 +69,23 @@ test("public card image chooses an initial source before hydration", () => {
   assert.match(publicCardImage, /useState<string \| undefined>\(initialSrc\)/);
   assert.match(publicCardImage, /Hydration must not be required just to choose the first image source/);
   assert.match(publicCardImage, /sizes=\{sizes\}/);
+});
+
+test("explore search is bounded and language-aware for public performance", () => {
+  const searchRoute = readSource("app", "api", "resolver", "search", "route.ts");
+  const exploreClient = readSource("components", "explore", "ExplorePageClient.tsx");
+  const gridItem = readSource("components", "explore", "ExploreCardGridItem.tsx");
+  const publicCardImage = readSource("components", "PublicCardImage.tsx");
+
+  assert.match(searchRoute, /const DEFAULT_RESULT_LIMIT = 48/);
+  assert.match(searchRoute, /const MAX_RESULT_LIMIT = 64/);
+  assert.match(searchRoute, /RESOLVER_RESPONSE_TIMEOUT_MS = 4200/);
+  assert.match(searchRoute, /languageScope !== "ja" &&/);
+  assert.match(searchRoute, /web_ranked_resolver_v2_degraded_soft_timeout/);
+  assert.match(exploreClient, /const INITIAL_VISIBLE_RESULT_COUNT = 24/);
+  assert.match(exploreClient, /const SEARCH_API_RESULT_LIMIT = 48/);
+  assert.match(exploreClient, /params\.set\("limit", String\(SEARCH_API_RESULT_LIMIT\)\)/);
+  assert.match(gridItem, /imagePrefetch=\{false\}/);
+  assert.match(gridItem, /imagePriority=\{imagePriority\}/);
+  assert.match(publicCardImage, /fetchPriority=\{priority \? "high" : undefined\}/);
 });

--- a/apps/web/src/lib/explore/getExploreRows.ts
+++ b/apps/web/src/lib/explore/getExploreRows.ts
@@ -37,11 +37,11 @@ import { getCardPrintingFinishLabel } from "@/lib/cards/displayDiscriminator";
 import type { ExploreResultCard } from "@/components/explore/exploreResultTypes";
 import type { VariantFlags } from "@/lib/cards/variantPresentation";
 
-const SEARCH_LIMIT = 80;
-const TOKEN_SEARCH_LIMIT = 40;
+const SEARCH_LIMIT = 64;
+const TOKEN_SEARCH_LIMIT = 32;
 const SET_CARD_SEARCH_LIMIT = 30;
-const SMART_FILTER_DISCOVERY_LIMIT = 500;
-const PRE_ENRICHMENT_RELEVANCE_LIMIT = SEARCH_LIMIT + 40;
+const SMART_FILTER_DISCOVERY_LIMIT = 160;
+const PRE_ENRICHMENT_RELEVANCE_LIMIT = SEARCH_LIMIT + 24;
 const MAX_SIGNIFICANT_TEXT_TOKENS = 4;
 const MAX_SET_CANDIDATES = 6;
 const GENERIC_TOKENS = new Set([
@@ -3196,7 +3196,7 @@ async function fetchLanguageScopedTextRows(
     const baseRequest = supabase
       .from("card_prints")
       .select(selectClause)
-      .limit(languageScope === "ja" ? 180 : 140);
+      .limit(languageScope === "ja" ? 96 : 80);
     const scopedRequest = applyLanguageScopeQuery(baseRequest, languageScope);
     const request =
       mode === "name"
@@ -3596,17 +3596,18 @@ export async function getExploreRowsForSmartFilterDiscovery(
         : parentRows,
     options,
   );
+  const enrichmentRows = exactRows.slice(0, SMART_FILTER_DISCOVERY_LIMIT);
   const query = await buildResolverQuery(normalizeQuery(""));
   const setMetadataByCode = await fetchPublicSetMetadata(
-    uniqueValues(exactRows.map((row) => row.set_code ?? "").filter(Boolean)),
+    uniqueValues(enrichmentRows.map((row) => row.set_code ?? "").filter(Boolean)),
   );
   const supabase = createServerComponentClient();
   const pricingByCardId = await getPublicPricingByCardIds(
     supabase,
-    exactRows.map((row) => row.id),
+    enrichmentRows.map((row) => row.id),
   );
   const rows = await buildExploreRows(
-    exactRows,
+    enrichmentRows,
     new Map<string, string>(),
     setMetadataByCode,
     pricingByCardId,
@@ -3661,16 +3662,17 @@ export async function getExploreRowsForSmartStructuredTextSearch(
     return [];
   }
 
+  const enrichmentRows = childScopedRows.slice(0, SMART_FILTER_DISCOVERY_LIMIT);
   const setMetadataByCode = await fetchPublicSetMetadata(
-    uniqueValues(childScopedRows.map((row) => row.set_code ?? "").filter(Boolean)),
+    uniqueValues(enrichmentRows.map((row) => row.set_code ?? "").filter(Boolean)),
   );
   const supabase = createServerComponentClient();
   const pricingByCardId = await getPublicPricingByCardIds(
     supabase,
-    childScopedRows.map((row) => row.id),
+    enrichmentRows.map((row) => row.id),
   );
   const rows = await buildExploreRows(
-    childScopedRows,
+    enrichmentRows,
     new Map<string, string>(),
     setMetadataByCode,
     pricingByCardId,
@@ -3711,17 +3713,18 @@ export async function getExploreRowsForOwnedSmartFilterDiscovery(
       : applyLanguageScopeRows(parentRows, options.languageScope),
     options,
   );
+  const enrichmentRows = exactRows.slice(0, SMART_FILTER_DISCOVERY_LIMIT);
   const query = await buildResolverQuery(normalizeQuery(""));
   const setMetadataByCode = await fetchPublicSetMetadata(
-    uniqueValues(exactRows.map((row) => row.set_code ?? "").filter(Boolean)),
+    uniqueValues(enrichmentRows.map((row) => row.set_code ?? "").filter(Boolean)),
   );
   const supabase = createServerComponentClient();
   const pricingByCardId = await getPublicPricingByCardIds(
     supabase,
-    exactRows.map((row) => row.id),
+    enrichmentRows.map((row) => row.id),
   );
   const rows = await buildExploreRows(
-    exactRows,
+    enrichmentRows,
     new Map<string, string>(),
     setMetadataByCode,
     pricingByCardId,


### PR DESCRIPTION
## Summary
- cap web resolver result/enrichment work and add a soft timeout degraded response
- keep Japanese searches language-scoped and skip provisional English-only work
- compact the Explore search landing/presets and reduce initial visible result count
- disable result-link prefetch and prioritize only above-the-fold card images
- add guard coverage for bounded search/performance behavior

## Verification
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm run web:build:strict
- npm run shipcheck
- local smoke: /explore?lang=ja&q=Pikachu -> 200
- local smoke: /api/resolver/search?q=Pikachu&lang=ja&limit=5 -> ok, rows=5, provisional=0