### PR TITLE
chore: rename feed surface to pulse

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -24,7 +24,7 @@ const themeBootstrapScript = `
 function ChromeFallback({ dexEnabled }: { dexEnabled: boolean }) {
   const desktopNavItems = [
     { href: "/explore", label: "Search" },
-    { href: "/network", label: "Feed" },
+    { href: "/network", label: "Pulse" },
     { href: "/sets", label: "Sets" },
     ...(dexEnabled ? [{ href: "/dex", label: "Dex" }] : []),
     { href: "/compare", label: "Compare" },
@@ -32,7 +32,7 @@ function ChromeFallback({ dexEnabled }: { dexEnabled: boolean }) {
   ];
   const mobileNavItems = [
     { href: "/explore", label: "Search" },
-    { href: "/network", label: "Feed" },
+    { href: "/network", label: "Pulse" },
     ...(dexEnabled ? [{ href: "/dex", label: "Dex" }] : []),
     { href: "/wall", label: "Wall" },
     { href: "/vault", label: "Vault" },

--- a/apps/web/src/app/network/nearby/page.tsx
+++ b/apps/web/src/app/network/nearby/page.tsx
@@ -104,8 +104,8 @@ export default async function NearbyNetworkPage() {
       {feed.status === "error" ? (
         <PageSection spacing="compact">
           <PublicCollectionEmptyState
-            title="Nearby feed is unavailable"
-            body="The local feed could not load. Your location and private vault data were not exposed."
+            title="Nearby activity is unavailable"
+            body="Nearby activity could not load. Your location and private vault data were not exposed."
           />
         </PageSection>
       ) : null}

--- a/apps/web/src/app/wall/page.tsx
+++ b/apps/web/src/app/wall/page.tsx
@@ -236,7 +236,7 @@ export default async function WallPage() {
             </p>
           </div>
           <div className="rounded-[1.5rem] border border-slate-200 bg-slate-50 px-5 py-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Feed Window</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Activity Window</p>
             <p className="mt-2 text-3xl font-semibold text-slate-950">{feed.length}</p>
             <p className="mt-1 text-sm text-slate-600">{feed.length === 1 ? "recent item" : "recent items"}</p>
           </div>
@@ -247,7 +247,7 @@ export default async function WallPage() {
 
       {error ? (
         <section className="rounded-[2rem] border border-rose-200 bg-rose-50 px-6 py-5 text-sm text-rose-700">
-          Wall feed could not be loaded right now: {error.message}
+          Wall activity could not be loaded right now: {error.message}
         </section>
       ) : feed.length === 0 ? (
         <section className="rounded-[2rem] border border-slate-200 bg-white px-6 py-6 text-sm text-slate-600 shadow-sm">

--- a/apps/web/src/components/explore/ExploreDiscoverySections.tsx
+++ b/apps/web/src/components/explore/ExploreDiscoverySections.tsx
@@ -516,8 +516,8 @@ export default function ExploreDiscoverySections({
         </section>
       </div>
 
-      {/* LOCK: Canonical, recently confirmed, and unconfirmed feed surfaces must remain visually and structurally separated. */}
-      {/* LOCK: Do not blend trust states into a single undifferentiated feed. */}
+      {/* LOCK: Canonical, recently confirmed, and unconfirmed Pulse surfaces must remain visually and structurally separated. */}
+      {/* LOCK: Do not blend trust states into a single undifferentiated Pulse. */}
       <RecentlyConfirmedDiscoverySection cards={recentlyConfirmedCards} compareCards={compareCards} />
       <PublicProvisionalDiscoverySection cards={provisionalCards} />
     </div>

--- a/apps/web/src/components/layout/MobileBottomNav.tsx
+++ b/apps/web/src/components/layout/MobileBottomNav.tsx
@@ -183,7 +183,7 @@ export function MobileBottomNav({ wallHref, dexEnabled }: MobileBottomNavProps) 
 
   const items: MobileNavItem[] = [
     { key: "search", label: "Search", href: "/explore" },
-    { key: "feed", label: "Feed", href: "/network" },
+    { key: "feed", label: "Pulse", href: "/network" },
     { key: "scan", label: "Scan", href: "/vault/import" },
     ...(dexEnabled ? [{ key: "dex" as const, label: "Dex", href: "/dex" }] : []),
     { key: "wall", label: "Wall", href: currentWallHref },

--- a/apps/web/src/components/layout/SiteHeader.tsx
+++ b/apps/web/src/components/layout/SiteHeader.tsx
@@ -20,7 +20,7 @@ type SiteHeaderProps = {
 function NetworkLabel({ unreadCount }: { unreadCount: number }) {
   return (
     <span className="inline-flex items-center gap-2">
-      <span>Feed</span>
+      <span>Pulse</span>
       {unreadCount > 0 ? (
         <span className="inline-flex min-w-[1.35rem] items-center justify-center rounded-full bg-emerald-100 px-1.5 py-0.5 text-[11px] font-semibold text-emerald-950 ring-1 ring-emerald-200">
           {unreadCount > 99 ? "99+" : unreadCount}
@@ -61,7 +61,7 @@ export function SiteHeader({ isAuthenticated, profileHref, networkUnreadCount, d
   const accountLabel = isAuthenticated ? "Account" : "Login";
   const primaryNav = [
     { href: buildPathWithCompareCards("/explore", "", compareCards), label: "Search", matchHref: "/explore" },
-    { href: "/network", label: "Feed", matchHref: "/network" },
+    { href: "/network", label: "Pulse", matchHref: "/network" },
     { href: "/vault/import", label: "Scan", matchHref: "/vault/import" },
     { href: "/wall", label: "Wall", matchHref: "/wall" },
     { href: "/vault", label: "Vault", matchHref: "/vault" },
@@ -79,7 +79,7 @@ export function SiteHeader({ isAuthenticated, profileHref, networkUnreadCount, d
       : pathname === "/account" || pathname.startsWith("/account/")
         ? "Profile"
         : pathname === "/network" || pathname.startsWith("/network/")
-          ? "Feed"
+          ? "Pulse"
           : pathname === "/wall" || pathname.startsWith("/wall/") || pathname.startsWith("/u/")
             ? "Wall"
           : pathname === "/dex" || pathname.startsWith("/dex/")

--- a/apps/web/src/components/provisional/PublicProvisionalDiscoverySection.tsx
+++ b/apps/web/src/components/provisional/PublicProvisionalDiscoverySection.tsx
@@ -7,7 +7,7 @@ type PublicProvisionalDiscoverySectionProps = {
   cards: PublicProvisionalCard[];
 };
 
-// LOCK: Unconfirmed feed cards must remain calm, secondary, and non-canonical.
+// LOCK: Unconfirmed Pulse cards must remain calm, secondary, and non-canonical.
 // LOCK: Do not add vault, pricing, ownership, provenance, or canonical route actions here.
 export default function PublicProvisionalDiscoverySection({ cards }: PublicProvisionalDiscoverySectionProps) {
   if (cards.length === 0) {

--- a/apps/web/src/components/vault/VaultCollectionView.tsx
+++ b/apps/web/src/components/vault/VaultCollectionView.tsx
@@ -789,7 +789,7 @@ export function VaultCollectionView({
 
         {recentError ? (
           <div className="rounded-[2rem] border border-rose-200 bg-rose-50 px-6 py-5 text-sm text-rose-700">
-            Recently added feed could not be loaded right now: {recentError}
+            Recently added activity could not be loaded right now: {recentError}
           </div>
         ) : recent.length === 0 ? (
           <PublicCollectionEmptyState

--- a/apps/web/src/lib/network/getLocalCommunityFeedRows.ts
+++ b/apps/web/src/lib/network/getLocalCommunityFeedRows.ts
@@ -205,7 +205,7 @@ export async function getLocalCommunityFeedRows({
       status: "error",
       rows: [],
       setting: null,
-      message: error instanceof Error ? error.message : "Local community feed is unavailable.",
+      message: error instanceof Error ? error.message : "Local community activity is unavailable.",
     };
   }
 }

--- a/apps/web/src/lib/provisional/getDiscoveryProvisionalCards.ts
+++ b/apps/web/src/lib/provisional/getDiscoveryProvisionalCards.ts
@@ -7,7 +7,7 @@ import type { PublicProvisionalCard } from "@/lib/provisional/publicProvisionalT
 const DISCOVERY_PROVISIONAL_CARD_LIMIT = 6;
 
 // LOCK: Discovery provisional cards must come only from the public provisional adapter.
-// LOCK: Never expose raw warehouse rows in feed surfaces.
+// LOCK: Never expose raw warehouse rows in Pulse surfaces.
 export const getDiscoveryProvisionalCards = cache(async function getDiscoveryProvisionalCards(
   limit = DISCOVERY_PROVISIONAL_CARD_LIMIT,
 ): Promise<PublicProvisionalCard[]> {

--- a/apps/web/src/lib/provisional/provisionalProductCopy.ts
+++ b/apps/web/src/lib/provisional/provisionalProductCopy.ts
@@ -4,7 +4,7 @@ export const PROVISIONAL_DETAIL_TRUST_COPY = "Visible while under review.";
 export const PROVISIONAL_NOT_CANON_COPY = "Not part of the canonical catalog yet.";
 export const PROVISIONAL_SOURCE_COPY = "Source available";
 
-// LOCK: Feed trust language must stay short, calm, and non-technical.
+// LOCK: Pulse trust language must stay short, calm, and non-technical.
 export function getProvisionalDisplayLabel(card: Pick<PublicProvisionalCard, "provisional_label">) {
   return card.provisional_label === "UNCONFIRMED" ? "Unconfirmed" : "Under Review";
 }

--- a/docs/audits/ui_cohesion_v1/grookai_app_source_of_truth_ui_audit_v1.json
+++ b/docs/audits/ui_cohesion_v1/grookai_app_source_of_truth_ui_audit_v1.json
@@ -7,7 +7,7 @@
   "ui_implementation_changes": false,
   "source_of_truth": {
     "product": "actual_flutter_app",
-    "primary_navigation": ["Search", "Feed", "Scan", "Wall", "Vault"],
+    "primary_navigation": ["Search", "Pulse", "Scan", "Wall", "Vault"],
     "design_principles": [
       "behavior_first_navigation",
       "compact_premium_surfaces",
@@ -45,8 +45,8 @@
   "high_priority_mismatches": [
     {
       "area": "mobile_navigation",
-      "current_web": ["Search", "Feed", "Wall", "Vault", "Profile"],
-      "actual_app": ["Search", "Feed", "Scan", "Wall", "Vault"],
+      "current_web": ["Search", "Pulse", "Wall", "Vault", "Profile"],
+      "actual_app": ["Search", "Pulse", "Scan", "Wall", "Vault"],
       "recommendation": "Move Profile out of primary bottom navigation and add Scan as the center primary action."
     },
     {

--- a/docs/audits/ui_cohesion_v1/grookai_app_source_of_truth_ui_audit_v1.md
+++ b/docs/audits/ui_cohesion_v1/grookai_app_source_of_truth_ui_audit_v1.md
@@ -51,7 +51,7 @@ Primary web files reviewed:
 The actual app primary navigation is:
 
 ```text
