### PR TITLE
chore: expose rate limit source in throttles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,5 @@ tools/
 backups/
 
 temp/
+
+.vercel

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -275,6 +275,7 @@ test("legal terms protect catalog data without blocking card indexing", () => {
   assert.match(middleware, /process\.env\.NODE_ENV !== "production"/);
   assert.match(middleware, /status: 429/);
   assert.match(middleware, /"Retry-After"/);
+  assert.match(middleware, /X-Grookai-Rate-Limit-Source/);
   assert.match(middleware, /X-Content-Type-Options/);
   assert.match(middleware, /Referrer-Policy/);
   assert.match(middleware, /Permissions-Policy/);

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -314,6 +314,7 @@ async function applyAbuseProtection(request: NextRequest, event: NextFetchEvent)
         "Content-Type": "text/plain; charset=utf-8",
         "Retry-After": String(retryAfterSeconds),
         "Cache-Control": "private, no-store",
+        "X-Grookai-Rate-Limit-Source": bucket.source,
       },
     });
 


### PR DESCRIPTION
## Summary
- add `X-Grookai-Rate-Limit-Source` to throttled middleware responses so production smoke can distinguish durable Redis enforcement from memory fallback
- keep the header limited to `429` responses only
- add `.vercel` to `.gitignore` after linking the local checkout to the existing Vercel project
- extend the public rendering guard test for the new throttle source header

## Verification
- `node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs`
- `npm --prefix apps/web run typecheck`
- `npm run web:build:strict`
- local temporary Upstash check confirmed the Upstash REST `/pipeline` endpoint works
- local `next dev` still reports `memory` source, which appears to be local dev/env behavior; production bundle keeps runtime `process.env.UPSTASH_REDIS_REST_URL` references
- pre-commit shipcheck passed
- pre-push shipcheck passed

## Notes
This does not enable durable production rate limits by itself. Production still needs permanent Upstash values added to Vercel env vars and a redeploy.