### PR TITLE
perf: serve immutable catalog card images

### DIFF
--- a/apps/web/src/app/api/canon/image/route.ts
+++ b/apps/web/src/app/api/canon/image/route.ts
@@ -1,9 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { normalizeWarehouseCanonImagePath } from "@/lib/canon/canonImageProxy";
-import { resolveVaultInstanceMediaUrl } from "@/lib/vault/resolveVaultInstanceMediaUrl";
+import { createServerAdminClient } from "@/lib/supabase/admin";
+import { VAULT_INSTANCE_MEDIA_BUCKET } from "@/lib/vaultInstanceMedia";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
+
+function getContentTypeForPath(path: string) {
+  const lowerPath = path.toLowerCase();
+  if (lowerPath.endsWith(".webp")) return "image/webp";
+  if (lowerPath.endsWith(".png")) return "image/png";
+  if (lowerPath.endsWith(".gif")) return "image/gif";
+  if (lowerPath.endsWith(".avif")) return "image/avif";
+  return "image/jpeg";
+}
 
 export async function GET(request: NextRequest) {
   const path = normalizeWarehouseCanonImagePath(request.nextUrl.searchParams.get("path"));
@@ -11,12 +21,20 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid image path." }, { status: 400 });
   }
 
-  const signedUrl = await resolveVaultInstanceMediaUrl(path);
-  if (!signedUrl) {
+  const admin = createServerAdminClient();
+  const { data, error } = await admin.storage
+    .from(VAULT_INSTANCE_MEDIA_BUCKET)
+    .download(path);
+
+  if (error || !data) {
     return NextResponse.json({ error: "Image unavailable." }, { status: 404 });
   }
 
-  const response = NextResponse.redirect(signedUrl, 307);
-  response.headers.set("Cache-Control", "public, max-age=300, s-maxage=900, stale-while-revalidate=3600");
+  const response = new NextResponse(await data.arrayBuffer(), {
+    headers: {
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Type": data.type || getContentTypeForPath(path),
+    },
+  });
   return response;
 }

--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -133,6 +133,10 @@ function buildExactExternalImageFallback(primaryImageUrl: string | null | undefi
   return buildTcgDexImageUrl(tcgdexExternalId);
 }
 
