### PR TITLE
Polish compact search card grid

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1034,6 +1034,37 @@ html.gv-dark :where([class*="_#ffffff"], [class*="\\#ffffff"], [class*="_white"]
   transform: translateY(-1px);
 }
 
+.gv-search-result-card.gv-visual-card {
+  border-radius: 22px;
+}
+
+.gv-search-result-card .gv-visual-card-image {
+  border-radius: 17px;
+  background: linear-gradient(180deg, rgba(246, 248, 252, 0.32) 0%, rgba(238, 243, 249, 0.14) 100%);
+}
+
+.gv-search-result-card .gv-visual-card-utility {
+  right: 0.55rem;
+  top: 0.55rem;
+}
+
+.gv-card-compare-floating {
+  box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.72);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .gv-search-result-card .gv-card-compare-floating:not(.gv-card-compare-floating-selected) {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+
+  .gv-search-result-card:hover .gv-card-compare-floating,
+  .gv-search-result-card .gv-card-compare-floating:focus-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .gv-set-logo-wash {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.86) 38%, rgba(255, 255, 255, 0.82) 100%);
@@ -1274,6 +1305,10 @@ html.gv-dark .gv-visual-card-image {
   background:
     radial-gradient(circle at 50% 0%, rgba(51, 65, 85, 0.34), transparent 15rem),
     rgba(8, 12, 22, 0.46);
+}
+
+html.gv-dark .gv-search-result-card .gv-visual-card-image {
+  background: rgba(8, 12, 22, 0.28);
 }
 
 html.gv-dark .gv-visual-card {

--- a/apps/web/src/components/compare/CompareCardButton.tsx
+++ b/apps/web/src/components/compare/CompareCardButton.tsx
@@ -5,7 +5,7 @@ import { buildPathWithCompareCards, MAX_COMPARE_CARDS, normalizeCompareCardsPara
 
 type CompareCardButtonProps = {
   gvId: string;
-  variant?: "default" | "compact";
+  variant?: "default" | "compact" | "floating";
 };
 
 export default function CompareCardButton({ gvId, variant = "default" }: CompareCardButtonProps) {
@@ -31,7 +31,15 @@ export default function CompareCardButton({ gvId, variant = "default" }: Compare
     commitCards(toggleCompareCard(compareCards, gvId));
   }
 
-  const buttonClassName = variant === "compact"
+  const buttonClassName = variant === "floating"
+    ? `gv-card-compare-floating inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-700 transition-all duration-100 ${
+        isSelected
+          ? "gv-card-compare-floating-selected border border-slate-900 bg-slate-900 text-white"
+          : isAtLimit
+            ? "cursor-not-allowed border border-slate-200 bg-slate-100 text-slate-400"
+            : "border border-slate-300 bg-white/88 hover:border-slate-400 hover:bg-white"
+      }`
+    : variant === "compact"
     ? `inline-flex rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-100 ${
         isSelected
           ? "border border-slate-900 bg-slate-900 text-white"
@@ -52,10 +60,25 @@ export default function CompareCardButton({ gvId, variant = "default" }: Compare
       type="button"
       onClick={handleToggle}
       disabled={isAtLimit}
-      title={isAtLimit ? `Compare is full. Remove a card to stay within the ${MAX_COMPARE_CARDS}-card limit.` : undefined}
+      aria-label={isSelected ? "Remove from compare" : "Add to compare"}
+      title={isAtLimit ? `Compare is full. Remove a card to stay within the ${MAX_COMPARE_CARDS}-card limit.` : isSelected ? "Remove from compare" : "Add to compare"}
       className={buttonClassName}
     >
-      {isSelected ? "In Compare" : "Compare"}
+      {variant === "floating" ? (
+        <>
+          <svg
+            viewBox="0 0 16 16"
+            className="h-4 w-4 fill-none stroke-current"
+            aria-hidden="true"
+          >
+            <path d="M3 4.5h7.5M3 8h10M5.5 11.5H13" strokeWidth="1.35" strokeLinecap="round" />
+            <path d="M10.5 2.5 13 4.5l-2.5 2M5.5 9.5 3 11.5l2.5 2" strokeWidth="1.35" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span className="sr-only">{isSelected ? "In Compare" : "Compare"}</span>
+        </>
+      ) : (
+        isSelected ? "In Compare" : "Compare"
+      )}
     </button>
   );
 }

--- a/apps/web/src/components/explore/ExploreCardGridItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardGridItem.tsx
@@ -51,7 +51,7 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
   return (
     <PokemonCardGridTile
       density={density}
-      utility={<CompareCardButton gvId={card.gv_id} variant="compact" />}
+      utility={<CompareCardButton gvId={card.gv_id} variant="floating" />}
       imageSrc={card.display_image_url ?? card.image_url}
       imageFallbackSrc={card.display_image_fallback_url}
       imageAlt={getCardImageAltText(displayIdentity.display_name, card)}
@@ -113,7 +113,8 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
           <VisiblePrice value={card.raw_price} size="grid" className="gv-hi-price" />
         ) : null
       }
-      imageClassName={isLarge ? "max-w-[280px]" : "mx-auto max-w-[180px]"}
+      imageClassName={isLarge ? "max-w-[280px]" : "mx-auto max-w-[172px]"}
+      className="gv-search-result-card"
     />
   );
 }

--- a/apps/web/src/components/explore/ExplorePageClient.tsx
+++ b/apps/web/src/components/explore/ExplorePageClient.tsx
@@ -2029,8 +2029,7 @@ export default function ExplorePageClient({
           ) : viewMode === "thumb-lg" ? (
             <div className="space-y-5">
               {visibleResultGroups.map((group, groupIndex) => (
-                <section key={`${group.intent}-${groupIndex}`} className="space-y-3">
-                  {renderGroupHeader(group)}
+                <section key={`${group.intent}-${groupIndex}`}>
                   <div className={POKEMON_CARD_BROWSE_LARGE_GRID_CLASSNAME}>
                     {group.rows.map((row, rowIndex) => (
                       <ExploreCardGridItem
@@ -2052,8 +2051,7 @@ export default function ExplorePageClient({
           ) : (
             <div className="space-y-5">
               {visibleResultGroups.map((group, groupIndex) => (
-                <section key={`${group.intent}-${groupIndex}`} className="space-y-3">
-                  {renderGroupHeader(group)}
+                <section key={`${group.intent}-${groupIndex}`}>
                   <div className={POKEMON_CARD_BROWSE_GRID_CLASSNAME}>
                     {group.rows.map((row, rowIndex) => (
                       <ExploreCardGridItem

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -101,16 +101,36 @@ test("explore search keeps results compact and cards above supporting tools", ()
   const gridLayout = readSource("components", "cards", "pokemonCardGridLayout.ts");
   const gridItem = readSource("components", "explore", "ExploreCardGridItem.tsx");
   const gridTile = readSource("components", "cards", "PokemonCardGridTile.tsx");
+  const compareButton = readSource("components", "compare", "CompareCardButton.tsx");
+  const globals = readSource("app", "globals.css");
 
   assert.match(gridLayout, /grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5/);
   assert.match(gridItem, /const density = isLarge \? "large" : "compact"/);
   assert.match(gridItem, /typeof card\.raw_price === "number"/);
-  assert.match(gridItem, /max-w-\[180px\]/);
+  assert.match(gridItem, /variant="floating"/);
+  assert.match(gridItem, /gv-search-result-card/);
+  assert.match(gridItem, /max-w-\[172px\]/);
   assert.match(gridTile, /compact: "p-2\.5"/);
+  assert.match(compareButton, /variant\?: "default" \| "compact" \| "floating"/);
+  assert.match(compareButton, /gv-card-compare-floating/);
+  assert.match(globals, /\.gv-search-result-card\.gv-visual-card/);
+  assert.match(globals, /\.gv-search-result-card \.gv-card-compare-floating:not\(\.gv-card-compare-floating-selected\)/);
   assert.match(exploreClient, /const resultControls = \(/);
   assert.match(exploreClient, /const presetPillStrip = \(/);
   assert.match(exploreClient, /resolverSummary && displayRows\.length === 0/);
   assert.match(exploreClient, /\{hasExplicitSmartFilters \? \(/);
+
+  const thumbGridStart = exploreClient.indexOf('viewMode === "thumb-lg"');
+  const listGridStart = exploreClient.indexOf('viewMode === "list"');
+  const firstThumbGroupHeader = exploreClient.indexOf("renderGroupHeader(group)", thumbGridStart);
+  assert.ok(
+    thumbGridStart > listGridStart,
+    "thumbnail grid branch should be present after list branch",
+  );
+  assert.ok(
+    firstThumbGroupHeader === -1,
+    "thumbnail grid branches should not render an extra result-group header above cards",
+  );
 });
 
 test("japanese pikachu display keeps english primary and printed name secondary", () => {


### PR DESCRIPTION
## Summary
- remove the result-group header above thumbnail search grids so cards start immediately after filters
- add a compact search-result card shell with tighter radius and lighter image well
- add an icon-only floating compare button for grid cards, hidden until hover/focus on desktop
- preserve text compare buttons for list/details/card-page contexts
- extend the public rendering guard for the compact grid contract

## Verification
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm run web:build:strict
- local route smoke: /explore?q=Pikachu returns 200 and omits the Card identity matches header
- repo pre-commit shipcheck
- repo pre-push shipcheck