### PR TITLE
Rank clean English search results first

### DIFF
--- a/apps/web/src/components/cards/PokemonCardGridTile.tsx
+++ b/apps/web/src/components/cards/PokemonCardGridTile.tsx
@@ -35,25 +35,25 @@ type PokemonCardGridBadgeProps = {
 };
 
 const TILE_PADDING_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "p-2.5",
-  default: "p-4",
-  large: "p-5",
-};
-
-const IMAGE_PADDING_BY_DENSITY: Record<ViewDensity, string> = {
   compact: "p-2",
   default: "p-4",
   large: "p-5",
 };
 
+const IMAGE_PADDING_BY_DENSITY: Record<ViewDensity, string> = {
+  compact: "p-1.5",
+  default: "p-4",
+  large: "p-5",
+};
+
 const CONTENT_STACK_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "space-y-2",
+  compact: "space-y-1.5",
   default: "space-y-3",
   large: "space-y-3.5",
 };
 
 const BODY_STACK_BY_DENSITY: Record<ViewDensity, string> = {
-  compact: "space-y-2",
+  compact: "space-y-1.5",
   default: "space-y-2.5",
   large: "space-y-3",
 };

--- a/apps/web/src/components/cards/pokemonCardGridLayout.ts
+++ b/apps/web/src/components/cards/pokemonCardGridLayout.ts
@@ -1,10 +1,10 @@
 import type { ViewDensity } from "@/hooks/useViewDensity";
 
 export const POKEMON_CARD_BROWSE_GRID_CLASSNAME =
-  "grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5";
+  "grid grid-cols-2 items-start gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5";
 
 export const POKEMON_CARD_BROWSE_LARGE_GRID_CLASSNAME =
-  "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3";
+  "grid grid-cols-1 items-start gap-4 md:grid-cols-2 xl:grid-cols-3";
 
 export const POKEMON_CARD_DISCOVERY_GRID_CLASSNAME =
   "grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4";