+function isCanonImageProxyUrl(value: string | null | undefined) {
+  return value?.startsWith("/api/canon/image?") ?? false;
+}
+
 function formatReleaseDate(releaseDate?: string) {
   if (!releaseDate) return undefined;
   const match = releaseDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -947,6 +951,7 @@ export default async function CardPage({
                 fallbackClassName="flex aspect-[3/4] w-full items-center justify-center rounded-[22px] bg-white/42 px-4 text-center text-sm font-medium text-slate-400 ring-1 ring-inset ring-slate-200/40 dark:bg-white/[0.04] dark:text-slate-600 dark:ring-white/[0.05]"
                 sizes="(max-width: 1024px) 86vw, 430px"
                 priority
+                unoptimized={isCanonImageProxyUrl(resolvedCardImageSrc)}
               />
             </div>
             {resolvedCardImagePresentation.compactBadgeLabel ? (

--- a/apps/web/src/components/PublicCardImage.tsx
+++ b/apps/web/src/components/PublicCardImage.tsx
@@ -14,6 +14,7 @@ type PublicCardImageProps = {
   loading?: "eager" | "lazy";
   priority?: boolean;
   sizes?: string;
+  unoptimized?: boolean;
 };
 
 export default function PublicCardImage({
@@ -26,6 +27,7 @@ export default function PublicCardImage({
   loading,
   priority = false,
   sizes = "(max-width: 640px) 42vw, (max-width: 1024px) 25vw, 220px",
+  unoptimized = false,
 }: PublicCardImageProps) {
   const normalizedPrimary = typeof src === "string" && src.trim().length > 0 ? src.trim() : undefined;
   const normalizedFallback =
@@ -56,6 +58,7 @@ export default function PublicCardImage({
       width={1200}
       height={1600}
       sizes={sizes}
+      unoptimized={unoptimized}
       onError={() => {
         if (canFallback && activeSrc === normalizedPrimary) {
           setActiveSrc(normalizedFallback);

--- a/apps/web/src/components/compare/CardZoomModal.tsx
+++ b/apps/web/src/components/compare/CardZoomModal.tsx
@@ -12,6 +12,7 @@ type CardZoomModalProps = {
   fallbackClassName: string;
   sizes?: string;
   priority?: boolean;
+  unoptimized?: boolean;
 };
 
 export default function CardZoomModal({
@@ -22,6 +23,7 @@ export default function CardZoomModal({
   fallbackClassName,
   sizes,
   priority = false,
+  unoptimized = false,
 }: CardZoomModalProps) {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -67,6 +69,7 @@ export default function CardZoomModal({
         fallbackClassName={fallbackClassName}
         sizes={sizes}
         priority={priority}
+        unoptimized={unoptimized}
       />
     );
   }
@@ -101,6 +104,7 @@ export default function CardZoomModal({
                 imageClassName="block h-auto max-h-[90dvh] w-auto max-w-[90vw] rounded-[18px] bg-white object-contain shadow-[0_28px_90px_rgba(0,0,0,0.55)] ring-1 ring-white/20"
                 fallbackClassName="flex aspect-[3/4] max-h-[90dvh] w-[min(90vw,34rem)] items-center justify-center rounded-[18px] bg-white px-6 text-center text-sm text-slate-500 shadow-[0_28px_90px_rgba(0,0,0,0.55)] ring-1 ring-white/20"
                 sizes="90vw"
+                unoptimized={unoptimized}
               />
             </div>
           </div>,
@@ -125,6 +129,7 @@ export default function CardZoomModal({
           fallbackClassName={fallbackClassName}
           sizes={sizes}
           priority={priority}
+          unoptimized={unoptimized}
         />
       </button>
 

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -64,15 +64,32 @@ test("Wall route does not eagerly fetch every custom section card grid", () => {
 
 test("public card image chooses an initial source before hydration", () => {
   const publicCardImage = readSource("components", "PublicCardImage.tsx");
+  const cardZoomModal = readSource("components", "compare", "CardZoomModal.tsx");
   const nextConfig = readFileSync(join(sourceRoot, "..", "next.config.mjs"), "utf8");
 
   assert.match(publicCardImage, /const initialSrc = normalizedPrimary \?\? normalizedFallback/);
   assert.match(publicCardImage, /useState<string \| undefined>\(initialSrc\)/);
   assert.match(publicCardImage, /Hydration must not be required just to choose the first image source/);
   assert.match(publicCardImage, /sizes=\{sizes\}/);
+  assert.match(publicCardImage, /unoptimized=\{unoptimized\}/);
+  assert.match(cardZoomModal, /unoptimized = false/);
+  assert.match(cardZoomModal, /unoptimized=\{unoptimized\}/);
   assert.match(nextConfig, /minimumCacheTTL:\s*60\s*\*\s*60\s*\*\s*24\s*\*\s*7/);
   assert.match(nextConfig, /deviceSizes:\s*\[640,\s*750,\s*828,\s*1080,\s*1200\]/);
   assert.doesNotMatch(nextConfig, /3840/);
+});
+
+test("canonical catalog image route is immutable and does not redirect through signed URLs", () => {
+  const canonImageRoute = readSource("app", "api", "canon", "image", "route.ts");
+  const cardPage = readSource("app", "card", "[gv_id]", "page.tsx");
+
+  assert.match(canonImageRoute, /normalizeWarehouseCanonImagePath/);
+  assert.match(canonImageRoute, /download\(path\)/);
+  assert.match(canonImageRoute, /max-age=31536000, immutable/);
+  assert.doesNotMatch(canonImageRoute, /NextResponse\.redirect/);
+  assert.doesNotMatch(canonImageRoute, /resolveVaultInstanceMediaUrl/);
+  assert.match(cardPage, /function isCanonImageProxyUrl/);
+  assert.match(cardPage, /unoptimized=\{isCanonImageProxyUrl\(resolvedCardImageSrc\)\}/);
 });
 
 test("explore search is bounded and language-aware for public performance", () => {


### PR DESCRIPTION
## Summary
- serve canonical catalog card images from /api/canon/image as immutable image bytes instead of redirecting through signed Storage URLs
- keep the route restricted to the existing warehouse-derived/self-hosted-images-v1 catalog prefix
- use unoptimized image delivery for card-detail hero images that already point at the canonical image proxy, while leaving grids on Next image optimization
- add regression guards for immutable image routing and card zoom unoptimized passthrough

## Verification
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- npm run web:build:strict
- pre-push shipcheck