### PR TITLE
[codex] fix trade second leg flow

### DIFF
--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, type ComponentProps } from "react";
 import Link from "next/link";
 import CardZoomModal from "@/components/compare/CardZoomModal";
 import { ConditionSnapshotSection } from "@/components/condition/ConditionSnapshotSection";
@@ -43,14 +43,16 @@ import {
 import { getSiteOrigin } from "@/lib/getSiteOrigin";
 import { getConditionSnapshotsForCard } from "@/lib/condition/getConditionSnapshotsForCard";
 import { getAssignmentCandidatesForSnapshot } from "@/lib/condition/getAssignmentCandidatesForSnapshot";
-import { getCardPricingUiRowsByCardPrintId } from "@/lib/pricing/getCardPricingUiByCardPrintId";
 import type { ConditionSnapshotListItem } from "@/lib/condition/getConditionSnapshotsForCard";
 import type { AssignmentCandidate } from "@/lib/condition/getAssignmentCandidatesForSnapshot";
 import { createSlabInstance } from "@/lib/slabs/createSlabInstance";
 import { createServerComponentClient, hasSupabaseServerAuthCookie } from "@/lib/supabase/server";
 import { trackServerEvent } from "@/lib/telemetry/trackServerEvent";
 import { addCardToVault, type AddCardToVaultResult } from "@/lib/vault/addCardToVault";
-import { getOwnedPrintingCountsByCardPrintIds } from "@/lib/vault/getOwnedPrintingCountsByCardPrintIds";
+import {
+  getOwnedPrintingCountsByCardPrintIds,
+  type OwnedPrintingCountsByCardPrintId,
+} from "@/lib/vault/getOwnedPrintingCountsByCardPrintIds";
 import { getVaultInstanceHref } from "@/lib/vault/getVaultInstanceHref";
 import { getOwnedObjectSummaryForCard, type OwnedObjectSummary } from "@/lib/vault/getOwnedObjectSummaryForCard";
 import type { CardCameo, CardDetail, RelatedCardPrint } from "@/types/cards";
@@ -763,17 +765,20 @@ export default async function CardPage({
   };
   let conditionSnapshots: ConditionSnapshotListItem[] = [];
   let assignmentCandidatesBySnapshotId: Record<string, AssignmentCandidate[]> = {};
+  let ownedPrintingCounts: OwnedPrintingCountsByCardPrintId = new Map();
 
   const signedInDataStartedAt = performance.now();
   if (user && resolvedCard.id) {
     try {
-      const [ownershipSummary, snapshots] = await Promise.all([
+      const [ownershipSummary, snapshots, printingCounts] = await Promise.all([
         getOwnedObjectSummaryForCard(user.id, resolvedCard.id),
         getConditionSnapshotsForCard(user.id, resolvedCard.id),
+        getOwnedPrintingCountsByCardPrintIds(user.id, [resolvedCard.id]),
       ]);
       ownedObjectSummary = ownershipSummary;
       vaultCount = ownershipSummary.totalCount;
       conditionSnapshots = snapshots;
+      ownedPrintingCounts = printingCounts;
 
       const unassignedSnapshots = snapshots.filter((snapshot) => snapshot.assignment_state === "unassigned");
       if (unassignedSnapshots.length > 0) {
@@ -807,16 +812,12 @@ export default async function CardPage({
   const signedInDataMs = roundPerfMs(performance.now() - signedInDataStartedAt);
 
   const loginHref = `/login?next=${encodeURIComponent(currentCardPath)}`;
-  const canViewPricing = Boolean(user);
   const pricingStartedAt = performance.now();
-  const [pricingRecords, ownedPrintingCounts] = await Promise.all([
-    canViewPricing && resolvedCard.id ? getCardPricingUiRowsByCardPrintId(resolvedCard.id) : Promise.resolve([]),
-    user && resolvedCard.id
-      ? getOwnedPrintingCountsByCardPrintIds(user.id, [resolvedCard.id])
-      : Promise.resolve(new Map()),
-  ]);
+  // Pricing is intentionally client-loaded for signed-in collectors so exact
+  // card identity, hero image, and vault actions are not blocked by market RPCs.
+  const pricingRecords: ComponentProps<typeof CardPageMarketVaultPanels>["pricingRecords"] = [];
   const pricingMs = roundPerfMs(performance.now() - pricingStartedAt);
-  const pricingUi = pricingRecords.find((record) => record.pricing_scope === "parent") ?? pricingRecords[0] ?? null;
+  const pricingUi = null;
 
   const setName = typeof resolvedCard.set_name === "string" ? resolvedCard.set_name.trim() : "";
   const setCodeLabel = resolvedCard.set_code?.trim().toUpperCase();

--- a/apps/web/src/app/sitemaps/sets/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/sets/sitemap.xml/route.ts
@@ -4,6 +4,7 @@ import {
   SITEMAP_REVALIDATE_SECONDS,
 } from "@/lib/seo/sitemaps";
 
+export const dynamic = "force-dynamic";
 export const revalidate = SITEMAP_REVALIDATE_SECONDS;
 
 export async function GET() {

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -190,6 +190,7 @@ test("card detail streams lower panels after exact card information", () => {
   const cardZoomModal = readSource("components", "compare", "CardZoomModal.tsx");
   const cardPerfProbe = readSource("components", "performance", "CardPagePerformanceProbe.tsx");
   const pricingRail = readSource("components", "pricing", "CardPagePricingRail.tsx");
+  const cardPricingRoute = readSource("app", "api", "card-pricing", "route.ts");
   const serverSupabase = readSource("lib", "supabase", "server.ts");
 
   assert.match(cardPage, /const card = await getPublicCardByGvId\(params\.gv_id, \{/);
@@ -199,8 +200,10 @@ test("card detail streams lower panels after exact card information", () => {
   assert.match(cardPage, /hasSupabaseServerAuthCookie/);
   assert.match(cardPage, /shouldReadAuthenticatedState\s*\?\s*await supabase\.auth\.getUser\(\)/);
   assert.doesNotMatch(cardPage, /getSetLogoAssetPathMap/);
-  assert.match(cardPage, /getCardPricingUiRowsByCardPrintId/);
   assert.match(cardPage, /pricingRecords=\{pricingRecords\}/);
+  assert.doesNotMatch(cardPage, /getCardPricingUiRowsByCardPrintId/);
+  assert.match(cardPage, /Pricing is intentionally client-loaded/);
+  assert.match(cardPricingRoute, /getCardPricingUiRowsByCardPrintIdWithClient/);
   assert.match(cardPage, /<CardZoomModal[\s\S]*priority/);
   assert.match(cardZoomModal, /priority = false/);
   assert.match(cardZoomModal, /priority=\{priority\}/);

--- a/apps/web/src/lib/network/getUserCardInteractions.ts
+++ b/apps/web/src/lib/network/getUserCardInteractions.ts
@@ -5,6 +5,7 @@ import {
   applyChildDisplayImageFallback,
   getChildDisplayImageFallbacks,
 } from "@/lib/cards/childDisplayImageFallbacks";
+import { resolveDisplayIdentity } from "@/lib/cards/resolveDisplayIdentity";
 import { createServerAdminClient } from "@/lib/supabase/admin";
 import { normalizeVaultIntent, type VaultIntent } from "@/lib/network/intent";
 import { resolveDisplayImageUrl } from "@/lib/publicCardImage";
@@ -37,6 +38,26 @@ type CardPrintSourceRow = {
   image_status: string | null;
   image_note: string | null;
   display_image_url?: string | null;
+  sets:
+    | {
+        name: string | null;
+        identity_model: string | null;
+      }
+    | {
+        name: string | null;
+        identity_model: string | null;
+      }[]
+    | null;
+};
+
+type TradeSourceCardRow = {
+  id: string | null;
+  gv_id: string | null;
+  name: string | null;
+  set_code: string | null;
+  number: string | null;
+  variant_key: string | null;
+  printed_identity_modifier: string | null;
   sets:
     | {
         name: string | null;
@@ -244,6 +265,34 @@ function buildOwnedInstanceLabel(row: OwnedSourceInstanceRow) {
     : [conditionLabel, gvviId];
 
   return parts.map((value) => normalizeOptionalText(value)).filter(Boolean).join(" • ") || "Owned instance";
+}
+
+function buildTradeSourceInstanceLabel(
+  row: OwnedSourceInstanceRow,
+  card: TradeSourceCardRow | null,
+) {
+  if (!card) {
+    return buildOwnedInstanceLabel(row);
+  }
+
+  const setRecord = Array.isArray(card.sets) ? card.sets[0] : card.sets;
+  const cardName = resolveDisplayIdentity({
+    name: normalizeOptionalText(card.name) ?? "Unknown card",
+    variant_key: normalizeOptionalText(card.variant_key),
+    printed_identity_modifier: normalizeOptionalText(card.printed_identity_modifier),
+    set_identity_model: normalizeOptionalText(setRecord?.identity_model),
+    set_code: normalizeOptionalText(card.set_code) ?? "Unknown set",
+    number: normalizeOptionalText(card.number) ?? "—",
+  }).display_name;
+  const setLabel = [
+    normalizeOptionalText(setRecord?.name) ?? normalizeOptionalText(card.set_code),
+    normalizeOptionalText(card.number) ? `#${normalizeOptionalText(card.number)}` : null,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const copyLabel = buildOwnedInstanceLabel(row);
+
+  return [cardName, setLabel, copyLabel].filter(Boolean).join(" • ");
 }
 
 export async function getUnreadCardInteractionGroupCount(userId: string): Promise<number> {
@@ -668,6 +717,79 @@ export async function getUserCardInteractionGroups(userId: string): Promise<User
     const candidates = tradeEventCandidatesByCounterpart.get(group.counterpartUserId) ?? [];
     group.pendingTradeExecutionEventId = candidates.length === 1 ? candidates[0] : null;
     group.hasAmbiguousPendingTradeEvent = candidates.length > 1;
+  }
+
+  const pendingTradeGroups = groupList.filter(
+    (group) => group.pendingTradeExecutionEventId && !group.hasAmbiguousPendingTradeEvent,
+  );
+
+  if (pendingTradeGroups.length > 0) {
+    const { data: tradeInstanceRows, error: tradeInstancesError } = await adminClient
+      .from("vault_item_instances")
+      .select(
+        "id,gv_vi_id,card_print_id,legacy_vault_item_id,condition_label,intent,is_graded,grade_company,grade_value,grade_label,created_at",
+      )
+      .eq("user_id", normalizedUserId)
+      .eq("intent", "trade")
+      .is("archived_at", null)
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false });
+
+    if (tradeInstancesError) {
+      throw new Error(`[network:inbox] trade source instance lookup failed: ${tradeInstancesError.message}`);
+    }
+
+    const tradeRows = (tradeInstanceRows ?? []) as OwnedSourceInstanceRow[];
+    const tradeCardPrintIds = uniqueValues(
+      tradeRows
+        .map((row) => normalizeOptionalText(row.card_print_id))
+        .filter((value): value is string => Boolean(value)),
+    );
+    const tradeCardById = new Map<string, TradeSourceCardRow>();
+
+    if (tradeCardPrintIds.length > 0) {
+      const { data: tradeCardRows, error: tradeCardError } = await adminClient
+        .from("card_prints")
+        .select("id,gv_id,name,set_code,number,variant_key,printed_identity_modifier,sets(name,identity_model)")
+        .in("id", tradeCardPrintIds);
+
+      if (tradeCardError) {
+        throw new Error(`[network:inbox] trade source card lookup failed: ${tradeCardError.message}`);
+      }
+
+      for (const row of (tradeCardRows ?? []) as TradeSourceCardRow[]) {
+        const cardPrintId = normalizeOptionalText(row.id);
+        if (cardPrintId) {
+          tradeCardById.set(cardPrintId, row);
+        }
+      }
+    }
+
+    const tradeSourceInstances = tradeRows
+      .map((row) => {
+        const cardPrintId = normalizeOptionalText(row.card_print_id);
+        return {
+          instanceId: row.id,
+          gvviId: normalizeOptionalText(row.gv_vi_id),
+          label: buildTradeSourceInstanceLabel(row, cardPrintId ? tradeCardById.get(cardPrintId) ?? null : null),
+          intent: normalizeVaultIntent(row.intent) ?? "hold",
+          conditionLabel: normalizeOptionalText(row.condition_label),
+          isGraded: Boolean(row.is_graded),
+          gradeCompany: normalizeOptionalText(row.grade_company),
+          gradeValue: normalizeOptionalText(row.grade_value),
+          gradeLabel: normalizeOptionalText(row.grade_label),
+          createdAt: row.created_at ?? null,
+        } satisfies UserCardInteractionOwnedSourceInstance;
+      })
+      .sort((left, right) => compareCreatedAtDescending(left.createdAt, right.createdAt));
+
+    for (const group of pendingTradeGroups) {
+      const existingInstanceIds = new Set(group.ownedSourceInstances.map((instance) => instance.instanceId));
+      const mergedTradeSources = tradeSourceInstances.filter((instance) => !existingInstanceIds.has(instance.instanceId));
+      group.ownedSourceInstances = [...group.ownedSourceInstances, ...mergedTradeSources].sort((left, right) =>
+        compareCreatedAtDescending(left.createdAt, right.createdAt),
+      );
+    }
   }
 
   return groupList;

--- a/apps/web/src/lib/seo/sitemaps.ts
+++ b/apps/web/src/lib/seo/sitemaps.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { getSiteOrigin } from "@/lib/getSiteOrigin";
-import { getPublicSets } from "@/lib/publicSets";
 import { createServerAdminClient } from "@/lib/supabase/admin";
 
 const BASE_URL = "https://grookaivault.com";
@@ -16,7 +15,7 @@ type CardSitemapRow = {
   updated_at: string | null;
 };
 
-type SetTimestampRow = {
+type SetSitemapRow = {
   code: string | null;
   updated_at: string | null;
 };
@@ -139,31 +138,23 @@ export async function getCardSitemapEntries(pageIndex: number) {
 export async function getSetSitemapEntries() {
   const origin = getSitemapOrigin();
   const admin = createServerAdminClient();
-  const publicSets = await getPublicSets();
-  const setTimestampsByCode = new Map<string, string | null>();
-  const setCodes = publicSets.map((setInfo) => setInfo.code).filter(Boolean);
 
-  if (setCodes.length > 0) {
-    const { data, error } = await admin
-      .from("sets")
-      .select("code,updated_at")
-      .in("code", setCodes);
+  const { data, error } = await admin
+    .from("sets")
+    .select("code,updated_at")
+    .not("code", "is", null)
+    .order("code", { ascending: true });
 
-    if (error) {
-      throw new Error(error.message);
-    }
-
-    for (const row of (data ?? []) as SetTimestampRow[]) {
-      if (row.code) {
-        setTimestampsByCode.set(row.code, row.updated_at ?? null);
-      }
-    }
+  if (error) {
+    throw new Error(error.message);
   }
 
-  return publicSets.map((setInfo) => ({
-    loc: `${origin}/sets/${encodeURIComponent(setInfo.code)}`,
-    lastmod: setTimestampsByCode.get(setInfo.code),
-  }));
+  return ((data ?? []) as SetSitemapRow[])
+    .filter((setInfo): setInfo is SetSitemapRow & { code: string } => Boolean(setInfo.code))
+    .map((setInfo) => ({
+      loc: `${origin}/sets/${encodeURIComponent(setInfo.code)}`,
+      lastmod: setInfo.updated_at,
+    }));
 }
 
 export async function getPublicProfileSitemapEntries() {

--- a/supabase/migrations/20260703090000_trade_execution_second_leg_any_trade_copy_v1.sql
+++ b/supabase/migrations/20260703090000_trade_execution_second_leg_any_trade_copy_v1.sql
@@ -1,0 +1,362 @@
+begin;
+
+create or replace function public.execute_card_interaction_outcome_v1(
+  p_execution_type text,
+  p_latest_interaction_id uuid,
+  p_source_instance_id uuid,
+  p_price_amount numeric default null,
+  p_price_currency text default null,
+  p_execution_event_id uuid default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_now timestamptz := now();
+  v_execution_type text := lower(btrim(coalesce(p_execution_type, '')));
+  v_price_currency text := upper(nullif(btrim(p_price_currency), ''));
+  v_is_second_trade_leg boolean := false;
+  v_interaction public.card_interactions%rowtype;
+  v_source_instance public.vault_item_instances%rowtype;
+  v_source_bucket public.vault_items%rowtype;
+  v_target_bucket public.vault_items%rowtype;
+  v_result_instance public.vault_item_instances%rowtype;
+  v_execution_event public.card_execution_events%rowtype;
+  v_event_leg_count integer := 0;
+  v_target_user_id uuid;
+  v_remaining_source_count integer := 0;
+  v_target_bucket_count integer := 0;
+  v_target_gv_id text;
+begin
+  if v_actor is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if v_execution_type not in ('sale', 'trade') then
+    raise exception 'invalid_execution_type' using errcode = 'P0001';
+  end if;
+
+  if p_latest_interaction_id is null then
+    raise exception 'latest_interaction_id_required' using errcode = 'P0001';
+  end if;
+
+  if p_source_instance_id is null then
+    raise exception 'source_instance_id_required' using errcode = 'P0001';
+  end if;
+
+  if p_price_amount is not null and p_price_amount < 0 then
+    raise exception 'price_amount_nonnegative_required' using errcode = 'P0001';
+  end if;
+
+  if (p_price_amount is null and v_price_currency is not null) or (p_price_amount is not null and v_price_currency is null) then
+    raise exception 'price_amount_and_currency_must_pair' using errcode = 'P0001';
+  end if;
+
+  if v_execution_type = 'sale' and p_execution_event_id is not null then
+    raise exception 'sale_does_not_accept_existing_event' using errcode = 'P0001';
+  end if;
+
+  v_is_second_trade_leg := v_execution_type = 'trade' and p_execution_event_id is not null;
+
+  select *
+  into v_interaction
+  from public.card_interactions
+  where id = p_latest_interaction_id;
+
+  if not found then
+    raise exception 'interaction_not_found' using errcode = 'P0001';
+  end if;
+
+  if v_actor <> v_interaction.sender_user_id and v_actor <> v_interaction.receiver_user_id then
+    raise exception 'interaction_participant_required' using errcode = 'P0001';
+  end if;
+
+  v_target_user_id :=
+    case
+      when v_interaction.sender_user_id = v_actor then v_interaction.receiver_user_id
+      else v_interaction.sender_user_id
+    end;
+
+  if v_target_user_id is null or v_target_user_id = v_actor then
+    raise exception 'counterpart_resolution_failed' using errcode = 'P0001';
+  end if;
+
+  select *
+  into v_source_instance
+  from public.vault_item_instances
+  where id = p_source_instance_id
+  for update;
+
+  if not found then
+    raise exception 'source_instance_not_found' using errcode = 'P0001';
+  end if;
+
+  if v_source_instance.archived_at is not null then
+    raise exception 'source_instance_already_archived' using errcode = 'P0001';
+  end if;
+
+  if v_source_instance.user_id <> v_actor then
+    raise exception 'source_instance_not_owned_by_actor' using errcode = 'P0001';
+  end if;
+
+  if v_source_instance.card_print_id is null then
+    raise exception 'source_instance_missing_card_print' using errcode = 'P0001';
+  end if;
+
+  if not v_is_second_trade_leg and v_source_instance.card_print_id <> v_interaction.card_print_id then
+    raise exception 'interaction_card_mismatch' using errcode = 'P0001';
+  end if;
+
+  if v_source_instance.legacy_vault_item_id is null then
+    raise exception 'source_instance_missing_vault_item_lineage' using errcode = 'P0001';
+  end if;
+
+  if not v_is_second_trade_leg and v_source_instance.legacy_vault_item_id <> v_interaction.vault_item_id then
+    raise exception 'interaction_vault_item_mismatch' using errcode = 'P0001';
+  end if;
+
+  if v_execution_type = 'sale' and v_source_instance.intent <> 'sell' then
+    raise exception 'source_instance_intent_sale_required' using errcode = 'P0001';
+  end if;
+
+  if v_execution_type = 'trade' and v_source_instance.intent <> 'trade' then
+    raise exception 'source_instance_intent_trade_required' using errcode = 'P0001';
+  end if;
+
+  select *
+  into v_source_bucket
+  from public.vault_items
+  where id = v_source_instance.legacy_vault_item_id
+  for update;
+
+  if not found then
+    raise exception 'source_vault_item_not_found' using errcode = 'P0001';
+  end if;
+
+  if v_source_bucket.archived_at is not null then
+    raise exception 'source_vault_item_already_archived' using errcode = 'P0001';
+  end if;
+
+  if v_source_bucket.user_id <> v_actor then
+    raise exception 'source_vault_item_not_owned_by_actor' using errcode = 'P0001';
+  end if;
+
+  if v_source_bucket.card_id <> v_source_instance.card_print_id then
+    raise exception 'source_bucket_card_mismatch' using errcode = 'P0001';
+  end if;
+
+  if p_execution_event_id is not null then
+    select *
+    into v_execution_event
+    from public.card_execution_events
+    where id = p_execution_event_id
+    for update;
+
+    if not found then
+      raise exception 'execution_event_not_found' using errcode = 'P0001';
+    end if;
+
+    if v_execution_event.execution_type <> 'trade' then
+      raise exception 'execution_event_type_mismatch' using errcode = 'P0001';
+    end if;
+
+    select count(*)
+    into v_event_leg_count
+    from public.card_interaction_outcomes outcomes
+    where outcomes.execution_event_id = v_execution_event.id;
+
+    if exists (
+      select 1
+      from public.card_interaction_outcomes outcomes
+      where outcomes.execution_event_id = v_execution_event.id
+        and (
+          outcomes.source_user_id not in (v_actor, v_target_user_id)
+          or outcomes.target_user_id not in (v_actor, v_target_user_id)
+        )
+    ) then
+      raise exception 'execution_event_participant_mismatch' using errcode = 'P0001';
+    end if;
+
+    if exists (
+      select 1
+      from public.card_interaction_outcomes outcomes
+      where outcomes.execution_event_id = v_execution_event.id
+        and outcomes.source_user_id = v_actor
+    ) then
+      raise exception 'trade_leg_already_recorded_for_actor' using errcode = 'P0001';
+    end if;
+
+    if v_event_leg_count >= 2 then
+      raise exception 'execution_event_already_complete' using errcode = 'P0001';
+    end if;
+  else
+    insert into public.card_execution_events (
+      execution_type,
+      initiated_by_user_id,
+      created_at
+    ) values (
+      v_execution_type,
+      v_actor,
+      v_now
+    )
+    returning *
+    into v_execution_event;
+  end if;
+
+  update public.vault_item_instances
+  set archived_at = v_now
+  where id = v_source_instance.id
+    and archived_at is null;
+
+  if not found then
+    raise exception 'source_instance_archive_failed' using errcode = 'P0001';
+  end if;
+
+  select count(*)
+  into v_remaining_source_count
+  from public.vault_item_instances
+  where legacy_vault_item_id = v_source_bucket.id
+    and archived_at is null;
+
+  if v_remaining_source_count <= 0 then
+    update public.vault_items
+    set
+      qty = 0,
+      archived_at = coalesce(archived_at, v_now)
+    where id = v_source_bucket.id
+      and user_id = v_actor
+      and archived_at is null
+    returning *
+    into v_source_bucket;
+  else
+    update public.vault_items
+    set qty = v_remaining_source_count
+    where id = v_source_bucket.id
+      and user_id = v_actor
+      and archived_at is null
+    returning *
+    into v_source_bucket;
+  end if;
+
+  select coalesce(nullif(btrim(v_source_bucket.gv_id), ''), nullif(btrim(cp.gv_id), ''))
+  into v_target_gv_id
+  from public.card_prints cp
+  where cp.id = v_source_instance.card_print_id;
+
+  select *
+  into v_target_bucket
+  from public.resolve_active_vault_anchor_v1(
+    p_user_id => v_target_user_id,
+    p_card_print_id => v_source_instance.card_print_id,
+    p_gv_id => v_target_gv_id,
+    p_condition_label => coalesce(v_source_instance.condition_label, v_source_bucket.condition_label, 'NM'),
+    p_notes => v_source_instance.notes,
+    p_name => coalesce(v_source_instance.name, v_source_bucket.name),
+    p_set_name => coalesce(v_source_instance.set_name, v_source_bucket.set_name),
+    p_photo_url => coalesce(v_source_instance.photo_url, v_source_bucket.photo_url),
+    p_create_if_missing => true
+  );
+
+  if v_target_bucket.id is null then
+    raise exception 'target_vault_item_resolution_failed' using errcode = 'P0001';
+  end if;
+
+  select *
+  into v_result_instance
+  from public.admin_vault_instance_create_v1(
+    p_user_id => v_target_user_id,
+    p_card_print_id => v_source_instance.card_print_id,
+    p_legacy_vault_item_id => v_target_bucket.id,
+    p_acquisition_cost => p_price_amount,
+    p_condition_label => v_source_instance.condition_label,
+    p_condition_score => v_source_instance.condition_score,
+    p_is_graded => v_source_instance.is_graded,
+    p_grade_company => v_source_instance.grade_company,
+    p_grade_value => v_source_instance.grade_value,
+    p_grade_label => v_source_instance.grade_label,
+    p_notes => v_source_instance.notes,
+    p_name => coalesce(v_source_instance.name, v_source_bucket.name),
+    p_set_name => coalesce(v_source_instance.set_name, v_source_bucket.set_name),
+    p_photo_url => coalesce(v_source_instance.photo_url, v_source_bucket.photo_url),
+    p_market_price => v_source_instance.market_price,
+    p_last_price_update => v_source_instance.last_price_update,
+    p_image_source => v_source_instance.image_source,
+    p_image_url => v_source_instance.image_url,
+    p_image_back_source => v_source_instance.image_back_source,
+    p_image_back_url => v_source_instance.image_back_url,
+    p_created_at => v_now,
+    p_card_printing_id => v_source_instance.card_printing_id
+  );
+
+  select count(*)
+  into v_target_bucket_count
+  from public.vault_item_instances
+  where legacy_vault_item_id = v_target_bucket.id
+    and archived_at is null;
+
+  update public.vault_items
+  set qty = greatest(v_target_bucket_count, 1)
+  where id = v_target_bucket.id
+    and user_id = v_target_user_id
+    and archived_at is null
+  returning *
+  into v_target_bucket;
+
+  insert into public.card_interaction_outcomes (
+    execution_event_id,
+    latest_interaction_id,
+    card_print_id,
+    source_instance_id,
+    source_vault_item_id,
+    source_user_id,
+    target_user_id,
+    result_instance_id,
+    result_vault_item_id,
+    outcome_type,
+    price_amount,
+    price_currency,
+    executed_by_user_id,
+    created_at
+  ) values (
+    v_execution_event.id,
+    v_interaction.id,
+    v_source_instance.card_print_id,
+    v_source_instance.id,
+    v_source_bucket.id,
+    v_actor,
+    v_target_user_id,
+    v_result_instance.id,
+    v_target_bucket.id,
+    v_execution_type,
+    p_price_amount,
+    v_price_currency,
+    v_actor,
+    v_now
+  );
+
+  return jsonb_build_object(
+    'execution_event_id', v_execution_event.id,
+    'latest_interaction_id', v_interaction.id,
+    'card_print_id', v_source_instance.card_print_id,
+    'source_instance_id', v_source_instance.id,
+    'source_vault_item_id', v_source_bucket.id,
+    'target_user_id', v_target_user_id,
+    'result_instance_id', v_result_instance.id,
+    'result_vault_item_id', v_target_bucket.id,
+    'outcome_type', v_execution_type,
+    'price_amount', p_price_amount,
+    'price_currency', v_price_currency
+  );
+end;
+$$;
+
+revoke all on function public.execute_card_interaction_outcome_v1(
+  text, uuid, uuid, numeric, text, uuid
+) from public, anon, authenticated;
+grant execute on function public.execute_card_interaction_outcome_v1(
+  text, uuid, uuid, numeric, text, uuid
+) to service_role;
+
+commit;

--- a/tests/contracts/mee_public_pricing_bridge_variant_aware_v1.test.mjs
+++ b/tests/contracts/mee_public_pricing_bridge_variant_aware_v1.test.mjs
@@ -84,10 +84,11 @@ test("readback includes Arceus Charizard variant regression and boundary guards"
   assert.match(readback, /assigned_finish_key/);
 });
 
-test("card detail pricing reads one parent-plus-variant bundle", () => {
+test("card detail pricing client-loads one parent-plus-variant bundle", () => {
   const helper = read(helperPath);
   const route = read(routePath);
   const page = read(cardPagePath);
+  const rail = read(railPath);
 
   assert.match(helper, /\.rpc\("get_market_evidence_public_pricing_bridge_variant_aware_v1"/);
   assert.match(helper, /getCardPricingUiRowsByCardPrintIdWithClient/);
@@ -97,8 +98,11 @@ test("card detail pricing reads one parent-plus-variant bundle", () => {
   assert.match(helper, /createServerAdminClient/);
   assert.match(route, /pricingRecords/);
   assert.match(route, /getCardPricingUiRowsByCardPrintIdWithClient/);
-  assert.match(page, /getCardPricingUiRowsByCardPrintId/);
+  assert.doesNotMatch(page, /getCardPricingUiRowsByCardPrintId/);
+  assert.match(page, /Pricing is intentionally client-loaded/);
   assert.match(page, /pricingRecords=\{pricingRecords\}/);
+  assert.match(rail, /\/api\/card-pricing\?/);
+  assert.match(rail, /isLoadingPricing && !selectedPricing/);
 });
 
 test("variant selector drives pricing rail without per-click pricing fetches", () => {

--- a/tests/contracts/trade_execution_second_leg_contract_v1.test.mjs
+++ b/tests/contracts/trade_execution_second_leg_contract_v1.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = process.cwd();
+
+function readRepoFile(...parts) {
+  return fs.readFileSync(path.join(repoRoot, ...parts), "utf8");
+}
+
+test("trade completion can expose active trade copies beyond the original card conversation", () => {
+  const source = readRepoFile("apps", "web", "src", "lib", "network", "getUserCardInteractions.ts");
+
+  assert.match(source, /pendingTradeGroups/);
+  assert.match(source, /\.eq\("intent", "trade"\)/);
+  assert.match(source, /trade source instance lookup failed/);
+  assert.match(source, /buildTradeSourceInstanceLabel/);
+  assert.match(source, /group\.ownedSourceInstances = \[\.\.\.group\.ownedSourceInstances, \.\.\.mergedTradeSources\]/);
+});
+
+test("trade execution second leg accepts a separate trade-marked source copy", () => {
+  const migration = readRepoFile(
+    "supabase",
+    "migrations",
+    "20260703090000_trade_execution_second_leg_any_trade_copy_v1.sql",
+  );
+
+  assert.match(migration, /v_is_second_trade_leg boolean := false;/);
+  assert.match(migration, /v_is_second_trade_leg := v_execution_type = 'trade' and p_execution_event_id is not null;/);
+  assert.match(migration, /if not v_is_second_trade_leg and v_source_instance\.card_print_id <> v_interaction\.card_print_id then/);
+  assert.match(migration, /if not v_is_second_trade_leg and v_source_instance\.legacy_vault_item_id <> v_interaction\.vault_item_id then/);
+  assert.match(migration, /if v_execution_type = 'trade' and v_source_instance\.intent <> 'trade' then/);
+  assert.match(migration, /p_card_printing_id => v_source_instance\.card_printing_id/);
+});


### PR DESCRIPTION
## What changed
- Allows pending trade completion groups to offer any active copy marked `Trade` owned by the current user, not only the original card from the first message thread.
- Updates `execute_card_interaction_outcome_v1` so the second leg of an existing trade bundle can use a separate trade-marked source copy while preserving exact child printing identity.
- Adds a contract test covering both the resolver surface and backend SQL guardrails.

## Why
Trades were not working end to end when the second collector needed to complete the trade using one of their own trade-marked copies. The old backend guard still required the source copy to match the original interaction card/vault item, which is correct for sale and first-leg flows but too strict for the second leg of a trade.

## Validation
- Live DB function migration applied directly and verified by reading back `execute_card_interaction_outcome_v1`.
- `node --test tests/contracts/trade_execution_second_leg_contract_v1.test.mjs`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run lint` with existing warehouse `<img>` warning only.
- `npm run contracts:test` passed 641 tests.
- Pre-commit and pre-push shipcheck both passed, including strict web build, `flutter analyze`, and full `flutter test`.

## Note
Android emulator launch started a process but did not register a device through `adb`; detached emulator processes were cleaned up. Fast Flutter test coverage still passed through the repo shipcheck.