-Search, Feed, Scan, Wall, Vault
+Search, Pulse, Scan, Wall, Vault
 ```
 
 This is documented in `lib/main_shell.dart` as the bottom navigation direction. Scan is a central primary action. Profile/account is not treated as a bottom-nav destination.
@@ -106,13 +106,13 @@ They do not read like admin tables.
 Current web mobile nav is:
 
 ```text
-Search, Feed, Wall, Vault, Profile
+Search, Pulse, Wall, Vault, Profile
 ```
 
 Actual app nav is:
 
 ```text
-Search, Feed, Scan, Wall, Vault
+Search, Pulse, Scan, Wall, Vault
 ```
 
 This is the strongest cohesion gap. It makes the web app feel like a different product.
@@ -205,7 +205,7 @@ Goal: make the web app immediately feel like the real app.
 
 Tasks:
 
-- update mobile bottom nav to `Search, Feed, Scan, Wall, Vault`
+- update mobile bottom nav to `Search, Pulse, Scan, Wall, Vault`
 - make Scan the center primary action
 - move Profile out of primary bottom navigation
 - align header spacing, surface, and typography with app shell

--- a/docs/audits/ui_cohesion_v1/web_shell_parity_phase1_v1.md
+++ b/docs/audits/ui_cohesion_v1/web_shell_parity_phase1_v1.md
@@ -11,7 +11,7 @@ Begin aligning the web app shell with the actual Grookai app shell.
 The app source-of-truth primary navigation is:
 
 ```text
