### PR TITLE
Show English primary names for Japanese Pikachu cards

### DIFF
--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -670,6 +670,11 @@ export default async function CardPage({
                   <h1 className="gv-hi-card-identity max-w-3xl text-[3rem] leading-[0.96] tracking-normal sm:text-[4.2rem] lg:text-[5.35rem]">
                     {resolvedDisplayIdentity.base_name}
                   </h1>
+                  {resolvedDisplayIdentity.printed_name ? (
+                    <p className="gv-hi-metadata text-sm font-medium sm:text-base">
+                      Japanese printed name: {resolvedDisplayIdentity.printed_name}
+                    </p>
+                  ) : null}
                   <div className="flex flex-wrap items-center gap-2">
                     {identitySubtitle ? (
                       <p className="gv-hi-metadata text-sm font-medium sm:text-base">{identitySubtitle}</p>

--- a/apps/web/src/components/PublicSetCardGrid.tsx
+++ b/apps/web/src/components/PublicSetCardGrid.tsx
@@ -173,6 +173,9 @@ export default function PublicSetCardGrid({
                   className="block transition hover:text-slate-700"
                 >
                   <span className="block truncate">{displayIdentity.base_name}</span>
+                  {displayIdentity.printed_name ? (
+                    <span className="gv-hi-metadata block truncate text-xs font-medium">{displayIdentity.printed_name}</span>
+                  ) : null}
                   {identitySubtitle ? (
                     <span className="gv-hi-metadata block truncate text-xs font-medium">{identitySubtitle}</span>
                   ) : null}

--- a/apps/web/src/components/explore/ExploreCardDetailsRow.tsx
+++ b/apps/web/src/components/explore/ExploreCardDetailsRow.tsx
@@ -63,6 +63,9 @@ export default function ExploreCardDetailsRow({ card, href, canViewPricing, sign
           <div className="min-w-0">
             <Link href={href} prefetch={false} className="block text-sm font-semibold text-slate-900 hover:underline dark:text-slate-100">
               <span className="gv-hi-card-identity block truncate">{displayIdentity.base_name}</span>
+              {displayIdentity.printed_name ? (
+                <span className="gv-hi-metadata block truncate text-xs font-medium">{displayIdentity.printed_name}</span>
+              ) : null}
               {identitySubtitle ? (
                 <span className="gv-hi-metadata block truncate text-xs font-medium">{identitySubtitle}</span>
               ) : null}

--- a/apps/web/src/components/explore/ExploreCardGridItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardGridItem.tsx
@@ -77,6 +77,9 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
       title={
         <Link href={href} prefetch={false} className="block transition hover:text-slate-700">
           <span className="gv-hi-card-identity block truncate">{displayIdentity.base_name}</span>
+          {displayIdentity.printed_name ? (
+            <span className="gv-hi-metadata block truncate text-xs font-medium">{displayIdentity.printed_name}</span>
+          ) : null}
           {identitySubtitle ? (
             <span className="gv-hi-metadata block truncate text-xs font-medium">{identitySubtitle}</span>
           ) : null}

--- a/apps/web/src/components/explore/ExploreCardListItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardListItem.tsx
@@ -67,6 +67,9 @@ export default function ExploreCardListItem({ card, href, canViewPricing, signIn
                 <span className="gv-hi-card-identity block truncate text-lg hover:underline">
                   {displayIdentity.base_name}
                 </span>
+                {displayIdentity.printed_name ? (
+                  <span className="gv-hi-metadata block truncate text-sm font-medium">{displayIdentity.printed_name}</span>
+                ) : null}
                 {identitySubtitle ? (
                   <span className="gv-hi-metadata block truncate text-sm font-medium">{identitySubtitle}</span>
                 ) : null}

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -95,3 +95,19 @@ test("explore search is bounded and language-aware for public performance", () =
   assert.match(gridItem, /imagePriority=\{imagePriority\}/);
   assert.match(publicCardImage, /fetchPriority=\{priority \? "high" : undefined\}/);
 });
+
+test("japanese pikachu display keeps english primary and printed name secondary", () => {
+  const displayIdentity = readSource("lib", "cards", "resolveDisplayIdentity.ts");
+  const exploreGridItem = readSource("components", "explore", "ExploreCardGridItem.tsx");
+  const exploreListItem = readSource("components", "explore", "ExploreCardListItem.tsx");
+  const setGrid = readSource("components", "PublicSetCardGrid.tsx");
+  const cardPage = readSource("app", "card", "[gv_id]", "page.tsx");
+
+  assert.match(displayIdentity, /prefix: "ピカチュウ", englishName: "Pikachu"/);
+  assert.match(displayIdentity, /return suffix \? `\$\{rule\.englishName\} \$\{suffix\}` : rule\.englishName/);
+  assert.match(displayIdentity, /printed_name/);
+  assert.match(exploreGridItem, /displayIdentity\.printed_name/);
+  assert.match(exploreListItem, /displayIdentity\.printed_name/);
+  assert.match(setGrid, /displayIdentity\.printed_name/);
+  assert.match(cardPage, /Japanese printed name: \{resolvedDisplayIdentity\.printed_name\}/);
+});

--- a/apps/web/src/lib/cards/resolveDisplayIdentity.ts
+++ b/apps/web/src/lib/cards/resolveDisplayIdentity.ts
@@ -16,6 +16,7 @@ export type CardPrint = {
 export type ResolvedDisplayIdentity = {
   display_name: string;
   base_name: string;
+  printed_name: string | null;
   suffix: string | null;
 };
 
@@ -50,6 +51,41 @@ function isLetterOrSymbolIdentity(value?: string | null) {
   return /^[\p{L}\p{N}★☆]$/u.test(normalized);
 }
 
+function normalizeJapanesePikachuSuffix(value: string) {
+  const suffix = value.trim().replace(/\s+/g, "");
+  if (!suffix) {
+    return "";
+  }
+
+  if (suffix === "（デルタ種）") {
+    return "Delta Species";
+  }
+
+  return /^[a-z0-9][a-z0-9.+-]*$/i.test(suffix) ? suffix : "";
+}
+
+function resolveEnglishPrimaryNameForJapanesePrintedName(value: string) {
+  const normalized = value.trim();
+  const rules: Array<{ prefix: string; englishName: string }> = [
+    { prefix: "そらをとぶピカチュウ", englishName: "Flying Pikachu" },
+    { prefix: "なみのりピカチュウ", englishName: "Surfing Pikachu" },
+    { prefix: "ピカチュウ", englishName: "Pikachu" },
+  ];
+
+  for (const rule of rules) {
+    if (!normalized.startsWith(rule.prefix)) {
+      continue;
+    }
+
+    const suffix = normalizeJapanesePikachuSuffix(
+      normalized.slice(rule.prefix.length),
+    );
+    return suffix ? `${rule.englishName} ${suffix}` : rule.englishName;
+  }
+
+  return null;
+}
+
 export function formatVariantKey(value?: string | null) {
   return getVariantDisplayLabel(value);
 }
@@ -59,7 +95,14 @@ export function formatPrintedIdentityModifier(value?: string | null) {
 }
 
 export function resolveDisplayIdentity(card: Partial<CardPrint> & { name?: string | null }): ResolvedDisplayIdentity {
-  const base_name = (card.name ?? "").trim() || "Unknown card";
+  const rawBaseName = (card.name ?? "").trim() || "Unknown card";
+  const englishPrimaryName =
+    resolveEnglishPrimaryNameForJapanesePrintedName(rawBaseName);
+  const base_name = englishPrimaryName ?? rawBaseName;
+  const printed_name =
+    englishPrimaryName && englishPrimaryName !== rawBaseName
+      ? rawBaseName
+      : null;
 
   let suffix = formatVariantKey(card.variant_key);
 
@@ -74,6 +117,7 @@ export function resolveDisplayIdentity(card: Partial<CardPrint> & { name?: strin
   return {
     display_name: suffix ? `${base_name} · ${suffix}` : base_name,
     base_name,
+    printed_name,
     suffix,
   };
 }


### PR DESCRIPTION
## Summary
- resolve vetted Japanese Pikachu printed names to English primary labels such as `Pikachu ex`
- keep the original Japanese printed name as a smaller secondary line
- update Explore result views, set grids, and card detail hero to show the secondary printed name
- add guard coverage for the display contract

## Verification
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm run web:build:strict
- repo pre-commit shipcheck
- repo pre-push shipcheck
- local card smoke: /card/GV-PK-JPN-MC-764 shows `Pikachu ex` and `Japanese printed name: ピカチュウex`