--- a/apps/web/src/components/explore/ExploreCardGridItem.tsx
+++ b/apps/web/src/components/explore/ExploreCardGridItem.tsx
@@ -62,7 +62,7 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
       imageSizes={
         isLarge
           ? "(max-width: 640px) 58vw, (max-width: 1024px) 34vw, 280px"
-          : "(max-width: 640px) 42vw, (max-width: 1024px) 28vw, (max-width: 1536px) 20vw, 180px"
+          : "(max-width: 640px) 42vw, (max-width: 1024px) 28vw, (max-width: 1536px) 20vw, 168px"
       }
       imageOverlay={
         imagePresentation.compactBadgeLabel ? (
@@ -113,7 +113,7 @@ export default function ExploreCardGridItem({ card, href, mode, canViewPricing, 
           <VisiblePrice value={card.raw_price} size="grid" className="gv-hi-price" />
         ) : null
       }
-      imageClassName={isLarge ? "max-w-[280px]" : "mx-auto max-w-[172px]"}
+      imageClassName={isLarge ? "max-w-[280px]" : "mx-auto max-w-[160px]"}
       className="gv-search-result-card"
     />
   );

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -103,18 +103,24 @@ test("explore search keeps results compact and cards above supporting tools", ()
   const gridTile = readSource("components", "cards", "PokemonCardGridTile.tsx");
   const compareButton = readSource("components", "compare", "CompareCardButton.tsx");
   const globals = readSource("app", "globals.css");
+  const exploreRows = readSource("lib", "explore", "getExploreRows.ts");
 
-  assert.match(gridLayout, /grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5/);
+  assert.match(gridLayout, /grid-cols-2 items-start gap-3 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5/);
   assert.match(gridItem, /const density = isLarge \? "large" : "compact"/);
   assert.match(gridItem, /typeof card\.raw_price === "number"/);
   assert.match(gridItem, /variant="floating"/);
   assert.match(gridItem, /gv-search-result-card/);
-  assert.match(gridItem, /max-w-\[172px\]/);
-  assert.match(gridTile, /compact: "p-2\.5"/);
+  assert.match(gridItem, /max-w-\[160px\]/);
+  assert.match(gridTile, /compact: "p-2"/);
+  assert.match(gridTile, /compact: "p-1\.5"/);
   assert.match(compareButton, /variant\?: "default" \| "compact" \| "floating"/);
   assert.match(compareButton, /gv-card-compare-floating/);
   assert.match(globals, /\.gv-search-result-card\.gv-visual-card/);
   assert.match(globals, /\.gv-search-result-card \.gv-card-compare-floating:not\(\.gv-card-compare-floating-selected\)/);
+  assert.match(exploreRows, /function compareRowsByDataQuality/);
+  assert.match(exploreRows, /getImageRelevanceQuality/);
+  assert.match(exploreRows, /hasKnownSetName/);
+  assert.match(exploreRows, /const qualityCompare = compareRowsByDataQuality/);
   assert.match(exploreClient, /const resultControls = \(/);
   assert.match(exploreClient, /const presetPillStrip = \(/);
   assert.match(exploreClient, /resolverSummary && displayRows\.length === 0/);

--- a/apps/web/src/lib/explore/getExploreRows.ts
+++ b/apps/web/src/lib/explore/getExploreRows.ts
@@ -110,6 +110,12 @@ const TRUSTED_SPECIES_DECORATED_PRINTED_NAME_BONUS = 1250;
 const DECORATED_NAME_FALLBACK_PENALTY = -220;
 const NO_TEXT_TOKEN_MATCH_PENALTY = -1600;
 const FAMILY_DIVERSITY_PROMOTION_LIMIT = 4;
+const EXACT_IMAGE_RELEVANCE_QUALITY = 4;
+const REPRESENTATIVE_IMAGE_RELEVANCE_QUALITY = 1;
+const MISSING_IMAGE_RELEVANCE_QUALITY = 0;
+const KNOWN_SET_RELEVANCE_QUALITY = 3;
+const COLLECTOR_NUMBER_RELEVANCE_QUALITY = 2;
+const RARITY_RELEVANCE_QUALITY = 1;
 const JAPANESE_SPECIES_ALIASES_BY_SLUG = new Map<string, string[]>([
   ["pikachu", ["ピカチュウ"]],
 ]);
@@ -912,6 +918,7 @@ function lookupRowToPreRankExploreRow(row: CardPrintLookupRow): ExploreRow {
     artist: row.artist ?? undefined,
     image_url: row.image_url ?? undefined,
     representative_image_url: row.representative_image_url ?? undefined,
+    image_status: row.image_status ?? undefined,
     image_source: row.image_source ?? undefined,
     set_code: row.set_code ?? undefined,
     printed_set_abbrev: row.printed_set_abbrev ?? undefined,
@@ -952,6 +959,12 @@ function limitRowsBeforeEnrichment(
       const leftScore = scoreRow(left.sortableRow, query);
       const rightScore = scoreRow(right.sortableRow, query);
       if (leftScore !== rightScore) return rightScore - leftScore;
+
+      const qualityCompare = compareRowsByDataQuality(
+        left.sortableRow,
+        right.sortableRow,
+      );
+      if (qualityCompare !== 0) return qualityCompare;
 
       const nameCompare = left.sortableRow.name.localeCompare(right.sortableRow.name);
       if (nameCompare !== 0) return nameCompare;
@@ -1252,6 +1265,73 @@ function addScoreComponent(
 ) {
   if (!value) return;
   components[key] = (components[key] ?? 0) + value;
+}
+
+function hasKnownSetName(row: Pick<ExploreRow, "set_name" | "set_code" | "printed_set_abbrev">) {
+  const visibleSetName = row.set_name?.trim();
+  if (
+    visibleSetName &&
+    visibleSetName.toLowerCase() !== "unknown set"
+  ) {
+    return true;
+  }
+
+  return Boolean(row.set_code?.trim() || row.printed_set_abbrev?.trim());
+}
+
+function getImageRelevanceQuality(row: Pick<ExploreRow, "display_image_kind" | "image_status" | "display_image_url" | "image_url">) {
+  const displayKind = row.display_image_kind?.trim().toLowerCase();
+  const imageStatus = row.image_status?.trim().toLowerCase();
+
+  if (displayKind === "exact" || imageStatus === "exact") {
+    return EXACT_IMAGE_RELEVANCE_QUALITY;
+  }
+
+  if (
+    displayKind === "representative" ||
+    displayKind === "missing_variant_visual" ||
+    imageStatus?.startsWith("representative") ||
+    imageStatus === "missing_variant_visual"
+  ) {
+    return REPRESENTATIVE_IMAGE_RELEVANCE_QUALITY;
+  }
+
+  return row.display_image_url || row.image_url
+    ? REPRESENTATIVE_IMAGE_RELEVANCE_QUALITY
+    : MISSING_IMAGE_RELEVANCE_QUALITY;
+}
+
+function getRowRelevanceQualityScore(row: ExploreRow) {
+  return (
+    getImageRelevanceQuality(row) +
+    (hasKnownSetName(row) ? KNOWN_SET_RELEVANCE_QUALITY : 0) +
+    (row.number?.trim() ? COLLECTOR_NUMBER_RELEVANCE_QUALITY : 0) +
+    (row.rarity?.trim() ? RARITY_RELEVANCE_QUALITY : 0)
+  );
+}
+
+function compareRowsByDataQuality(a: ExploreRow, b: ExploreRow) {
+  const qualityCompare =
+    getRowRelevanceQualityScore(b) - getRowRelevanceQualityScore(a);
+  if (qualityCompare !== 0) return qualityCompare;
+
+  const imageCompare =
+    getImageRelevanceQuality(b) - getImageRelevanceQuality(a);
+  if (imageCompare !== 0) return imageCompare;
+
+  if (hasKnownSetName(a) !== hasKnownSetName(b)) {
+    return hasKnownSetName(a) ? -1 : 1;
+  }
+
+  if (Boolean(a.number?.trim()) !== Boolean(b.number?.trim())) {
+    return a.number?.trim() ? -1 : 1;
+  }
+
+  if (Boolean(a.rarity?.trim()) !== Boolean(b.rarity?.trim())) {
+    return a.rarity?.trim() ? -1 : 1;
+  }
+
+  return 0;
 }
 
 // Resolver Quality Pass V1:
@@ -1807,6 +1887,9 @@ function rankRows(rows: ExploreRow[], query: ResolverQuery) {
     const scoreB = scoreRow(b, query);
     if (scoreA !== scoreB) return scoreB - scoreA;
 
+    const qualityCompare = compareRowsByDataQuality(a, b);
+    if (qualityCompare !== 0) return qualityCompare;
+
     const nameCompare = a.name.localeCompare(b.name);
     if (nameCompare !== 0) return nameCompare;
 
@@ -1905,6 +1988,9 @@ function compareRowsByRelevance(
   const scoreA = scoreRow(a, query);
   const scoreB = scoreRow(b, query);
   if (scoreA !== scoreB) return scoreB - scoreA;
+
+  const qualityCompare = compareRowsByDataQuality(a, b);
+  if (qualityCompare !== 0) return qualityCompare;
 
   const nameCompare = a.name.localeCompare(b.name);
   if (nameCompare !== 0) return nameCompare;


### PR DESCRIPTION
## Summary
- rank English relevance results with known set, exact image, collector number, and rarity ahead of unknown/representative rows
- keep the existing language filter chip behavior unchanged
- tighten compact thumbnail grid rhythm by preventing row stretch and reducing compact tile spacing/image cap
- extend the rendering guard for relevance quality and compact density

## Verification
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm run web:build:strict
- local resolver smoke: /api/resolver/search?q=Pikachu&lang=en returns known-set exact-image rows first
- local page smoke: /explore?q=Pikachu&lang=en returns 200, keeps language chip, omits Card identity header
- repo pre-commit shipcheck
- repo pre-push shipcheck