### PR TITLE
feat: strengthen card ID crawl links

### DIFF
--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -256,12 +256,17 @@ export async function generateMetadata({ params }: { params: { gv_id: string } }
   const metadataImageUrl =
     normalizeCardImageUrl(card.image_url) ?? buildTcgDexImageUrl(card.tcgdex_external_id);
 
-  const titleParts = [displayName, card.set_name, card.gv_id].filter((value): value is string => Boolean(value));
+  const collectorNumberLabel = displayIdentity.displayPrintedNumber
+    ? `#${displayIdentity.displayPrintedNumber}`
+    : undefined;
+  const titleParts = [card.gv_id, displayName, card.set_name, collectorNumberLabel].filter(
+    (value): value is string => Boolean(value),
+  );
   const title = `${titleParts.join(" • ")} | Grookai Vault`;
   const description = [
-    `View card details for ${displayName}`,
+    `${card.gv_id} is the Grookai Vault canonical ID for ${displayName}`,
     card.set_name ? `from ${card.set_name}` : undefined,
-    displayIdentity.displayPrintedNumber ? `#${displayIdentity.displayPrintedNumber}` : undefined,
+    collectorNumberLabel,
     "including finishes and collection info on Grookai Vault.",
   ]
     .filter((value): value is string => Boolean(value))
@@ -763,6 +768,9 @@ export default async function CardPage({
                     </p>
                   ) : null}
                   <div className="flex flex-wrap items-center gap-2">
+                    <p className="inline-flex w-fit rounded-full border border-slate-200/80 bg-slate-50/90 px-3 py-1 font-mono text-sm font-semibold uppercase tracking-[0.12em] text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200">
+                      Grookai ID {resolvedCard.gv_id}
+                    </p>
                     {identitySubtitle ? (
                       <p className="gv-hi-metadata text-sm font-medium sm:text-base">{identitySubtitle}</p>
                     ) : null}

--- a/apps/web/src/app/ids/cards/[page]/page.tsx
+++ b/apps/web/src/app/ids/cards/[page]/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getCardIdRegistryEntries,
+  getCardIdRegistryPageCount,
+  ID_REGISTRY_PAGE_SIZE,
+} from "@/lib/seo/idRegistry";
+
+export const revalidate = 300;
+
+type CardIdPageProps = {
+  params: { page: string };
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function parsePageIndex(value: string) {
+  const pageIndex = Number(value);
+  return Number.isInteger(pageIndex) && pageIndex >= 0 ? pageIndex : null;
+}
+
+export async function generateMetadata({ params }: CardIdPageProps): Promise<Metadata> {
+  const pageIndex = parsePageIndex(params.page);
+  if (pageIndex === null) {
+    return {
+      title: "Card ID registry page not found | Grookai Vault",
+    };
+  }
+
+  const start = pageIndex * ID_REGISTRY_PAGE_SIZE + 1;
+  const end = (pageIndex + 1) * ID_REGISTRY_PAGE_SIZE;
+
+  return {
+    title: `GV-ID registry page ${pageIndex + 1} | Records ${start}-${end} | Grookai Vault`,
+    description: `Indexable Grookai Vault card ID links for records ${start}-${end}.`,
+    alternates: {
+      canonical: `https://grookaivault.com/ids/cards/${pageIndex}`,
+    },
+  };
+}
+
+export default async function CardIdRegistryChunkPage({ params }: CardIdPageProps) {
+  const pageIndex = parsePageIndex(params.page);
+  if (pageIndex === null) {
+    notFound();
+  }
+
+  const pageCount = await getCardIdRegistryPageCount();
+  if (pageIndex >= pageCount) {
+    notFound();
+  }
+
+  const entries = await getCardIdRegistryEntries(pageIndex);
+  const previousPage = pageIndex > 0 ? pageIndex - 1 : null;
+  const nextPage = pageIndex + 1 < pageCount ? pageIndex + 1 : null;
+
+  return (
+    <div className="gv-page-rhythm py-6">
+      <section className="gv-soft-surface px-5 py-6 sm:px-7">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="gv-eyebrow">Grookai card IDs</p>
+            <h1 className="mt-2 text-3xl font-black tracking-normal text-slate-950 dark:text-slate-50">
+              GV-ID page {pageIndex + 1}
+            </h1>
+            <p className="mt-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+              {formatNumber(entries.length)} canonical card links on this page.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/ids" className="gv-secondary-button min-h-0 px-4 py-2 text-sm">
+              All ID pages
+            </Link>
+            {previousPage !== null ? (
+              <Link href={`/ids/cards/${previousPage}`} className="gv-secondary-button min-h-0 px-4 py-2 text-sm">
+                Previous
+              </Link>
+            ) : null}
+            {nextPage !== null ? (
+              <Link href={`/ids/cards/${nextPage}`} className="gv-secondary-button min-h-0 px-4 py-2 text-sm">
+                Next
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-[8px] border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950">
+        <div className="grid grid-cols-[minmax(0,1fr)_7rem] gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:border-slate-800 dark:bg-white/[0.03]">
+          <span>Canonical card link</span>
+          <span>Language</span>
+        </div>
+        <div className="divide-y divide-slate-200 dark:divide-slate-800">
+          {entries.map((entry) => (
+            <Link
+              key={entry.gvId}
+              href={`/card/${encodeURIComponent(entry.gvId)}`}
+              className="grid grid-cols-[minmax(0,1fr)_7rem] gap-3 px-4 py-3 transition hover:bg-slate-50 dark:hover:bg-white/[0.03]"
+            >
+              <span className="min-w-0">
+                <span className="block font-mono text-xs font-bold uppercase tracking-[0.12em] text-slate-950 dark:text-slate-50">
+                  {entry.gvId}
+                </span>
+                <span className="mt-1 block truncate text-sm font-semibold text-slate-700 dark:text-slate-300">
+                  {entry.name}
+                  {entry.setName ? ` - ${entry.setName}` : ""}
+                  {entry.number ? ` #${entry.number}` : ""}
+                </span>
+              </span>
+              <span className="self-center text-xs font-semibold text-slate-500">{entry.language}</span>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/ids/page.tsx
+++ b/apps/web/src/app/ids/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getCardIdRegistrySummary } from "@/lib/seo/idRegistry";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: "Grookai Card ID Registry | Grookai Vault",
+  description:
+    "Browse indexable Grookai Vault card IDs by page, language, and set. Each registry page links directly to canonical card records.",
+  alternates: {
+    canonical: "https://grookaivault.com/ids",
+  },
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+export default async function CardIdRegistryPage() {
+  const summary = await getCardIdRegistrySummary();
+  const pageIndexes = Array.from({ length: summary.pageCount }, (_, index) => index);
+
+  return (
+    <div className="gv-page-rhythm py-6">
+      <section className="gv-soft-surface px-5 py-6 sm:px-7">
+        <p className="gv-eyebrow">Grookai identity registry</p>
+        <div className="mt-3 grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(260px,360px)] lg:items-end">
+          <div className="space-y-3">
+            <h1 className="text-4xl font-black tracking-normal text-slate-950 dark:text-slate-50 sm:text-5xl">
+              Card IDs
+            </h1>
+            <p className="max-w-3xl text-sm font-medium leading-6 text-slate-600 dark:text-slate-300">
+              Public canonical Grookai Vault identifiers, organized into crawlable pages that link directly to card records.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="gv-dex-mini-stat">
+              <p>{formatNumber(summary.totalCards)}</p>
+              <span>Cards</span>
+            </div>
+            <div className="gv-dex-mini-stat">
+              <p>{formatNumber(summary.japaneseCards)}</p>
+              <span>Japanese</span>
+            </div>
+            <div className="gv-dex-mini-stat">
+              <p>{formatNumber(summary.englishCards)}</p>
+              <span>English</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="gv-eyebrow">Identifier pages</p>
+            <h2 className="mt-1 text-2xl font-black tracking-normal text-slate-950 dark:text-slate-50">
+              Public GV-ID ranges
+            </h2>
+          </div>
+          <p className="text-sm font-semibold text-slate-500 dark:text-slate-400">
+            {formatNumber(summary.pageCount)} pages
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          {pageIndexes.map((pageIndex) => {
+            const start = pageIndex * 1000 + 1;
+            const end = Math.min((pageIndex + 1) * 1000, summary.totalCards);
+            return (
+              <Link
+                key={pageIndex}
+                href={`/ids/cards/${pageIndex}`}
+                className="rounded-[8px] border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-950 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:text-white"
+              >
+                <span className="block">GV-ID page {pageIndex + 1}</span>
+                <span className="mt-1 block text-xs font-medium text-slate-500">
+                  Records {formatNumber(start)}-{formatNumber(end)}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <p className="gv-eyebrow">Set entry points</p>
+          <h2 className="mt-1 text-2xl font-black tracking-normal text-slate-950 dark:text-slate-50">
+            High-signal set links
+          </h2>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {summary.featuredSets.map((setInfo) => (
+            <Link
+              key={setInfo.code}
+              href={`/sets/${encodeURIComponent(setInfo.code)}`}
+              className="rounded-[8px] border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 dark:border-slate-800 dark:bg-slate-950 dark:hover:border-slate-600"
+            >
+              <span className="block text-sm font-bold text-slate-950 dark:text-slate-50">{setInfo.name}</span>
+              <span className="mt-1 block text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+                {setInfo.code.toUpperCase()} - {formatNumber(setInfo.cardCount)} cards
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -119,6 +119,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               <Link href="/early-access" className="underline-offset-4 hover:text-slate-900 hover:underline">
                 Early Access
               </Link>
+              <Link href="/ids" className="underline-offset-4 hover:text-slate-900 hover:underline">
+                Card IDs
+              </Link>
               <Link href="/legal" className="underline-offset-4 hover:text-slate-900 hover:underline">
                 Legal
               </Link>

--- a/apps/web/src/components/PublicSetCardGrid.tsx
+++ b/apps/web/src/components/PublicSetCardGrid.tsx
@@ -179,6 +179,9 @@ export default function PublicSetCardGrid({
                   {identitySubtitle ? (
                     <span className="gv-hi-metadata block truncate text-xs font-medium">{identitySubtitle}</span>
                   ) : null}
+                  <span className="gv-hi-metadata block truncate font-mono text-[11px] font-semibold uppercase tracking-[0.12em]">
+                    Grookai ID {card.gv_id}
+                  </span>
                 </Link>
               }
               subtitle={<span className="block truncate">{setLabel}</span>}

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -207,3 +207,24 @@ test("card SEO exposes full sitemap index and product identifiers", () => {
   assert.match(cardPage, /mpn: card\.gv_id/);
   assert.match(cardPage, /propertyID: "Grookai Vault ID"/);
 });
+
+test("card SEO exposes exact GV IDs through visible internal links", () => {
+  const cardPage = readSource("app", "card", "[gv_id]", "page.tsx");
+  const setGrid = readSource("components", "PublicSetCardGrid.tsx");
+  const layout = readSource("app", "layout.tsx");
+  const idRegistry = readSource("lib", "seo", "idRegistry.ts");
+  const idsPage = readSource("app", "ids", "page.tsx");
+  const idsCardPage = readSource("app", "ids", "cards", "[page]", "page.tsx");
+  const sitemapHelpers = readSource("lib", "seo", "sitemaps.ts");
+
+  assert.match(cardPage, /\[card\.gv_id, displayName, card\.set_name, collectorNumberLabel\]/);
+  assert.match(cardPage, /Grookai Vault canonical ID/);
+  assert.match(cardPage, /Grookai ID \{resolvedCard\.gv_id\}/);
+  assert.match(setGrid, /Grookai ID \{card\.gv_id\}/);
+  assert.match(layout, /href="\/ids"/);
+  assert.match(idRegistry, /ID_REGISTRY_PAGE_SIZE = 1_000/);
+  assert.match(idsPage, /href=\{`\/ids\/cards\/\$\{pageIndex\}`\}/);
+  assert.match(idsCardPage, /href=\{`\/card\/\$\{encodeURIComponent\(entry\.gvId\)\}`\}/);
+  assert.match(idsCardPage, /\{entry\.gvId\}/);
+  assert.match(sitemapHelpers, /`\$\{origin\}\/ids`/);
+});

--- a/apps/web/src/lib/seo/idRegistry.ts
+++ b/apps/web/src/lib/seo/idRegistry.ts
@@ -1,0 +1,141 @@
+import "server-only";
+
+import { cache } from "react";
+import { createServerAdminClient } from "@/lib/supabase/admin";
+import { getPublicSets } from "@/lib/publicSets";
+
+export const ID_REGISTRY_PAGE_SIZE = 1_000;
+
+type CardIdRegistryRow = {
+  gv_id: string | null;
+  name: string | null;
+  set_code: string | null;
+  number: string | null;
+  updated_at: string | null;
+  sets?:
+    | {
+        name: string | null;
+        release_date: string | null;
+      }
+    | {
+        name: string | null;
+        release_date: string | null;
+      }[]
+    | null;
+};
+
+export type CardIdRegistryEntry = {
+  gvId: string;
+  name: string;
+  setCode: string | null;
+  setName: string | null;
+  number: string | null;
+  updatedAt: string | null;
+  language: "Japanese" | "English";
+};
+
+export type CardIdRegistrySummary = {
+  totalCards: number;
+  japaneseCards: number;
+  englishCards: number;
+  pageCount: number;
+  setCount: number;
+  featuredSets: Array<{
+    code: string;
+    name: string;
+    cardCount: number;
+  }>;
+};
+
+function getLanguageForGvId(gvId: string): "Japanese" | "English" {
+  return /^GV-PK-JPN-/i.test(gvId) ? "Japanese" : "English";
+}
+
+function mapRegistryRow(row: CardIdRegistryRow): CardIdRegistryEntry | null {
+  const gvId = row.gv_id?.trim();
+  if (!gvId) return null;
+
+  const setRecord = Array.isArray(row.sets) ? row.sets[0] : row.sets;
+
+  return {
+    gvId,
+    name: row.name?.trim() || "Unknown card",
+    setCode: row.set_code?.trim() || null,
+    setName: setRecord?.name?.trim() || null,
+    number: row.number?.trim() || null,
+    updatedAt: row.updated_at ?? null,
+    language: getLanguageForGvId(gvId),
+  };
+}
+
+export const getCardIdRegistryPageCount = cache(async () => {
+  const admin = createServerAdminClient();
+  const { count, error } = await admin
+    .from("card_prints")
+    .select("id", { count: "exact", head: true })
+    .not("gv_id", "is", null);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return Math.max(1, Math.ceil((count ?? 0) / ID_REGISTRY_PAGE_SIZE));
+});
+
+export const getCardIdRegistrySummary = cache(async (): Promise<CardIdRegistrySummary> => {
+  const admin = createServerAdminClient();
+  const [{ count: totalCards, error: totalError }, { count: japaneseCards, error: japaneseError }, publicSets] =
+    await Promise.all([
+      admin.from("card_prints").select("id", { count: "exact", head: true }).not("gv_id", "is", null),
+      admin
+        .from("card_prints")
+        .select("id", { count: "exact", head: true })
+        .not("gv_id", "is", null)
+        .ilike("gv_id", "GV-PK-JPN-%"),
+      getPublicSets(),
+    ]);
+
+  if (totalError) {
+    throw new Error(totalError.message);
+  }
+  if (japaneseError) {
+    throw new Error(japaneseError.message);
+  }
+
+  const normalizedTotal = totalCards ?? 0;
+  const normalizedJapanese = japaneseCards ?? 0;
+
+  return {
+    totalCards: normalizedTotal,
+    japaneseCards: normalizedJapanese,
+    englishCards: Math.max(0, normalizedTotal - normalizedJapanese),
+    pageCount: Math.max(1, Math.ceil(normalizedTotal / ID_REGISTRY_PAGE_SIZE)),
+    setCount: publicSets.length,
+    featuredSets: publicSets.slice(0, 24).map((setInfo) => ({
+      code: setInfo.code,
+      name: setInfo.name,
+      cardCount: setInfo.card_count,
+    })),
+  };
+});
+
+export const getCardIdRegistryEntries = cache(async (pageIndex: number): Promise<CardIdRegistryEntry[]> => {
+  const safePageIndex = Number.isInteger(pageIndex) && pageIndex >= 0 ? pageIndex : 0;
+  const from = safePageIndex * ID_REGISTRY_PAGE_SIZE;
+  const to = from + ID_REGISTRY_PAGE_SIZE - 1;
+  const admin = createServerAdminClient();
+  const { data, error } = await admin
+    .from("card_prints")
+    .select("gv_id,name,set_code,number,updated_at,sets(name,release_date)")
+    .not("gv_id", "is", null)
+    .order("gv_id", { ascending: true })
+    .range(from, to);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return ((data ?? []) as CardIdRegistryRow[])
+    .map(mapRegistryRow)
+    .filter((entry): entry is CardIdRegistryEntry => entry !== null);
+});

--- a/apps/web/src/lib/seo/sitemaps.ts
+++ b/apps/web/src/lib/seo/sitemaps.ts
@@ -195,5 +195,6 @@ export function getStaticSitemapEntries() {
     { loc: `${origin}/` },
     { loc: `${origin}/sets` },
     { loc: `${origin}/explore` },
+    { loc: `${origin}/ids` },
   ];
 }


### PR DESCRIPTION
## Summary
- front-load canonical GV IDs in card page metadata titles and descriptions
- surface Grookai IDs visibly in the card hero and set card links
- add a lightweight /ids crawl hub plus paginated /ids/cards/[page] registry pages
- include /ids in the static sitemap and footer discovery
- add regression guards for exact-ID crawl surfaces

## Verification
- `node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run lint` (existing warehouse `<img>` warning only)
- `npm run web:build:strict`
- local smoke: `/ids` renders the card ID hub
- local smoke: `/ids/cards/0` renders 1,000 card links
- local smoke: card page title starts with exact GV ID and renders visible Grookai ID
- local smoke: set page renders visible Grookai ID context
- pre-commit shipcheck passed