### PR TITLE
perf: cache optimized card images

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -124,6 +124,11 @@ const nextConfig = {
     ];
   },
   images: {
+    // Card art is immutable once its canonical storage path is assigned. Keeping
+    // optimized derivatives warm avoids repeated 500ms+ image optimizer misses.
+    minimumCacheTTL: 60 * 60 * 24 * 7,
+    deviceSizes: [640, 750, 828, 1080, 1200],
+    imageSizes: [48, 64, 74, 96, 128, 160, 220, 320],
     remotePatterns: [
       {
         protocol: "https",

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -64,11 +64,15 @@ test("Wall route does not eagerly fetch every custom section card grid", () => {
 
 test("public card image chooses an initial source before hydration", () => {
   const publicCardImage = readSource("components", "PublicCardImage.tsx");
+  const nextConfig = readFileSync(join(sourceRoot, "..", "next.config.mjs"), "utf8");
 
   assert.match(publicCardImage, /const initialSrc = normalizedPrimary \?\? normalizedFallback/);
   assert.match(publicCardImage, /useState<string \| undefined>\(initialSrc\)/);
   assert.match(publicCardImage, /Hydration must not be required just to choose the first image source/);
   assert.match(publicCardImage, /sizes=\{sizes\}/);
+  assert.match(nextConfig, /minimumCacheTTL:\s*60\s*\*\s*60\s*\*\s*24\s*\*\s*7/);
+  assert.match(nextConfig, /deviceSizes:\s*\[640,\s*750,\s*828,\s*1080,\s*1200\]/);
+  assert.doesNotMatch(nextConfig, /3840/);
 });
 
 test("explore search is bounded and language-aware for public performance", () => {


### PR DESCRIPTION
## Summary
- raise Next image optimizer cache TTL for immutable card art derivatives
- bound generated image widths to card-appropriate sizes instead of 3840px candidates
- add a performance guard so this image config does not regress

## Verification
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- npm run web:build:strict
- npm run shipcheck via pre-commit and pre-push hooks