### PR TITLE
perf: defer card detail pricing load

### DIFF
--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, type ComponentProps } from "react";
 import Link from "next/link";
 import CardZoomModal from "@/components/compare/CardZoomModal";
 import { ConditionSnapshotSection } from "@/components/condition/ConditionSnapshotSection";
@@ -43,14 +43,16 @@ import {
 import { getSiteOrigin } from "@/lib/getSiteOrigin";
 import { getConditionSnapshotsForCard } from "@/lib/condition/getConditionSnapshotsForCard";
 import { getAssignmentCandidatesForSnapshot } from "@/lib/condition/getAssignmentCandidatesForSnapshot";
-import { getCardPricingUiRowsByCardPrintId } from "@/lib/pricing/getCardPricingUiByCardPrintId";
 import type { ConditionSnapshotListItem } from "@/lib/condition/getConditionSnapshotsForCard";
 import type { AssignmentCandidate } from "@/lib/condition/getAssignmentCandidatesForSnapshot";
 import { createSlabInstance } from "@/lib/slabs/createSlabInstance";
 import { createServerComponentClient, hasSupabaseServerAuthCookie } from "@/lib/supabase/server";
 import { trackServerEvent } from "@/lib/telemetry/trackServerEvent";
 import { addCardToVault, type AddCardToVaultResult } from "@/lib/vault/addCardToVault";
-import { getOwnedPrintingCountsByCardPrintIds } from "@/lib/vault/getOwnedPrintingCountsByCardPrintIds";
+import {
+  getOwnedPrintingCountsByCardPrintIds,
+  type OwnedPrintingCountsByCardPrintId,
+} from "@/lib/vault/getOwnedPrintingCountsByCardPrintIds";
 import { getVaultInstanceHref } from "@/lib/vault/getVaultInstanceHref";
 import { getOwnedObjectSummaryForCard, type OwnedObjectSummary } from "@/lib/vault/getOwnedObjectSummaryForCard";
 import type { CardCameo, CardDetail, RelatedCardPrint } from "@/types/cards";
@@ -763,17 +765,20 @@ export default async function CardPage({
   };
   let conditionSnapshots: ConditionSnapshotListItem[] = [];
   let assignmentCandidatesBySnapshotId: Record<string, AssignmentCandidate[]> = {};
+  let ownedPrintingCounts: OwnedPrintingCountsByCardPrintId = new Map();
 
   const signedInDataStartedAt = performance.now();
   if (user && resolvedCard.id) {
     try {
-      const [ownershipSummary, snapshots] = await Promise.all([
+      const [ownershipSummary, snapshots, printingCounts] = await Promise.all([
         getOwnedObjectSummaryForCard(user.id, resolvedCard.id),
         getConditionSnapshotsForCard(user.id, resolvedCard.id),
+        getOwnedPrintingCountsByCardPrintIds(user.id, [resolvedCard.id]),
       ]);
       ownedObjectSummary = ownershipSummary;
       vaultCount = ownershipSummary.totalCount;
       conditionSnapshots = snapshots;
+      ownedPrintingCounts = printingCounts;
 
       const unassignedSnapshots = snapshots.filter((snapshot) => snapshot.assignment_state === "unassigned");
       if (unassignedSnapshots.length > 0) {
@@ -807,16 +812,12 @@ export default async function CardPage({
   const signedInDataMs = roundPerfMs(performance.now() - signedInDataStartedAt);
 
   const loginHref = `/login?next=${encodeURIComponent(currentCardPath)}`;
-  const canViewPricing = Boolean(user);
   const pricingStartedAt = performance.now();
-  const [pricingRecords, ownedPrintingCounts] = await Promise.all([
-    canViewPricing && resolvedCard.id ? getCardPricingUiRowsByCardPrintId(resolvedCard.id) : Promise.resolve([]),
-    user && resolvedCard.id
-      ? getOwnedPrintingCountsByCardPrintIds(user.id, [resolvedCard.id])
-      : Promise.resolve(new Map()),
-  ]);
+  // Pricing is intentionally client-loaded for signed-in collectors so exact
+  // card identity, hero image, and vault actions are not blocked by market RPCs.
+  const pricingRecords: ComponentProps<typeof CardPageMarketVaultPanels>["pricingRecords"] = [];
   const pricingMs = roundPerfMs(performance.now() - pricingStartedAt);
-  const pricingUi = pricingRecords.find((record) => record.pricing_scope === "parent") ?? pricingRecords[0] ?? null;
+  const pricingUi = null;
 
   const setName = typeof resolvedCard.set_name === "string" ? resolvedCard.set_name.trim() : "";
   const setCodeLabel = resolvedCard.set_code?.trim().toUpperCase();

--- a/apps/web/src/app/sitemaps/sets/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/sets/sitemap.xml/route.ts
@@ -4,6 +4,7 @@ import {
   SITEMAP_REVALIDATE_SECONDS,
 } from "@/lib/seo/sitemaps";
 
+export const dynamic = "force-dynamic";
 export const revalidate = SITEMAP_REVALIDATE_SECONDS;
 
 export async function GET() {

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -190,6 +190,7 @@ test("card detail streams lower panels after exact card information", () => {
   const cardZoomModal = readSource("components", "compare", "CardZoomModal.tsx");
   const cardPerfProbe = readSource("components", "performance", "CardPagePerformanceProbe.tsx");
   const pricingRail = readSource("components", "pricing", "CardPagePricingRail.tsx");
+  const cardPricingRoute = readSource("app", "api", "card-pricing", "route.ts");
   const serverSupabase = readSource("lib", "supabase", "server.ts");
 
   assert.match(cardPage, /const card = await getPublicCardByGvId\(params\.gv_id, \{/);
@@ -199,8 +200,10 @@ test("card detail streams lower panels after exact card information", () => {
   assert.match(cardPage, /hasSupabaseServerAuthCookie/);
   assert.match(cardPage, /shouldReadAuthenticatedState\s*\?\s*await supabase\.auth\.getUser\(\)/);
   assert.doesNotMatch(cardPage, /getSetLogoAssetPathMap/);
-  assert.match(cardPage, /getCardPricingUiRowsByCardPrintId/);
   assert.match(cardPage, /pricingRecords=\{pricingRecords\}/);
+  assert.doesNotMatch(cardPage, /getCardPricingUiRowsByCardPrintId/);
+  assert.match(cardPage, /Pricing is intentionally client-loaded/);
+  assert.match(cardPricingRoute, /getCardPricingUiRowsByCardPrintIdWithClient/);
   assert.match(cardPage, /<CardZoomModal[\s\S]*priority/);
   assert.match(cardZoomModal, /priority = false/);
   assert.match(cardZoomModal, /priority=\{priority\}/);

--- a/apps/web/src/lib/seo/sitemaps.ts
+++ b/apps/web/src/lib/seo/sitemaps.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { getSiteOrigin } from "@/lib/getSiteOrigin";
-import { getPublicSets } from "@/lib/publicSets";
 import { createServerAdminClient } from "@/lib/supabase/admin";
 
 const BASE_URL = "https://grookaivault.com";
@@ -16,7 +15,7 @@ type CardSitemapRow = {
   updated_at: string | null;
 };
 
-type SetTimestampRow = {
+type SetSitemapRow = {
   code: string | null;
   updated_at: string | null;
 };
@@ -139,31 +138,23 @@ export async function getCardSitemapEntries(pageIndex: number) {
 export async function getSetSitemapEntries() {
   const origin = getSitemapOrigin();
   const admin = createServerAdminClient();
-  const publicSets = await getPublicSets();
-  const setTimestampsByCode = new Map<string, string | null>();
-  const setCodes = publicSets.map((setInfo) => setInfo.code).filter(Boolean);
 
-  if (setCodes.length > 0) {
-    const { data, error } = await admin
-      .from("sets")
-      .select("code,updated_at")
-      .in("code", setCodes);
+  const { data, error } = await admin
+    .from("sets")
+    .select("code,updated_at")
+    .not("code", "is", null)
+    .order("code", { ascending: true });
 
-    if (error) {
-      throw new Error(error.message);
-    }
-
-    for (const row of (data ?? []) as SetTimestampRow[]) {
-      if (row.code) {
-        setTimestampsByCode.set(row.code, row.updated_at ?? null);
-      }
-    }
+  if (error) {
+    throw new Error(error.message);
   }
 
-  return publicSets.map((setInfo) => ({
-    loc: `${origin}/sets/${encodeURIComponent(setInfo.code)}`,
-    lastmod: setTimestampsByCode.get(setInfo.code),
-  }));
+  return ((data ?? []) as SetSitemapRow[])
+    .filter((setInfo): setInfo is SetSitemapRow & { code: string } => Boolean(setInfo.code))
+    .map((setInfo) => ({
+      loc: `${origin}/sets/${encodeURIComponent(setInfo.code)}`,
+      lastmod: setInfo.updated_at,
+    }));
 }
 
 export async function getPublicProfileSitemapEntries() {

--- a/tests/contracts/mee_public_pricing_bridge_variant_aware_v1.test.mjs
+++ b/tests/contracts/mee_public_pricing_bridge_variant_aware_v1.test.mjs
@@ -84,10 +84,11 @@ test("readback includes Arceus Charizard variant regression and boundary guards"
   assert.match(readback, /assigned_finish_key/);
 });
 
-test("card detail pricing reads one parent-plus-variant bundle", () => {
+test("card detail pricing client-loads one parent-plus-variant bundle", () => {
   const helper = read(helperPath);
   const route = read(routePath);
   const page = read(cardPagePath);
+  const rail = read(railPath);
 
   assert.match(helper, /\.rpc\("get_market_evidence_public_pricing_bridge_variant_aware_v1"/);
   assert.match(helper, /getCardPricingUiRowsByCardPrintIdWithClient/);
@@ -97,8 +98,11 @@ test("card detail pricing reads one parent-plus-variant bundle", () => {
   assert.match(helper, /createServerAdminClient/);
   assert.match(route, /pricingRecords/);
   assert.match(route, /getCardPricingUiRowsByCardPrintIdWithClient/);
-  assert.match(page, /getCardPricingUiRowsByCardPrintId/);
+  assert.doesNotMatch(page, /getCardPricingUiRowsByCardPrintId/);
+  assert.match(page, /Pricing is intentionally client-loaded/);
   assert.match(page, /pricingRecords=\{pricingRecords\}/);
+  assert.match(rail, /\/api\/card-pricing\?/);
+  assert.match(rail, /isLoadingPricing && !selectedPricing/);
 });
 
 test("variant selector drives pricing rail without per-click pricing fetches", () => {


### PR DESCRIPTION
## Summary
- remove signed-in pricing RPC work from the card detail server render path
- keep pricing available through the existing authenticated /api/card-pricing client loader
- batch owned printing counts with the existing signed-in ownership/snapshot reads
- update performance and pricing contracts to lock this behavior

## Verification
- node --test tests/contracts/mee_public_pricing_bridge_variant_aware_v1.test.mjs
- node --test apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- npm run web:build:strict
- pre-commit shipcheck
- pre-push shipcheck