### PR TITLE
perf: skip search pricing unless requested

### DIFF
--- a/apps/web/src/app/api/resolver/search/route.ts
+++ b/apps/web/src/app/api/resolver/search/route.ts
@@ -102,6 +102,11 @@ function parseOwnedState(value: string | null): SmartSearchIntent["ownedState"] 
   return value === "owned" || value === "missing" ? value : undefined;
 }
 
+function parseBooleanParam(value: string | null) {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 function parseImageState(value: string | null): SmartSearchIntent["imageState"] {
   if (value === "exact" || value === "representative" || value === "missing") {
     return value;
@@ -354,6 +359,11 @@ export async function GET(request: NextRequest) {
   const explicitFinishKeys = parseMultiParam(request.nextUrl.searchParams, "finish");
   const explicitStampLabels = parseMultiParam(request.nextUrl.searchParams, "stamp");
   const explicitImageState = parseImageState(request.nextUrl.searchParams.get("image_state") ?? request.nextUrl.searchParams.get("image"));
+  const sortMode = parseSortMode(request.nextUrl.searchParams.get("sort"));
+  const includePricing =
+    parseBooleanParam(request.nextUrl.searchParams.get("include_pricing")) ||
+    sortMode === "value_high" ||
+    sortMode === "value_low";
   const explicitOwnedState = parseOwnedState(request.nextUrl.searchParams.get("owned"));
   const exactIllustrator = normalizeIllustrator(request.nextUrl.searchParams.get("illustrator")) ?? smartSearchIntent.artist;
   const effectiveSmartSearchIntent: SmartSearchIntent = {
@@ -378,7 +388,6 @@ export async function GET(request: NextRequest) {
     ]),
   };
   const identityFilter = normalizeIdentityFilterKey(request.nextUrl.searchParams.get("identity"));
-  const sortMode = parseSortMode(request.nextUrl.searchParams.get("sort"));
   const hasSmartYearRange =
     typeof effectiveSmartSearchIntent.releaseYearMin === "number" ||
     typeof effectiveSmartSearchIntent.releaseYearMax === "number";
@@ -449,6 +458,7 @@ export async function GET(request: NextRequest) {
             stampLabels: effectiveSmartSearchIntent.stampLabels,
             imageState: effectiveSmartSearchIntent.imageState,
             languageScope,
+            includePricing,
           }),
         ).then((rows) => ({
           rows,
@@ -461,6 +471,7 @@ export async function GET(request: NextRequest) {
             query,
             languageScope,
             sortMode,
+            includePricing,
           ).then((rows) => ({
             rows,
             meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
@@ -469,23 +480,24 @@ export async function GET(request: NextRequest) {
           }))
       : shouldUseSmartFilterDiscovery
         ? getExploreRowsForSmartFilterDiscovery({
-          sortMode,
-          exactSetCode,
-          exactReleaseYear,
-          exactIllustrator,
-          identityFilter,
-          releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
-          releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
-          finishKeys: effectiveSmartSearchIntent.finishKeys,
-          stampLabels: effectiveSmartSearchIntent.stampLabels,
-          imageState: effectiveSmartSearchIntent.imageState,
-          languageScope,
-        }).then((rows) => ({
-          rows,
-          meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
-          smartSearchIntent: effectiveSmartSearchIntent,
-          degraded: false,
-        }))
+            sortMode,
+            exactSetCode,
+            exactReleaseYear,
+            exactIllustrator,
+            identityFilter,
+            releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
+            releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
+            finishKeys: effectiveSmartSearchIntent.finishKeys,
+            stampLabels: effectiveSmartSearchIntent.stampLabels,
+            imageState: effectiveSmartSearchIntent.imageState,
+            languageScope,
+            includePricing,
+          }).then((rows) => ({
+            rows,
+            meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
+            smartSearchIntent: effectiveSmartSearchIntent,
+            degraded: false,
+          }))
         : shouldUseStructuredTextExpansion
           ? getExploreRowsForSmartStructuredTextSearch(query, {
               sortMode,
@@ -499,6 +511,7 @@ export async function GET(request: NextRequest) {
               stampLabels: effectiveSmartSearchIntent.stampLabels,
               imageState: effectiveSmartSearchIntent.imageState,
               languageScope,
+              includePricing,
             }).then((rows) => ({
               rows,
               meta: buildSmartFilterDiscoveryMeta(rows, effectiveSmartSearchIntent),
@@ -515,6 +528,7 @@ export async function GET(request: NextRequest) {
               releaseYearMin: effectiveSmartSearchIntent.releaseYearMin,
               releaseYearMax: effectiveSmartSearchIntent.releaseYearMax,
               languageScope,
+              includePricing,
             }).then((resolved) => ({
               ...resolved,
               smartSearchIntent: effectiveSmartSearchIntent,

--- a/apps/web/src/components/explore/ExplorePageClient.tsx
+++ b/apps/web/src/components/explore/ExplorePageClient.tsx
@@ -606,6 +606,14 @@ export default function ExplorePageClient({
           params.set("sort", sortMode);
         }
 
+        if (
+          effectiveCanViewPricing ||
+          sortMode === "value_high" ||
+          sortMode === "value_low"
+        ) {
+          params.set("include_pricing", "1");
+        }
+
         if (exactSetCode) {
           params.set("set", exactSetCode);
         }
@@ -717,6 +725,7 @@ export default function ExplorePageClient({
     hasExplicitSmartFilters,
     identityFilter,
     shouldServerFilterByIdentity,
+    effectiveCanViewPricing,
   ]);
 
   useEffect(() => {

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -91,6 +91,7 @@ test("explore search is bounded and language-aware for public performance", () =
   assert.match(exploreClient, /const INITIAL_VISIBLE_RESULT_COUNT = 24/);
   assert.match(exploreClient, /const SEARCH_API_RESULT_LIMIT = 48/);
   assert.match(exploreClient, /params\.set\("limit", String\(SEARCH_API_RESULT_LIMIT\)\)/);
+  assert.match(exploreClient, /params\.set\("include_pricing", "1"\)/);
   assert.match(gridItem, /imagePrefetch=\{false\}/);
   assert.match(gridItem, /imagePriority=\{imagePriority\}/);
   assert.match(publicCardImage, /fetchPriority=\{priority \? "high" : undefined\}/);
@@ -121,6 +122,8 @@ test("explore search keeps results compact and cards above supporting tools", ()
   assert.match(exploreRows, /getImageRelevanceQuality/);
   assert.match(exploreRows, /hasKnownSetName/);
   assert.match(exploreRows, /const qualityCompare = compareRowsByDataQuality/);
+  assert.match(exploreRows, /includePricing = false/);
+  assert.match(exploreRows, /options\.includePricing/);
   assert.match(exploreClient, /const resultControls = \(/);
   assert.match(exploreClient, /const presetPillStrip = \(/);
   assert.match(exploreClient, /resolverSummary && displayRows\.length === 0/);

--- a/apps/web/src/lib/explore/getExploreRows.ts
+++ b/apps/web/src/lib/explore/getExploreRows.ts
@@ -294,6 +294,7 @@ type SmartFilterDiscoveryOptions = {
   stampLabels?: string[];
   imageState?: SmartFilterImageState;
   languageScope?: PublicLanguageScope;
+  includePricing?: boolean;
 };
 
 type PublicSetMetadata = {
@@ -3689,6 +3690,7 @@ export async function getExploreRowsForLanguageScopedTextSearch(
   rawQuery: string,
   languageScope: PublicLanguageScope,
   sortMode: SortMode,
+  includePricing = false,
 ): Promise<ExploreRow[]> {
   const query = await buildResolverQuery(normalizeQuery(rawQuery));
   const exactRows = await fetchLanguageScopedTextRows(query, languageScope);
@@ -3698,7 +3700,7 @@ export async function getExploreRowsForLanguageScopedTextSearch(
   );
   const supabase = createServerComponentClient();
   const pricingByCardId =
-    sortMode === "value_high" || sortMode === "value_low"
+    includePricing || sortMode === "value_high" || sortMode === "value_low"
       ? await getPublicPricingByCardIds(
           supabase,
           enrichmentRows.map((row) => row.id),
@@ -4051,10 +4053,12 @@ export async function getExploreRowsForSmartFilterDiscovery(
     uniqueValues(enrichmentRows.map((row) => row.set_code ?? "").filter(Boolean)),
   );
   const supabase = createServerComponentClient();
-  const pricingByCardId = await getPublicPricingByCardIds(
-    supabase,
-    enrichmentRows.map((row) => row.id),
-  );
+  const pricingByCardId = options.includePricing
+    ? await getPublicPricingByCardIds(
+        supabase,
+        enrichmentRows.map((row) => row.id),
+      )
+    : new Map<string, PublicPricingRecord>();
   const rows = await buildExploreRows(
     enrichmentRows,
     new Map<string, string>(),
@@ -4116,10 +4120,12 @@ export async function getExploreRowsForSmartStructuredTextSearch(
     uniqueValues(enrichmentRows.map((row) => row.set_code ?? "").filter(Boolean)),
   );
   const supabase = createServerComponentClient();
-  const pricingByCardId = await getPublicPricingByCardIds(
-    supabase,
-    enrichmentRows.map((row) => row.id),
-  );
+  const pricingByCardId = options.includePricing
+    ? await getPublicPricingByCardIds(
+        supabase,
+        enrichmentRows.map((row) => row.id),
+      )
+    : new Map<string, PublicPricingRecord>();
   const rows = await buildExploreRows(
     enrichmentRows,
     new Map<string, string>(),
@@ -4168,10 +4174,12 @@ export async function getExploreRowsForOwnedSmartFilterDiscovery(
     uniqueValues(enrichmentRows.map((row) => row.set_code ?? "").filter(Boolean)),
   );
   const supabase = createServerComponentClient();
-  const pricingByCardId = await getPublicPricingByCardIds(
-    supabase,
-    enrichmentRows.map((row) => row.id),
-  );
+  const pricingByCardId = options.includePricing
+    ? await getPublicPricingByCardIds(
+        supabase,
+        enrichmentRows.map((row) => row.id),
+      )
+    : new Map<string, PublicPricingRecord>();
   const rows = await buildExploreRows(
     enrichmentRows,
     new Map<string, string>(),
@@ -4228,6 +4236,7 @@ export async function getExploreRowsPacketWithTiming(
   releaseYearMin?: number,
   releaseYearMax?: number,
   languageScope: PublicLanguageScope = "all",
+  includePricing = false,
 ): Promise<{ rows: ExploreRow[]; timing: ExploreRowsTiming }> {
   const totalStartMs = performance.now();
   const totalStartRemote = snapshotRemoteTiming();
@@ -4432,10 +4441,12 @@ export async function getExploreRowsPacketWithTiming(
 
   const supabase = createServerComponentClient();
   const timedPricing = await measureStage(() =>
-    getPublicPricingByCardIds(
-      supabase,
-      exactRows.map((row) => row.id),
-    ),
+    includePricing
+      ? getPublicPricingByCardIds(
+          supabase,
+          exactRows.map((row) => row.id),
+        )
+      : Promise.resolve(new Map<string, PublicPricingRecord>()),
   );
   Object.assign(fetchPricingStage, timedPricing.timing);
   const pricingByCardId = timedPricing.value;
@@ -4528,6 +4539,7 @@ export async function getExploreRowsWithTiming(
   exactIllustrator?: string,
   releaseYearMin?: number,
   releaseYearMax?: number,
+  includePricing = false,
 ): Promise<{ rows: ExploreRow[]; timing: ExploreRowsTiming }> {
   return getExploreRowsPacketWithTiming(
     normalizeQuery(rawQuery),
@@ -4538,6 +4550,8 @@ export async function getExploreRowsWithTiming(
     "all",
     releaseYearMin,
     releaseYearMax,
+    "all",
+    includePricing,
   );
 }
 
@@ -4549,6 +4563,7 @@ export async function getExploreRows(
   exactIllustrator?: string,
   releaseYearMin?: number,
   releaseYearMax?: number,
+  includePricing = false,
 ): Promise<ExploreRow[]> {
   return (
     await getExploreRowsWithTiming(
@@ -4559,6 +4574,7 @@ export async function getExploreRows(
       exactIllustrator,
       releaseYearMin,
       releaseYearMax,
+      includePricing,
     )
   ).rows;
 }

--- a/apps/web/src/lib/resolver/resolveQuery.ts
+++ b/apps/web/src/lib/resolver/resolveQuery.ts
@@ -43,6 +43,7 @@ type RankedResolveOptions = {
   releaseYearMin?: number;
   releaseYearMax?: number;
   languageScope?: PublicLanguageScope;
+  includePricing?: boolean;
 };
 
 export type ResolverState =
@@ -318,6 +319,7 @@ export async function resolveQueryWithMeta(
     options.releaseYearMin,
     options.releaseYearMax,
     options.languageScope,
+    options.includePricing,
   );
   const meta = buildRankedResolverMeta(resolved.rows, resolved.timing, packet);
 


### PR DESCRIPTION
## Summary
- make public explore search skip pricing bridge enrichment by default
- opt back into pricing when the viewer can see pricing, `include_pricing=1` is present, or value sorting is requested
- preserve value-based sorting behavior while reducing DB work for broad searches like Pikachu / Japanese catalog searches

## Verification
- `node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run lint`
- `npm run web:build:strict`
- pre-commit/pre-push `npm run shipcheck`

## Notes
- This does not change card identity, public indexing, or database rows.
- Existing lint warning remains in `WarehouseSubmissionForm.tsx` for `<img>` usage.