### PR TITLE
fix: render canonical card images

### DIFF
--- a/apps/web/src/app/api/canon/cards/[gv_id]/image/route.ts
+++ b/apps/web/src/app/api/canon/cards/[gv_id]/image/route.ts
@@ -72,7 +72,9 @@ export async function GET(
 
   return new NextResponse(await data.arrayBuffer(), {
     headers: {
-      "Cache-Control": "no-store, max-age=0",
+      "Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=600",
+      "CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+      "Vercel-CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
       "Content-Type": data.type || getContentTypeForPath(imagePath),
     },
   });

--- a/apps/web/src/app/card/[gv_id]/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/page.tsx
@@ -20,6 +20,7 @@ import CardImageTruthBadge from "@/components/cards/CardImageTruthBadge";
 import CardPagePerformanceProbe from "@/components/performance/CardPagePerformanceProbe";
 import { buildGrookaiVariantExplanationFromPublicCopy } from "@/lib/ai/grookaiVariantExplanationBuilder";
 import { buildTcgDexImageUrl } from "@/lib/cards/buildTcgDexImageUrl";
+import { normalizeCanonCardImageProxyUrl } from "@/lib/canon/canonImageProxy";
 import {
   formatPublicJourneyCountsLine,
   getPublicCardJourneyCounts,
@@ -140,7 +141,8 @@ function buildExactExternalImageFallback(primaryImageUrl: string | null | undefi
 }
 
 function isCanonImageProxyUrl(value: string | null | undefined) {
-  return value?.startsWith("/api/canon/image?") ?? false;
+  if (!value) return false;
+  return value.startsWith("/api/canon/image?") || Boolean(normalizeCanonCardImageProxyUrl(value));
 }
 
 function formatReleaseDate(releaseDate?: string) {

--- a/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
+++ b/apps/web/src/components/performance/publicRenderingCacheGuards.test.mjs
@@ -81,16 +81,26 @@ test("public card image chooses an initial source before hydration", () => {
   assert.doesNotMatch(nextConfig, /3840/);
 });
 
-test("canonical catalog image route is immutable and does not redirect through signed URLs", () => {
+test("canonical catalog image routes use safe cache policies and do not redirect through signed URLs", () => {
   const canonImageRoute = readSource("app", "api", "canon", "image", "route.ts");
+  const canonCardImageRoute = readSource("app", "api", "canon", "cards", "[gv_id]", "image", "route.ts");
+  const publicCardImageHelper = readSource("lib", "publicCardImage.ts");
   const cardPage = readSource("app", "card", "[gv_id]", "page.tsx");
 
   assert.match(canonImageRoute, /normalizeWarehouseCanonImagePath/);
   assert.match(canonImageRoute, /download\(path\)/);
   assert.match(canonImageRoute, /max-age=31536000, immutable/);
+  assert.match(canonCardImageRoute, /download\(imagePath\)/);
+  assert.match(canonCardImageRoute, /CDN-Cache-Control/);
+  assert.match(canonCardImageRoute, /Vercel-CDN-Cache-Control/);
+  assert.match(canonCardImageRoute, /s-maxage=300, stale-while-revalidate=600/);
+  assert.doesNotMatch(canonCardImageRoute, /31536000, immutable/);
+  assert.match(publicCardImageHelper, /normalizeCanonCardImageProxyUrl\(normalized\)/);
   assert.doesNotMatch(canonImageRoute, /NextResponse\.redirect/);
+  assert.doesNotMatch(canonCardImageRoute, /NextResponse\.redirect/);
   assert.doesNotMatch(canonImageRoute, /resolveVaultInstanceMediaUrl/);
   assert.match(cardPage, /function isCanonImageProxyUrl/);
+  assert.match(cardPage, /Boolean\(normalizeCanonCardImageProxyUrl\(value\)\)/);
   assert.match(cardPage, /unoptimized=\{isCanonImageProxyUrl\(resolvedCardImageSrc\)\}/);
 });
 

--- a/apps/web/src/lib/canon/canonImageProxy.ts
+++ b/apps/web/src/lib/canon/canonImageProxy.ts
@@ -107,3 +107,20 @@ export function buildCanonCardImageProxyUrl(gvId: string | null | undefined) {
   const normalizedGvId = normalizeCanonImageGvId(gvId);
   return normalizedGvId ? `/api/canon/cards/${encodeURIComponent(normalizedGvId)}/image` : null;
 }
+
+export function normalizeCanonCardImageProxyUrl(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = value.trim().match(/^\/api\/canon\/cards\/([^/?#]+)\/image$/);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    return buildCanonCardImageProxyUrl(decodeURIComponent(match[1]));
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/publicCardImage.ts
+++ b/apps/web/src/lib/publicCardImage.ts
@@ -1,6 +1,7 @@
 import {
   buildCanonImageProxyUrlFromStorageUrl,
   isPrivateCardImagePublicUrl,
+  normalizeCanonCardImageProxyUrl,
 } from "@/lib/canon/canonImageProxy";
 
 const NEXT_IMAGE_PATHNAME = "/_next/image";
@@ -88,8 +89,12 @@ export function normalizePublicCardImageSrc(value: string | null | undefined) {
   }
 
   const normalized = normalizePublicCardImageUrl(value.trim());
+  const canonCardProxyUrl = normalizeCanonCardImageProxyUrl(normalized);
   if (normalized.startsWith("/api/canon/image?path=")) {
     return normalized;
+  }
+  if (canonCardProxyUrl) {
+    return canonCardProxyUrl;
   }
 
   return isUsablePublicImageUrl(normalized) ? normalized : undefined;

--- a/tests/contracts/image_surface_consistency_v1.test.mjs
+++ b/tests/contracts/image_surface_consistency_v1.test.mjs
@@ -68,6 +68,7 @@ test("canon identity images prefer stable card image routes over raw signed URLs
   const resolver = source("apps/web/src/lib/canon/resolveCanonImageV1.ts");
   const route = source("apps/web/src/app/api/canon/cards/[gv_id]/image/route.ts");
   const batchRoute = source("apps/web/src/app/api/canon/images/route.ts");
+  const publicImageResolver = source("apps/web/src/lib/publicCardImage.ts");
 
   assert.match(proxy, /buildCanonCardImageProxyUrl/);
   assert.match(proxy, /warehouse-derived\/self-hosted-images-v1\//);
@@ -80,7 +81,11 @@ test("canon identity images prefer stable card image routes over raw signed URLs
   assert.match(route, /\.from\("card_printings"\)/);
   assert.match(route, /\.select\("printing_gv_id,image_source,image_path"\)/);
   assert.match(route, /\.download\(imagePath\)/);
-  assert.match(route, /"Cache-Control": "no-store, max-age=0"/);
+  assert.match(route, /"Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=600"/);
+  assert.match(route, /"CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=600"/);
+  assert.match(route, /"Vercel-CDN-Cache-Control": "public, s-maxage=300, stale-while-revalidate=600"/);
+  assert.doesNotMatch(route, /31536000, immutable/);
+  assert.match(publicImageResolver, /normalizeCanonCardImageProxyUrl\(normalized\)/);
   assert.match(batchRoute, /\.from\("card_prints"\)/);
   assert.match(batchRoute, /\.from\("card_printings"\)/);
   assert.match(batchRoute, /buildCanonCardImageProxyUrl\(row\.gv_id \?\? row\.printing_gv_id\)/);

--- a/tests/contracts/private_catalog_image_delivery_v1.test.mjs
+++ b/tests/contracts/private_catalog_image_delivery_v1.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { normalizeCanonCardImageProxyUrl } from "../../apps/web/src/lib/canon/canonImageProxy.ts";
 
 const ROOT = process.cwd();
 
@@ -26,6 +27,18 @@ test("legacy private catalog URLs are routed through the bounded canon proxy", (
 test("the catalog image proxy is CDN-cacheable and remains prefix restricted", () => {
   const proxy = readSource("apps", "web", "src", "lib", "canon", "canonImageProxy.ts");
   const route = readSource("apps", "web", "src", "app", "api", "canon", "image", "route.ts");
+  const cardRoute = readSource(
+    "apps",
+    "web",
+    "src",
+    "app",
+    "api",
+    "canon",
+    "cards",
+    "[gv_id]",
+    "image",
+    "route.ts",
+  );
 
   assert.match(proxy, /WAREHOUSE_CANON_IMAGE_PREFIXES\.some/);
   assert.match(route, /normalizeWarehouseCanonImagePath/);
@@ -33,4 +46,40 @@ test("the catalog image proxy is CDN-cacheable and remains prefix restricted", (
   assert.match(route, /Vercel-CDN-Cache-Control/);
   assert.match(route, /\.from\(VAULT_INSTANCE_MEDIA_BUCKET\)/);
   assert.match(route, /\.download\(path\)/);
+  assert.match(cardRoute, /CDN-Cache-Control/);
+  assert.match(cardRoute, /Vercel-CDN-Cache-Control/);
+  assert.match(cardRoute, /s-maxage=300, stale-while-revalidate=600/);
+  assert.doesNotMatch(cardRoute, /31536000, immutable/);
+});
+
+test("stable card image proxy URLs survive the public image safety boundary", () => {
+  const proxy = readSource("apps", "web", "src", "lib", "canon", "canonImageProxy.ts");
+  const resolver = readSource("apps", "web", "src", "lib", "publicCardImage.ts");
+
+  assert.match(proxy, /normalizeCanonCardImageProxyUrl/);
+  assert.match(proxy, /buildCanonCardImageProxyUrl\(decodeURIComponent\(match\[1\]\)\)/);
+  assert.match(resolver, /normalizeCanonCardImageProxyUrl\(normalized\)/);
+  assert.match(resolver, /if \(canonCardProxyUrl\)/);
+
+  assert.equal(
+    normalizeCanonCardImageProxyUrl("/api/canon/cards/GV-PK-OBF-001/image"),
+    "/api/canon/cards/GV-PK-OBF-001/image",
+  );
+  assert.equal(
+    normalizeCanonCardImageProxyUrl("/api/canon/cards/gv-pk-obf-001/image"),
+    "/api/canon/cards/GV-PK-OBF-001/image",
+  );
+
+  for (const rejected of [
+    "/api/canon/cards/GV-PK-OBF-001/image?download=1",
+    "/api/canon/cards/GV-PK-OBF-001/image#fragment",
+    "https://grookaivault.com/api/canon/cards/GV-PK-OBF-001/image",
+    "/api/canon/card/GV-PK-OBF-001/image",
+    "/api/canon/cards/GV-PK-OBF-001/extra/image",
+    "/api/canon/cards/GV-PK-OBF-001%2FEXTRA/image",
+    "/api/canon/cards/not-a-gv-id/image",
+    `/api/canon/cards/GV-${"A".repeat(100)}/image`,
+  ]) {
+    assert.equal(normalizeCanonCardImageProxyUrl(rejected), null, rejected);
+  }
 });

--- a/tests/contracts/public_card_image_release_guards_v1.test.mjs
+++ b/tests/contracts/public_card_image_release_guards_v1.test.mjs
@@ -17,6 +17,8 @@ test("public card image URLs unwrap nested Next optimizer sources before renderi
   assert.match(imageHelper, /NEXT_IMAGE_UNWRAP_LIMIT = 3/);
   assert.match(imageHelper, /url\.searchParams\.get\("url"\)/);
   assert.match(imageHelper, /unwrapNextImageUrl\(normalized\)/);
+  assert.match(imageHelper, /normalizeCanonCardImageProxyUrl\(normalized\)/);
+  assert.match(imageHelper, /if \(canonCardProxyUrl\)/);
   assert.match(publicCardImage, /normalizePublicCardImageSrc\(src\)/);
   assert.match(publicCardImage, /normalizePublicCardImageSrc\(fallbackSrc\)/);
 });


### PR DESCRIPTION
## What changed
- accept only the exact same-origin canonical card image route at the public image safety boundary
- keep grid thumbnails on Next image optimization while bypassing only the card-detail hero
- add bounded 5-minute CDN caching with 10-minute stale revalidation for the mutable GV-ID indirection
- add runtime rejection coverage for malformed, external, query, fragment, encoded-slash, and overlong routes

## Verification
- complete pre-commit shipcheck passed
- 746 contract tests passed
- production Next build passed (47 static pages)
- Flutter analyze passed
- 309 Flutter tests passed

No migrations. No P8.