-Search, Feed, Scan, Wall, Vault
+Search, Pulse, Scan, Wall, Vault
 ```
 
 ## Changes
@@ -24,13 +24,13 @@ Updated:
 
 Implemented:
 
-- Mobile bottom navigation now uses `Search, Feed, Scan, Wall, Vault`.
+- Mobile bottom navigation now uses `Search, Pulse, Scan, Wall, Vault`.
 - Profile was removed from the primary mobile dock.
 - Scan is the center dock action.
 - Scan currently routes to `/vault/import`, the closest existing web scan/import entry point.
 - Desktop header now prioritizes behavior-first app navigation:
   - Search
-  - Feed
+  - Pulse
   - Scan
   - Wall
   - Vault

--- a/docs/contracts/DEX_CARD_HIERARCHY_POLISH_V1.md
+++ b/docs/contracts/DEX_CARD_HIERARCHY_POLISH_V1.md
@@ -57,7 +57,7 @@ The whole card may remain clickable. A separate `OPEN` button is not required.
 
 ## Guardrails
 
-- Keep nav labels: Search, Feed, Scan, Dex, Wall, Vault.
+- Keep nav labels: Search, Pulse, Scan, Dex, Wall, Vault.
 - Preserve dark mode tokens and safe-area behavior.
 - Preserve existing Dex search.
 - Preserve existing Dex routes.

--- a/docs/contracts/DISCOVERY_FIRST_EXPERIENCE_V1.md
+++ b/docs/contracts/DISCOVERY_FIRST_EXPERIENCE_V1.md
@@ -7,12 +7,12 @@ Make Grookai feel like a collector intelligence system, not a card database.
 The navigation names stay stable:
 
 - Search
-- Feed
+- Pulse
 - Dex
 - Wall
 - Vault
 
-The product upgrade is not renaming surfaces. The upgrade is exposing the relationships Grookai already knows:
+The product upgrade keeps the behavior-first surfaces clear. Pulse is the activity and discovery surface; the upgrade is exposing the relationships Grookai already knows:
 
 - card identities
 - child printings
@@ -72,13 +72,13 @@ Required behavior:
 - Dex must reflect vault ownership
 - Dex must link back into Search for cards, cameos, variants, and missing printings
 
-### 4. Feed and Wall Remain Tangible
+### 4. Pulse and Wall Remain Tangible
 
 Do not replace them with generic "Community".
 
 Required behavior:
 
-- Feed should show activity and discovery
+- Pulse should show activity and discovery
 - Wall should show collector identity
 - both surfaces should connect back to cards, sets, Dex, and variant families
 
@@ -91,7 +91,7 @@ Collector
   Search
   Dex
   Vault
-  Feed
+  Pulse
   Wall
 ```
 
