### PR TITLE
Compact Explore search results layout

### DIFF
--- a/apps/web/src/components/cards/PokemonCardGridTile.tsx
+++ b/apps/web/src/components/cards/PokemonCardGridTile.tsx
@@ -35,19 +35,19 @@ type PokemonCardGridBadgeProps = {
 };
 
 const TILE_PADDING_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "p-3",
+  compact: "p-2.5",
   default: "p-4",
   large: "p-5",
 };
 
 const IMAGE_PADDING_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "p-3",
+  compact: "p-2",
   default: "p-4",
   large: "p-5",
 };
 
 const CONTENT_STACK_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "space-y-2.5",
+  compact: "space-y-2",
   default: "space-y-3",
   large: "space-y-3.5",
 };
@@ -59,13 +59,13 @@ const BODY_STACK_BY_DENSITY: Record<ViewDensity, string> = {
 };
 
 const TITLE_TEXT_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "text-sm",
+  compact: "text-[13px]",
   default: "text-[15px]",
   large: "text-base",
 };
 
 const SUBTITLE_TEXT_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "text-xs",
+  compact: "text-[11px]",
   default: "text-sm",
   large: "text-sm",
 };
@@ -116,8 +116,8 @@ function renderImage({
         loading={imageLoading}
         priority={imagePriority}
         sizes={imageSizes}
-        imageClassName={`aspect-[3/4] w-full rounded-[20px] object-contain transition duration-200 group-hover:scale-[1.018] ${imageClassName ?? ""}`.trim()}
-        fallbackClassName="flex aspect-[3/4] w-full items-center justify-center rounded-[20px] bg-white/42 px-4 text-center text-sm font-medium text-slate-400 ring-1 ring-inset ring-slate-200/40 dark:bg-white/[0.04] dark:text-slate-600 dark:ring-white/[0.05]"
+        imageClassName={`aspect-[3/4] w-full rounded-[14px] object-contain transition duration-200 group-hover:scale-[1.012] ${imageClassName ?? ""}`.trim()}
+        fallbackClassName="flex aspect-[3/4] w-full items-center justify-center rounded-[14px] bg-white/42 px-4 text-center text-sm font-medium text-slate-400 ring-1 ring-inset ring-slate-200/40 dark:bg-white/[0.04] dark:text-slate-600 dark:ring-white/[0.05]"
         fallbackLabel={imageFallbackLabel ?? imageAlt}
       />
       {imageOverlay ? (

--- a/apps/web/src/components/cards/pokemonCardGridLayout.ts
+++ b/apps/web/src/components/cards/pokemonCardGridLayout.ts
@@ -1,10 +1,10 @@
 import type { ViewDensity } from "@/hooks/useViewDensity";
 
 export const POKEMON_CARD_BROWSE_GRID_CLASSNAME =
-  "grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
+  "grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5";
 
 export const POKEMON_CARD_BROWSE_LARGE_GRID_CLASSNAME =
-  "grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3";
+  "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3";
 
 export const POKEMON_CARD_DISCOVERY_GRID_CLASSNAME =
   "grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4";

--- a/apps/web/src/components/explore/ExploreCardGridItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardGridItem.tsx
@@ -4,7 +4,6 @@ import CompareCardButton from "@/components/compare/CompareCardButton";
 import PokemonCardGridTile from "@/components/cards/PokemonCardGridTile";
 import PromotionTransitionNote from "@/components/provisional/PromotionTransitionNote";
 import VariantBadge from "@/components/cards/VariantBadge";
-import LockedPrice from "@/components/pricing/LockedPrice";
 import VisiblePrice from "@/components/pricing/VisiblePrice";
 import { getCardImageAltText, resolveCardImagePresentation } from "@/lib/cards/resolveCardImagePresentation";
 import {
@@ -41,7 +40,7 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
   const searchDiscriminator = getSearchContextLabel(card);
   const imagePresentation = resolveCardImagePresentation(card);
   const isLarge = mode === "thumb-lg";
-  const density = isLarge ? "large" : "default";
+  const density = isLarge ? "large" : "compact";
   const primaryFinishLabel = getPrimaryFinishLabel(card);
   const secondaryVariantLabels = getSecondaryBadgeLabels(variantLabels, [
     primaryFinishLabel,
@@ -63,7 +62,7 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
       imageSizes={
         isLarge
           ? "(max-width: 640px) 58vw, (max-width: 1024px) 34vw, 280px"
-          : "(max-width: 640px) 44vw, (max-width: 1024px) 24vw, 190px"
+          : "(max-width: 640px) 42vw, (max-width: 1024px) 28vw, (max-width: 1536px) 20vw, 180px"
       }
       imageOverlay={
         imagePresentation.compactBadgeLabel ? (
@@ -109,8 +108,12 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
         </>
       }
       meta={<span>{metaLine}</span>}
-      summary={canViewPricing ? <VisiblePrice value={card.raw_price} size="grid" className="gv-hi-price" /> : <LockedPrice size="grid" className="gv-hi-price" />}
-      imageClassName={isLarge ? "max-w-[280px]" : undefined}
+      summary={
+        canViewPricing && typeof card.raw_price === "number" ? (
+          <VisiblePrice value={card.raw_price} size="grid" className="gv-hi-price" />
+        ) : null
+      }
+      imageClassName={isLarge ? "max-w-[280px]" : "mx-auto max-w-[180px]"}
     />
   );
 }

--- a/apps/web/src/components/explore/ExplorePageClient.tsx
+++ b/apps/web/src/components/explore/ExplorePageClient.tsx
@@ -281,46 +281,6 @@ function getDiscoveryTitle(payload: {
   return residual || collectorLabels[0] || payload.fallback;
 }
 
-function getCollectorObjectNoun(familyCopy: VariantOriginFamilyCopy | null) {
-  if (!familyCopy) {
-    return "collector results";
-  }
-
-  if (familyCopy.variant_category.includes("stamp")) {
-    return "stamped identities";
-  }
-
-  if (familyCopy.variant_category.includes("error")) {
-    return "recognized variants";
-  }
-
-  if (familyCopy.variant_category.includes("subset")) {
-    return "subset identities";
-  }
-
-  return "collector identities";
-}
-
-function getSingularCollectorObjectNoun(familyCopy: VariantOriginFamilyCopy | null) {
-  if (!familyCopy) {
-    return "collector result";
-  }
-
-  if (familyCopy.variant_category.includes("stamp")) {
-    return "stamped identity";
-  }
-
-  if (familyCopy.variant_category.includes("error")) {
-    return "recognized variant";
-  }
-
-  if (familyCopy.variant_category.includes("subset")) {
-    return "subset identity";
-  }
-
-  return "collector identity";
-}
-
 function isCameoLabel(value?: string | null) {
   const normalized = value?.trim().toLowerCase() ?? "";
   return (
@@ -1197,20 +1157,6 @@ export default function ExplorePageClient({
     smartSearchIntent,
     fallback: "Collector discovery",
   });
-  const discoveryNoun = getCollectorObjectNoun(variantFamilyCopy);
-  const discoveryCountLabel =
-    displayRows.length === 1
-      ? `1 ${getSingularCollectorObjectNoun(variantFamilyCopy)}`
-      : `${displayRows.length} ${discoveryNoun}`;
-  const discoveryEyebrow = variantFamilyCopy
-    ? "Family identified"
-    : interpretedLabels.length > 0
-      ? "Search understood"
-      : "Collector discovery";
-  const discoveryDescription = variantFamilyCopy?.why_it_exists
-    ?? (normalizedQuery
-      ? "Grookai is using deterministic card identity, finish, set, ownership, image, and variant signals to narrow the catalog."
-      : "Search the catalog by collector language, variants, finishes, stamps, artists, ownership, and years.");
   const emptyStateTitle = ownershipRequiresSignIn
     ? "Sign in to search your vault"
     : ownershipState === "owned" && viewer.isAuthenticated
@@ -1402,6 +1348,150 @@ export default function ExplorePageClient({
       </div>
     </section>
   );
+  const resultControls = (
+    <div className="flex flex-wrap items-center gap-2">
+      <label className="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+        <span className="hidden sm:inline">Sort</span>
+        <select
+          value={sortMode}
+          onChange={(event) =>
+            commitSortMode(event.target.value as SortMode)
+          }
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-slate-500 dark:focus:ring-slate-700"
+        >
+          <option value="relevance">Relevance</option>
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+          <option value="set_order">Set order</option>
+          <option value="number">Collector number</option>
+          <option value="value_high">Value high to low</option>
+          <option value="value_low">Value low to high</option>
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+        <span className="hidden sm:inline">Image</span>
+        <select
+          value={imageConfidenceFilter}
+          onChange={(event) =>
+            commitImageConfidenceFilter(
+              event.target.value as ImageConfidenceFilter,
+            )
+          }
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-slate-500 dark:focus:ring-slate-700"
+          aria-label="Image confidence filter"
+        >
+          <option value="all">All images</option>
+          <option value="exact">Exact images</option>
+          <option value="representative">Representative</option>
+          <option value="missing_variant_visual">Variant pending</option>
+        </select>
+      </label>
+      <ExploreViewModeToggle
+        value={viewMode}
+        onChange={commitViewMode}
+      />
+    </div>
+  );
+  const activeFilterStrip = activeFilterChips.length > 0 ? (
+    <div className="flex flex-wrap items-center gap-2 border-t border-slate-200/70 pt-3 dark:border-slate-800/70">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+        Filters
+      </span>
+      {activeFilterChips.map((chip) => (
+        <Link
+          key={chip.key}
+          href={chip.href}
+          className="group inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300 dark:hover:text-slate-50"
+          aria-label={`Remove ${chip.label} filter`}
+        >
+          <span className="text-[9px] font-bold uppercase tracking-[0.12em] text-slate-400 dark:text-slate-500">
+            {chip.label}
+          </span>
+          <span className="truncate font-semibold">{chip.value}</span>
+          <span
+            aria-hidden="true"
+            className="rounded-full bg-slate-100 px-1.5 text-[10px] font-bold text-slate-500 transition group-hover:bg-slate-950 group-hover:text-white dark:bg-slate-800 dark:text-slate-300 dark:group-hover:bg-slate-100 dark:group-hover:text-slate-950"
+          >
+            x
+          </span>
+        </Link>
+      ))}
+      {activeFilterChips.length > 1 ? (
+        <Link
+          href={buildSmartSearchRefinementHref((params) => {
+            params.delete("q");
+            params.delete("set");
+            params.delete("year");
+            params.delete("year_min");
+            params.delete("year_max");
+            params.delete("finish");
+            params.delete("stamp");
+            params.delete("owned");
+            params.delete("image_state");
+            params.delete("image");
+            params.delete("illustrator");
+            params.delete("identity");
+          })}
+          className="inline-flex rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-slate-500 transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-slate-50"
+        >
+          Clear all
+        </Link>
+      ) : null}
+    </div>
+  ) : null;
+  const presetPillStrip = (
+    <div className="flex gap-2 overflow-x-auto border-t border-slate-200/70 pt-3 dark:border-slate-800/70">
+      <span className="inline-flex shrink-0 items-center text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+        Presets
+      </span>
+      <Link
+        href={buildScopedExploreHref("q=Build-A-Bear stamped cards")}
+        className="inline-flex shrink-0 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-slate-600 transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-slate-50"
+      >
+        Sentence search
+      </Link>
+      {COLLECTOR_SEARCH_PRESETS.map((preset) => (
+        <Link
+          key={preset.key}
+          href={buildScopedExploreHref(preset.query)}
+          className="inline-flex shrink-0 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300 dark:hover:text-slate-50"
+          title={preset.description}
+        >
+          {preset.title}
+        </Link>
+      ))}
+    </div>
+  );
+  const identityFilterStrip = visibleIdentityFilters.length > 1 ? (
+    <div className="flex flex-wrap gap-2 border-t border-slate-200/70 pt-3 dark:border-slate-800/70">
+      {visibleIdentityFilters.map((option) => {
+        const selected = identityFilter === option.key;
+        const count = identityFilterCounts[option.key];
+
+        return (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => commitIdentityFilter(option.key)}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold transition ${
+              selected
+                ? "border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-950"
+                : "border-slate-200 bg-slate-50 text-slate-700 hover:border-slate-300 hover:bg-white dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-600"
+            }`}
+          >
+            <span>{option.label}</span>
+            {count > 0 ? (
+              <span
+                className={`text-[10px] ${selected ? "text-white/80 dark:text-slate-950/70" : "text-slate-500"}`}
+              >
+                {count}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
 
   return (
     <div
@@ -1457,22 +1547,44 @@ export default function ExplorePageClient({
           </div>
         </div>
       ) : (
-        <div className="gv-command-surface px-4 py-3 sm:px-5">
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="min-w-0">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                Grookai Search
-              </p>
-              <h1 className="mt-1 truncate text-2xl font-semibold tracking-normal text-slate-950 dark:text-slate-50">
-                {normalizedQuery || discoveryTitle}
-              </h1>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                {resultCountLabel}
-              </p>
+        <section className="gv-command-surface px-4 py-3 sm:px-5">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                  Grookai Search
+                </p>
+                {loading && displayRows.length > 0 ? (
+                  <span className="rounded-full bg-slate-950 px-2 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-slate-950">
+                    Refreshing
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-1 flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+                <div className="min-w-0">
+                  <h1 className="truncate text-2xl font-semibold tracking-normal text-slate-950 dark:text-slate-50">
+                    {normalizedQuery || discoveryTitle}
+                  </h1>
+                  <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+                    {resultCountLabel}
+                    {variantFamilyCopy ? (
+                      <span className="ml-2 hidden text-slate-400 dark:text-slate-500 sm:inline">
+                        Source-backed family copy
+                      </span>
+                    ) : null}
+                  </p>
+                </div>
+                {resultControls}
+              </div>
             </div>
-            {languageScopeControl}
+            <div className="shrink-0">
+              {languageScopeControl}
+            </div>
           </div>
-        </div>
+          {activeFilterStrip}
+          {presetPillStrip}
+          {identityFilterStrip}
+        </section>
       )}
 
       {error ? (
@@ -1495,187 +1607,8 @@ export default function ExplorePageClient({
           />
         </>
       ) : (
-        <div className="gv-collector-search-results space-y-4">
-          <section className="gv-command-surface px-4 py-3 sm:px-5">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                    {discoveryEyebrow}
-                  </span>
-                  {variantFamilyCopy?.confidence ? (
-                    <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-                      {formatFilterValue(variantFamilyCopy.confidence)}
-                    </span>
-                  ) : null}
-                  {loading && displayRows.length > 0 ? (
-                    <span className="rounded-full bg-slate-950 px-2.5 py-1 text-[11px] font-semibold text-white dark:bg-white dark:text-slate-950">
-                      Refreshing
-                    </span>
-                  ) : null}
-                </div>
-                <h2 className="mt-1 truncate text-xl font-semibold tracking-normal text-slate-950 dark:text-slate-50">
-                  {discoveryTitle}
-                </h2>
-                <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  {variantFamilyCopy?.how_to_identify ?? discoveryDescription}
-                </p>
-              </div>
-              <div className="shrink-0 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/80 lg:text-right">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                  Results
-                </p>
-                <p className="mt-1 text-2xl font-semibold text-slate-950 dark:text-slate-50">
-                  {discoveryCountLabel}
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <div className="gv-command-surface flex flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-5">
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              {resultCountLabel}
-              {variantFamilyCopy ? (
-                <span className="ml-2 hidden text-slate-400 dark:text-slate-500 sm:inline">
-                  Source-backed family copy
-                </span>
-              ) : null}
-            </p>
-            <div className="flex flex-wrap items-center gap-3">
-              <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
-                <span>Sort</span>
-                <select
-                  value={sortMode}
-                  onChange={(event) =>
-                    commitSortMode(event.target.value as SortMode)
-                  }
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-slate-500 dark:focus:ring-slate-700"
-                >
-                  <option value="relevance">Relevance</option>
-                  <option value="newest">Newest first</option>
-                  <option value="oldest">Oldest first</option>
-                  <option value="set_order">Set order</option>
-                  <option value="number">Collector number</option>
-                  <option value="value_high">Value high to low</option>
-                  <option value="value_low">Value low to high</option>
-                </select>
-              </label>
-              <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
-                <span>Image</span>
-                <select
-                  value={imageConfidenceFilter}
-                  onChange={(event) =>
-                    commitImageConfidenceFilter(
-                      event.target.value as ImageConfidenceFilter,
-                    )
-                  }
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-slate-500 dark:focus:ring-slate-700"
-                  aria-label="Image confidence filter"
-                >
-                  <option value="all">All images</option>
-                  <option value="exact">Exact images</option>
-                  <option value="representative">Representative</option>
-                  <option value="missing_variant_visual">Variant pending</option>
-                </select>
-              </label>
-              <ExploreViewModeToggle
-                value={viewMode}
-                onChange={commitViewMode}
-              />
-            </div>
-          </div>
-
-          {activeFilterChips.length > 0 ? (
-            <div className="gv-command-surface px-4 py-3">
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                    Active filters
-                  </p>
-                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
-                    {activeFilterChips.length} active filter{activeFilterChips.length === 1 ? "" : "s"} narrowing {displayRows.length} result{displayRows.length === 1 ? "" : "s"}.
-                  </p>
-                </div>
-                {activeFilterChips.length > 1 ? (
-                  <Link
-                    href={buildSmartSearchRefinementHref((params) => {
-                      params.delete("q");
-                      params.delete("set");
-                      params.delete("year");
-                      params.delete("year_min");
-                      params.delete("year_max");
-                      params.delete("finish");
-                      params.delete("stamp");
-                      params.delete("owned");
-                      params.delete("image_state");
-                      params.delete("image");
-                      params.delete("illustrator");
-                      params.delete("identity");
-                    })}
-                    className="inline-flex shrink-0 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold uppercase tracking-[0.12em] text-slate-600 transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-slate-50"
-                  >
-                    Clear all
-                  </Link>
-                ) : null}
-              </div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {activeFilterChips.map((chip) => (
-                  <Link
-                    key={chip.key}
-                    href={chip.href}
-                    className="group inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-300 dark:hover:text-slate-50"
-                    aria-label={`Remove ${chip.label} filter`}
-                  >
-                    <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
-                      {chip.label}
-                    </span>
-                    <span className="truncate font-semibold">{chip.value}</span>
-                    <span
-                      aria-hidden="true"
-                      className="rounded-full bg-slate-100 px-1.5 text-xs font-bold text-slate-500 transition group-hover:bg-slate-950 group-hover:text-white dark:bg-slate-800 dark:text-slate-300 dark:group-hover:bg-slate-100 dark:group-hover:text-slate-950"
-                    >
-                      x
-                    </span>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {compactPresetStrip}
-
-          {visibleIdentityFilters.length > 1 ? (
-            <div className="gv-command-surface flex flex-wrap gap-2 px-4 py-3">
-              {visibleIdentityFilters.map((option) => {
-                const selected = identityFilter === option.key;
-                const count = identityFilterCounts[option.key];
-
-                return (
-                  <button
-                    key={option.key}
-                    type="button"
-                    onClick={() => commitIdentityFilter(option.key)}
-                    className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition ${
-                      selected
-                        ? "border-slate-900 bg-slate-900 text-white"
-                        : "border-slate-200 bg-slate-50 text-slate-700 hover:border-slate-300 hover:bg-white"
-                    }`}
-                  >
-                    <span>{option.label}</span>
-                    {count > 0 ? (
-                      <span
-                        className={`text-[11px] ${selected ? "text-white/80" : "text-slate-500"}`}
-                      >
-                        {count}
-                      </span>
-                    ) : null}
-                  </button>
-                );
-              })}
-            </div>
-          ) : null}
-
-          {resolverSummary ? (
+        <div className="gv-collector-search-results space-y-3">
+          {resolverSummary && displayRows.length === 0 ? (
             <div
               className={`rounded-[16px] border px-4 py-3 text-sm shadow-sm ${resolverSummary.tone}`}
             >
@@ -1834,8 +1767,9 @@ export default function ExplorePageClient({
             </div>
           ) : null}
 
+          {hasExplicitSmartFilters ? (
           <details
-            open={hasExplicitSmartFilters}
+            open
             className="gv-soft-surface group px-4 py-3"
           >
             <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
@@ -1988,6 +1922,7 @@ export default function ExplorePageClient({
               </div>
             </form>
           </details>
+          ) : null}
 
           {loading && displayRows.length === 0 ? (
             loadingState

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -96,6 +96,23 @@ test("explore search is bounded and language-aware for public performance", () =
   assert.match(publicCardImage, /fetchPriority=\{priority \? "high" : undefined\}/);
 });
 
+test("explore search keeps results compact and cards above supporting tools", () => {
+  const exploreClient = readSource("components", "explore", "ExplorePageClient.tsx");
+  const gridLayout = readSource("components", "cards", "pokemonCardGridLayout.ts");
+  const gridItem = readSource("components", "explore", "ExploreCardGridItem.tsx");
+  const gridTile = readSource("components", "cards", "PokemonCardGridTile.tsx");
+
+  assert.match(gridLayout, /grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5/);
+  assert.match(gridItem, /const density = isLarge \? "large" : "compact"/);
+  assert.match(gridItem, /typeof card\.raw_price === "number"/);
+  assert.match(gridItem, /max-w-\[180px\]/);
+  assert.match(gridTile, /compact: "p-2\.5"/);
+  assert.match(exploreClient, /const resultControls = \(/);
+  assert.match(exploreClient, /const presetPillStrip = \(/);
+  assert.match(exploreClient, /resolverSummary && displayRows\.length === 0/);
+  assert.match(exploreClient, /\{hasExplicitSmartFilters \? \(/);
+});
+
 test("japanese pikachu display keeps english primary and printed name secondary", () => {
   const displayIdentity = readSource("lib", "cards", "resolveDisplayIdentity.ts");
   const exploreGridItem = readSource("components", "explore", "ExploreCardGridItem.tsx");


### PR DESCRIPTION
## Summary
- collapse the Explore search results header into one compact control surface
- keep presets discoverable as horizontal pills while removing duplicate explanatory result panels above cards
- make default card search tiles denser with full-card thumbnail sizing and more desktop columns
- hide empty Grookai Value rows when no numeric price is available
- add a guard for the compact search layout contract

## Verification
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm run web:build:strict
- local route smoke: /explore?q=Pikachu returns 200, keeps presets, omits empty Grookai Value markup
- repo pre-commit shipcheck
- repo pre-push shipcheck