@@ -216,4 +216,3 @@ This phase succeeds when:
 - variant/stamp/error families are visible as first-class collector concepts
 - navigation names remain stable
 - no canonical data behavior changes are required
-

--- a/docs/plans/product_evolution/E6_PLAN.md
+++ b/docs/plans/product_evolution/E6_PLAN.md
@@ -193,7 +193,7 @@ Why a separate table instead of `card_events`:
 
 ### Entry Conditions
 
-Show E6 onboarding on the first Feed/Search landing only when all are true:
+Show E6 onboarding on the first Pulse/Search landing only when all are true:
 
 - signed in
 - `onboarding_ladder_state_v1().is_complete=false`
@@ -436,6 +436,6 @@ Required before E6 merge:
 
 1. PR 1 uses the bridge approach: `user_card_intents.want` syncs to `wishlist_items` through a DB trigger.
 2. PR 4 UI is design-gated like E4/E5.
-3. Onboarding appears on the first Feed/Search landing with no owned/wanted state, not immediately at signup.
+3. Onboarding appears on the first Pulse/Search landing with no owned/wanted state, not immediately at signup.
 4. Users with owned + wanted but no follows see collector suggestions only.
 5. `rung_3_first_message` counts on either participant's first card message.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4391,8 +4391,8 @@ class HomePageState extends State<HomePage> {
                 const SizedBox(width: 8),
                 IconButton.filledTonal(
                   tooltip: showFeedDebugOverlay
-                      ? 'Hide feed debug overlay'
-                      : 'Show feed debug overlay',
+                      ? 'Hide Pulse debug overlay'
+                      : 'Show Pulse debug overlay',
                   onPressed: () {
                     setState(() {
                       _showFeedDebugOverlay = !_showFeedDebugOverlay;

--- a/lib/main_shell.dart
+++ b/lib/main_shell.dart
@@ -27,9 +27,9 @@ enum _ExploreHeaderAction { dex, sets, compare }
 
 enum _ShellDestination {
   // BOTTOM_NAV_LUXURY_PASS_V1
-  // Primary app navigation is behavior-first: Search, Feed, Scan, Wall, Vault.
+  // Primary app navigation is behavior-first: Search, Pulse, Scan, Wall, Vault.
   search(navIndex: 0, stackIndex: 0, title: 'Search'),
-  feed(navIndex: 1, stackIndex: 1, title: 'Feed'),
+  feed(navIndex: 1, stackIndex: 1, title: 'Pulse'),
   wall(navIndex: 3, stackIndex: 2, title: 'Wall'),
   vault(navIndex: 4, stackIndex: 3, title: 'Vault');
 
@@ -1020,7 +1020,7 @@ class _AppShellState extends State<AppShell> {
                       child: _buildDockButton(
                         colorScheme: colorScheme,
                         navIndex: 1,
-                        label: 'Feed',
+                        label: 'Pulse',
                         icon: Icons.dynamic_feed_rounded,
                         collapsed: collapsed,
                         badgeCount: _pulseUnreadCount,
@@ -1271,7 +1271,7 @@ class _GrookaiDesktopRail extends StatelessWidget {
             ),
             _GrookaiRailTile(
               icon: Icons.dynamic_feed_rounded,
-              label: 'Feed',
+              label: 'Pulse',
               selected: currentDestination == _ShellDestination.feed,
               onTap: onOpenFeed,
             ),
@@ -2087,7 +2087,7 @@ class _LoginPageState extends State<LoginPage> {
                               ],
                               const SizedBox(height: 22),
                               Text(
-                                'Use one Grookai identity across your vault, wall, and collector feed.',
+                                'Use one Grookai identity across your vault, wall, and Pulse.',
                                 textAlign: TextAlign.center,
                                 style: textTheme.bodySmall?.copyWith(
                                   color: Colors.white.withValues(alpha: 0.46),

--- a/lib/screens/network/network_screen.dart
+++ b/lib/screens/network/network_screen.dart
@@ -684,7 +684,7 @@ class NetworkScreenState extends State<NetworkScreen> {
                   ),
                 ),
               // PERFORMANCE_P1_NETWORK_LAZY_RENDER
-              // Uses lazy sliver rendering so Network feed scales without
+              // Uses lazy sliver rendering so Pulse scales without
               // eager whole-page builds in grid or list modes.
               if (_segment == _NetworkHomeSegment.pulse)
                 _PulseContentSliver(
@@ -1634,7 +1634,7 @@ class _NetworkRefreshingBanner extends StatelessWidget {
                 child: Text(
                   fromCache
                       ? 'Showing recent cards while refreshing'
-                      : 'Refreshing feed',
+                      : 'Refreshing Pulse',
                   style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     color: colorScheme.onSurface.withValues(alpha: 0.68),
                     fontWeight: FontWeight.w700,
@@ -1768,9 +1768,9 @@ class _NetworkStreamResultsSliver extends StatelessWidget {
           }
           final rowIndex = index ~/ 2;
           // FEED_CHIP_REMOVAL_V1
-          // Removed redundant lower-row view controls so the Feed screen keeps
+          // Removed redundant lower-row view controls so the Pulse screen keeps
           // only real content filters and always renders in the default
-          // comfortable/feed card layout.
+          // comfortable Pulse card layout.
           return _buildCard(
             context,
             rows[rowIndex],

--- a/lib/services/network/network_stream_service.dart
+++ b/lib/services/network/network_stream_service.dart
@@ -2207,7 +2207,7 @@ class NetworkStreamService {
   }) {
     // TASTE_FUNCTION_HOOK_V2:
     // live inputs currently used:
-    // - recent Network feed opens / taps recorded in-session
+    // - recent Pulse opens / taps recorded in-session
     // placeholder inputs left for later:
     // - recent vault adds
     // - recent inquiries/messages

--- a/test/app_flow_prod_readiness_test.dart
+++ b/test/app_flow_prod_readiness_test.dart
@@ -104,7 +104,7 @@ void main() {
     ).firstMatch(shell)!.group(0)!;
 
     expect(bottomNavBlock, contains("label: 'Search'"));
-    expect(bottomNavBlock, contains("label: 'Feed'"));
+    expect(bottomNavBlock, contains("label: 'Pulse'"));
     expect(bottomNavBlock, contains("label: 'Scan'"));
     expect(bottomNavBlock, contains("label: 'Wall'"));
     expect(bottomNavBlock, contains("label: 'Vault'"));
@@ -123,7 +123,7 @@ void main() {
       r'class _GrookaiAppDrawer extends StatelessWidget[\s\S]*?class _GrookaiDrawerTile',
     ).firstMatch(shell)!.group(0)!;
 
-    for (final label in ['Search', 'Feed', 'Wall', 'Vault']) {
+    for (final label in ['Search', 'Pulse', 'Wall', 'Vault']) {
       expect(bottomNavBlock, contains("label: '$label'"));
       expect(drawerBlock, isNot(contains("label: '$label'")));
     }
@@ -252,7 +252,7 @@ void main() {
     expect(vault, contains("detailsLabel: 'Manage card'"));
   });
 
-  test('Feed inventory cards stay card-first and avoid FOMO hook copy', () {
+  test('Pulse inventory cards stay card-first and avoid FOMO hook copy', () {
     final networkCard = File(
       'lib/widgets/network/network_interaction_card.dart',
     ).readAsStringSync();

--- a/test/app_wall_sections_parity_test.dart
+++ b/test/app_wall_sections_parity_test.dart
@@ -41,7 +41,7 @@ void main() {
     },
   );
 
-  test('app network feed preserves uploaded copy display images', () {
+  test('app Pulse preserves uploaded copy display images', () {
     expect(networkStreamService, contains('display_image_url'));
     expect(networkStreamService, contains('display_image_kind'));
     expect(

--- a/test/local_community_feed_mobile_test.dart
+++ b/test/local_community_feed_mobile_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('mobile nearby feed uses the governed RPC contract only', () {
+  test('mobile nearby surface uses the governed RPC contract only', () {
     final service = File(
       'lib/services/network/local_community_feed_service.dart',
     ).readAsStringSync();

--- a/test/public_wall_sections_rendering_test.dart
+++ b/test/public_wall_sections_rendering_test.dart
@@ -165,7 +165,7 @@ void main() {
     expect(gridSource, contains('key={cardKey}'));
   });
 
-  test('network feed selects and resolves instance display images', () {
+  test('Pulse selects and resolves instance display images', () {
     expect(networkStreamSource, contains('display_image_url'));
     expect(networkStreamSource, contains('display_image_kind'));
     expect(networkStreamSource, contains('resolveVaultInstanceMediaUrl'));

--- a/test/pulse_ui_integration_test.dart
+++ b/test/pulse_ui_integration_test.dart
@@ -41,4 +41,31 @@ void main() {
     expect(mainShell, contains('GrookaiCanonicalRouteKind.feed'));
     expect(mainShell, contains('openPulse'));
   });
+
+  test('Pulse navigation copy does not regress to Feed labels', () {
+    final mainShell = File('lib/main_shell.dart').readAsStringSync();
+    final main = File('lib/main.dart').readAsStringSync();
+    final networkScreen = File(
+      'lib/screens/network/network_screen.dart',
+    ).readAsStringSync();
+
+    expect(mainShell, contains("title: 'Pulse'"));
+    expect(mainShell, contains("label: 'Pulse'"));
+    expect(
+      mainShell,
+      contains('Use one Grookai identity across your vault, wall, and Pulse.'),
+    );
+    expect(main, contains('Hide Pulse debug overlay'));
+    expect(main, contains('Show Pulse debug overlay'));
+    expect(networkScreen, contains('Refreshing Pulse'));
+    expect(networkScreen, contains('Show older Pulse'));
+    expect(networkScreen, contains('Unable to load Pulse'));
+
+    expect(mainShell, isNot(contains("title: 'Feed'")));
+    expect(mainShell, isNot(contains("label: 'Feed'")));
+    expect(mainShell, isNot(contains('collector feed')));
+    expect(main, isNot(contains('Hide feed debug overlay')));
+    expect(main, isNot(contains('Show feed debug overlay')));
+    expect(networkScreen, isNot(contains('Refreshing feed')));
+  });
 }

--- a/tests/contracts/e6_onboarding_contracts_v1.test.mjs
+++ b/tests/contracts/e6_onboarding_contracts_v1.test.mjs
@@ -68,7 +68,7 @@ test("E6 plan records the approved amendments in-body", () => {
 
   assert.match(plan, /uses the bridge approach/i);
   assert.match(plan, /PR 4 UI is design-gated/i);
-  assert.match(plan, /first Feed\/Search landing/i);
+  assert.match(plan, /first Pulse\/Search landing/i);
   assert.match(plan, /owned \+ wanted but no follows see collector suggestions only/i);
   assert.match(plan, /either participant's first card message/i);
 });

--- a/tests/contracts/pulse_navigation_copy_contract_v1.test.mjs
+++ b/tests/contracts/pulse_navigation_copy_contract_v1.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function readSource(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+}
+
+test("web shell uses Pulse as the visible network surface label", () => {
+  const siteHeader = readSource("apps/web/src/components/layout/SiteHeader.tsx");
+  const mobileBottomNav = readSource("apps/web/src/components/layout/MobileBottomNav.tsx");
+  const layoutFallback = readSource("apps/web/src/app/layout.tsx");
+
+  assert.match(siteHeader, /<span>Pulse<\/span>/);
+  assert.match(siteHeader, /label: "Pulse", matchHref: "\/network"/);
+  assert.match(siteHeader, /\? "Pulse"/);
+  assert.match(mobileBottomNav, /key: "feed", label: "Pulse", href: "\/network"/);
+  assert.match(layoutFallback, /href: "\/network", label: "Pulse"/);
+
+  for (const source of [siteHeader, mobileBottomNav, layoutFallback]) {
+    assert.doesNotMatch(source, /label: "Feed"/);
+    assert.doesNotMatch(source, />Feed</);
+    assert.doesNotMatch(source, /\? "Feed"/);
+  }
+});
+
+test("web visible error copy avoids obsolete feed wording", () => {
+  const wallPage = readSource("apps/web/src/app/wall/page.tsx");
+  const vaultCollection = readSource("apps/web/src/components/vault/VaultCollectionView.tsx");
+  const nearbyPage = readSource("apps/web/src/app/network/nearby/page.tsx");
+  const localCommunityHelper = readSource("apps/web/src/lib/network/getLocalCommunityFeedRows.ts");
+
+  assert.match(wallPage, /Activity Window/);
+  assert.match(wallPage, /Wall activity could not be loaded right now/);
+  assert.match(vaultCollection, /Recently added activity could not be loaded right now/);
+  assert.match(nearbyPage, /Nearby activity is unavailable/);
+  assert.match(nearbyPage, /Nearby activity could not load/);
+  assert.match(localCommunityHelper, /Local community activity is unavailable/);
+
+  for (const source of [wallPage, vaultCollection, nearbyPage, localCommunityHelper]) {
+    assert.doesNotMatch(source, /Feed Window/);
+    assert.doesNotMatch(source, /Wall feed could not be loaded/);
+    assert.doesNotMatch(source, /Recently added feed could not be loaded/);
+    assert.doesNotMatch(source, /Nearby feed is unavailable/);
+    assert.doesNotMatch(source, /local feed could not load/i);
+    assert.doesNotMatch(source, /Local community feed is unavailable/);
+  }
+});
+
+test("active product guidance records Pulse in primary navigation", () => {
+  const discoveryContract = readSource("docs/contracts/DISCOVERY_FIRST_EXPERIENCE_V1.md");
+  const dexContract = readSource("docs/contracts/DEX_CARD_HIERARCHY_POLISH_V1.md");
+  const webShellAudit = readSource("docs/audits/ui_cohesion_v1/web_shell_parity_phase1_v1.md");
+  const sourceOfTruthAudit = readSource("docs/audits/ui_cohesion_v1/grookai_app_source_of_truth_ui_audit_v1.md");
+
+  for (const source of [discoveryContract, dexContract, webShellAudit, sourceOfTruthAudit]) {
+    assert.match(source, /Pulse/);
+    assert.doesNotMatch(source, /Search, Feed/);
+  }
+
+  assert.match(discoveryContract, /Pulse is the activity and discovery surface/);
+  assert.doesNotMatch(discoveryContract, /not renaming surfaces/);
+});


### PR DESCRIPTION
## Summary

Renames the visible Feed surface to Pulse across Flutter, web shell/navigation, visible error copy, and active product guidance docs.

Keeps internal/canonical `feed` route and service names intact for compatibility, including `/feed?segment=pulse`, analytics surfaces, and Instagram Feed export wording.

## Validation

- Full pre-commit shipcheck passed in the main worktree when committing `0f6d06f8`.
- Full pre-push shipcheck passed in the main worktree before the dirty-worktree guard blocked the push.
- Clean branch contract checks passed:
  - `node --test tests\contracts\pulse_navigation_copy_contract_v1.test.mjs tests\contracts\e6_onboarding_contracts_v1.test.mjs`
- Debug APK was built, installed on Samsung, and visually verified with Pulse header/tab/bottom-nav.

## Notes

This PR is intentionally scoped to the Pulse rename. It was cherry-picked onto `origin/main` as a clean branch so earlier unrelated local Grookai Objects/ownership work stays out of this PR.