### PR TITLE
Add guarded Collaborative Binders production rollout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 *.ps1 text eol=crlf
 *.psm1 text eol=crlf
+*.sql text eol=lf
 *.dart text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf

--- a/.github/workflows/contracts-runtime-protection.yml
+++ b/.github/workflows/contracts-runtime-protection.yml
@@ -54,3 +54,21 @@ jobs:
 
       - name: Run focused contracts test suite
         run: npm run contracts:test
+
+  binder-rollout-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run Binder rollout and process-containment contracts
+        run: >-
+          node --test
+          tests/contracts/collaborative_binders_process_containment_v1.test.mjs
+          tests/contracts/collaborative_binders_production_rollout_v1.test.mjs

--- a/docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md
+++ b/docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md
@@ -1,0 +1,289 @@
+# Collaborative Binders V1 Production Rollout
+
+Status: prepared, not applied
+
+Package: `COLLABORATIVE-BINDERS-DB-V1`
+
+Production project: `ycdxbpibncqcchqiihfz`
+
+Package fingerprint:
+`14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9`
+
+## Purpose and boundary
+
+This runbook installs the reviewed Collaborative Binders database package. It
+does not activate Binders, change application environment variables, deploy
+the web or mobile app, or enable any feature flag.
+
+The five migrations are individually transactional. They are not one atomic
+five-migration transaction. If a command or readback fails, stop. Do not retry
+the push, change migration history, or attempt an automatic rollback.
+
+The following flags remain explicitly outside this rollout:
+
+- `set_binders`
+- `notifications`
+- `pulse_milestones`
+
+P8 is excluded. All 11 Binder flags must remain disabled after installation.
+
+## Reviewed migration set
+
+Only these pending migrations are allowed, in this order:
+
+1. `20260723100000_collaborative_binders_schema_v1.sql`
+2. `20260723101000_collaborative_binders_core_rpcs_v1.sql`
+3. `20260723102000_collaborative_binders_collaboration_rpcs_v1.sql`
+4. `20260723103000_collaborative_binders_read_rpcs_v1.sql`
+5. `20260723104000_collaborative_binders_service_rpcs_v1.sql`
+
+The immutable filenames, byte hashes, cumulative object counts, expected final
+shape, and disabled flags are recorded in
+`scripts/ops/collaborative_binders_production_manifest_v1.json`.
+The two linked readback SQL files are byte-hash pinned into the same package
+fingerprint. The cumulative stage counts are evidence from the completed
+disposable five-stage replay; the production command still applies the exact
+pending set in one CLI invocation and performs a final readback afterward.
+Before this first rollout, the still-pending schema migration was amended to
+remove raw `anon` and `authenticated` access to the Binder rate-limit identity
+sequence and reserve that sequence for `service_role`. This is part of the
+reviewed first migration, not a sixth migration.
+
+This is not an inert schema-only change even while flags are off. The package
+also hardens Trust privileges and policies, installs Trust/Vault/slab Binder
+guards, publishes `binder_refresh_signals`, and wraps Pulse/card-event read
+paths. That is why recovery evidence and immediate post-apply readback are
+mandatory.
+
+## Preconditions
+
+Complete all of these before running the linked preflight:
+
+1. Merge the rollout guard package to `main`.
+2. Pull the exact reviewed `origin/main` commit into a clean `main` worktree.
+3. Record that 40-character commit SHA. It is the `ExpectedHeadSha`.
+4. Use Supabase CLI `2.90.0`, the version exercised by this package.
+5. Confirm the linked database is PostgreSQL major 17. The read-only preflight
+   rejects every other major version before an apply can be authorized.
+6. Explicitly link the worktree to project `ycdxbpibncqcchqiihfz`. The scripts
+   never link a project automatically.
+7. Set `SUPABASE_URL` to
+   `https://ycdxbpibncqcchqiihfz.supabase.co`.
+8. Remove database-routing overrides such as `DATABASE_URL`,
+   `SUPABASE_DB_URL`, and `PG*`.
+9. Confirm a recent recoverable production backup or PITR point.
+10. Choose a new absolute artifact directory outside every Git worktree.
+
+The guard requires `HEAD`, `origin/main`, and the reviewed SHA to be identical.
+It also requires the Binder base commit to be an ancestor. A feature branch,
+dirty tree, untracked file, wrong project, stale backup, ledger drift, hash
+drift, or dry-run drift stops before the apply command can be constructed. The
+reviewed Supabase launcher, binary, and Scoop shim descriptor are known-hash
+pinned. Before the push, the guard opens read-only exclusive seals over all
+migration files, the project link/config, pinned readbacks, package manifest,
+backup evidence, and those CLI components. It keeps the seals through the
+decisive post-apply ledger and catalog readback, and through any diagnostic
+reads on a stopped apply. The migration directory must contain exactly the SQL
+files tracked by Git; ignored or untracked SQL is not allowed. The guard then
+copies that exact locked source into a temporary sealed Supabase worktree,
+denies file creation and writes in its migration directory, locks every staged
+input, rehashes the staged copy, and runs the single push from that sealed
+copy.
+
+## Backup evidence
+
+The operator creates a JSON evidence file outside the repository. The rollout
+does not create or claim a backup.
+
+```json
+{
+  "schema_version": 1,
+  "project_ref": "ycdxbpibncqcchqiihfz",
+  "backup_kind": "supabase_pitr",
+  "verified_at_utc": "2026-07-23T12:00:00Z",
+  "recoverable_through_utc": "2026-07-23T12:00:00Z",
+  "evidence_reference": "operator-visible backup or PITR reference",
+  "restore_path_reviewed": true,
+  "operator": "operator name"
+}
+```
+
+`backup_kind` may be `supabase_pitr`, `supabase_platform_backup`, or
+`verified_logical_backup`. Verification must be no more than 24 hours old, and
+the recoverable horizon must be within 15 minutes of the preflight.
+
+## Source-only validation
+
+This mode is local-only. It verifies the package fingerprint, exact migration
+bytes, project config, SQL read-only boundary, repository identity, and pinned
+CLI version. It does not inspect or change production.
+
+```powershell
+pwsh -NoProfile -File scripts/ops/collaborative_binders_production_preflight_v1.ps1 `
+  -ValidateSourceOnly
+```
+
+## Linked production preflight
+
+Run from the clean, reviewed `main` worktree:
+
+```powershell
+pwsh -NoProfile -File scripts/ops/collaborative_binders_production_preflight_v1.ps1 `
+  -ExpectedHeadSha "<reviewed-main-sha>" `
+  -BackupEvidencePath "C:\secure-ops\binder-backup-evidence.json" `
+  -ArtifactRoot "C:\secure-ops\binder-rollout-<timestamp>"
+```
+
+The preflight is read-only. It checks the production binding, linked migration
+ledger, exact five-file dry run, baseline Trust/Pulse/card-event fingerprints,
+the exact relevant default-ACL baseline, client schema-creation denial, exact
+Realtime publication configuration, absence of pre-existing Binder
+objects/data, and the recovery evidence. It writes a four-hour preflight
+manifest and two exact acknowledgement strings to the external artifact
+directory.
+
+The linked catalog reads are one static CTE `SELECT` each. Supabase CLI 2.90.0
+executes linked queries as one prepared statement, so the source validator
+rejects semicolons, multiple statements, and mutation-capable SQL keywords.
+An external 45-second process timeout bounds each read.
+
+Review every artifact, especially:
+
+- `repository.json`
+- `project-binding.json`
+- `ledger.before.json`
+- `readback.before.json`
+- `dry-run.parsed.json`
+- `preflight-manifest.json`
+- `approval.txt`
+
+Do not continue if the preflight reports anything other than `pass`.
+
+## Apply
+
+Copy the two exact values from `approval.txt` into the current PowerShell
+process. Do not edit, normalize, or shorten them.
+
+```powershell
+$env:GROOKAI_BINDER_PROD_BACKUP_ACK = "<exact BACKUP-VERIFIED value>"
+$env:GROOKAI_BINDER_PROD_APPLY_ACK = "<exact APPLY-COLLABORATIVE-BINDERS-V1 value>"
+
+pwsh -NoProfile -File scripts/ops/collaborative_binders_production_apply_v1.ps1 `
+  -ManifestPath "C:\secure-ops\binder-rollout-<timestamp>\preflight-manifest.json" `
+  -ConfirmProduction
+```
+
+PowerShell asks for high-impact confirmation unless the operator deliberately
+supplies its standard confirmation override. Immediately before applying, the
+guard revalidates the manifest, expiry, source bytes, CLI binary, clean main
+SHA, origin SHA, production binding, recovery evidence, exact ledger, baseline
+catalog readback, and dry run. It also rechecks the exact tracked migration
+directory before constructing the sealed temporary source.
+
+There is exactly one permitted remote mutation command:
+
+```text
+supabase db push --linked --yes
+```
+
+The package has no arbitrary command or SQL passthrough. It never includes
+seeds, roles, a database URL, or a password. It never links, pulls, resets,
+changes migration history, or writes feature flags.
+
+The mutator runs inside a gated Windows Job Object. The reviewed executable
+cannot start until its supervisor is inside the job, and source cleanup cannot
+begin until both the supervisor and its entire process tree have exited. If
+the push times out, the guard terminates the job, preserves bounded
+stdout/stderr, marks remote mutation as possible, performs only a diagnostic
+ledger/readback after termination is confirmed, and stops. If termination
+cannot be confirmed, the runner fails fast while the kill-on-close job handle
+and source seals are still held; it does not clean the staged source or begin
+diagnostic reads. It never claims that flags or migration state are unchanged
+after a timed-out or failed push.
+
+After process-tree termination is confirmed, the sealed temporary source is
+deleted. It contains no copied pooler URL or database password. A sanitized
+manifest of staged filenames and hashes is retained in the external apply
+evidence directory. If ordinary cleanup cannot safely unseal and remove the
+temporary source, the guard stops. In the exceptional fail-fast containment
+path, ordinary cleanup deliberately does not run; treat any matching sealed
+temporary directory as incident evidence until the process tree is confirmed
+absent and recovery is directed.
+
+## Mandatory post-apply readback
+
+After a successful push, the apply guard automatically requires:
+
+- the exact ledger delta is only the five reviewed migration versions, with no
+  removed or additional version
+- all five migrations shared in the linked ledger, with no local-only or
+  remote-only row
+- 21 Binder tables, all with RLS
+- 124 Binder functions with the reviewed aggregate body fingerprint
+- 65 indexes, 22 policies, and 22 introduced triggers
+- exact fixed `search_path` distribution
+- zero default PUBLIC Binder-function execution
+- reviewed anon/authenticated/service RPC execution counts
+- no raw anonymous Binder-table access
+- no raw anonymous or authenticated Binder-sequence access
+- no authenticated raw Binder mutations
+- authenticated raw `SELECT` only on `binder_refresh_signals`
+- `binder_refresh_signals` as the only Binder Realtime table
+- exact Realtime publication owner/options and the reviewed
+  `binder_refresh_signals` column projection with no row filter
+- no effective `CREATE` privilege for client roles on `public` or `extensions`
+- exactly 11 flags and zero enabled flags
+- empty Binder domain tables before activation
+- no Binder events or Binder trust reports seeded by installation
+
+The apply result is not `pass` unless every assertion succeeds.
+
+## Smoke and observation
+
+After the automatic readback passes, perform read-only smoke checks against the
+existing production behavior:
+
+1. Web: sign in, Discover, Vault, Wall, Pulse, and a card detail.
+2. Android: the same signed-in paths on the production build.
+3. Trust: open report/block entry points without submitting test abuse data.
+4. Messaging and public card-event feeds: verify ordinary existing reads.
+5. Images: verify hosted card thumbnails and high-quality card detail images.
+6. Observe database latency, API errors, auth errors, and Realtime errors for a
+   defined stabilization window.
+
+Because every Binder flag is off, no Binder UI or client traffic should be
+activated by this database installation.
+
+## Stop conditions
+
+Stop immediately on any of these:
+
+- partial or unexpected migration ledger
+- wrong project, URL, database host, branch, or SHA
+- missing, stale, or changed recovery evidence
+- changed migration byte hash or package fingerprint
+- unexpected pre-existing Binder object or domain data
+- Trust/Pulse/card-event baseline drift
+- push failure or timeout
+- post-apply ledger or catalog mismatch
+- any enabled Binder flag
+- unexpected app, API, auth, latency, or Realtime regression
+
+On a stop, preserve the external artifacts and `STOP-incident.json`. Leave all
+flags off. Do not use migration-history repair, force inclusion, manual SQL, an
+automatic retry, or an improvised rollback. Escalate with the exact ledger and
+readback evidence and choose recovery deliberately.
+
+## Later activation boundary
+
+Feature activation is a separate reviewed project. The intended sequence is:
+
+1. `schema_internal`
+2. `personal`
+3. `shared`
+4. `view_links`, then `public`
+5. `community`, `custom`, and `templates`
+
+Each step needs its own smoke/observation gate. `set_binders`,
+`notifications`, and `pulse_milestones` remain excluded, and P8 is not part of
+this runbook.

--- a/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
+++ b/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
@@ -1,0 +1,3741 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:PackageFingerprintV1 = '14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9'
+
+function Assert-BinderConditionV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$Condition,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if (-not $Condition) {
+    throw $Message
+  }
+}
+
+function Get-BinderRolloutPolicyV1 {
+  [CmdletBinding()]
+  param()
+
+  return [pscustomobject][ordered]@{
+    SchemaVersion = 1
+    PackageId = 'COLLABORATIVE-BINDERS-DB-V1'
+    PackageFingerprintSha256 = $script:PackageFingerprintV1
+    ProjectRef = 'ycdxbpibncqcchqiihfz'
+    CanonicalRepository = 'OriginalSoseji/grookai_vault'
+    RequiredAncestorSha = '34caa07324587815040957f9adde1f771ebfc85a'
+    SupportedSupabaseCliVersion = '2.90.0'
+    SupabaseCliLauncherSha256 = '140e3801d8adeda639a21b14e62b93a4c7d26b7a758421f43c82be59753be49b'
+    SupabaseCliBinarySha256 = '31c2a25bd590a36ad803a7c669cf76a62eac3cd5aa7112eeb2e1c5f308c8b39c'
+    SupabaseCliShimDescriptorSha256 = '0c68f69a367b2b76e61f3e71fb98c9a867143628a361a2e715dd30f33c4b2c3f'
+    ManifestRelativePath = 'scripts/ops/collaborative_binders_production_manifest_v1.json'
+    PreflightSqlRelativePath = 'scripts/ops/sql/collaborative_binders_production_preflight_v1.sql'
+    PostApplySqlRelativePath = 'scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql'
+    PreflightSqlSha256 = '268458ed8a4a16dc513b55b6d0e5b3b03c301320e55a9ab4887a135c7652800d'
+    PostApplySqlSha256 = '5125b0d89f5b3d36c66f98863f0b69b9c6df55561dfb54303437d47d8731f1a1'
+    MigrationVersions = @(
+      '20260723100000',
+      '20260723101000',
+      '20260723102000',
+      '20260723103000',
+      '20260723104000'
+    )
+    MigrationFiles = @(
+      '20260723100000_collaborative_binders_schema_v1.sql',
+      '20260723101000_collaborative_binders_core_rpcs_v1.sql',
+      '20260723102000_collaborative_binders_collaboration_rpcs_v1.sql',
+      '20260723103000_collaborative_binders_read_rpcs_v1.sql',
+      '20260723104000_collaborative_binders_service_rpcs_v1.sql'
+    )
+    MigrationSha256 = @(
+      '7e83ab8bb83e5b938fbec758b21f8cae2b4a71427a6600c54c5f773c974bae33',
+      'eb9ca9898bca12b127f4b79aff9df81259efe74fa1029487ea133e94e8a67a7d',
+      '680580044161936c8a382e5209e2cc54369943e13f1a3ae2ed41c299532cf3bf',
+      '73dab7009f059267dcc571fcb6ec79cffdb23b728fc5bf04cd81397a06bcd6fb',
+      '2edbef712d6b228c73b504498a6aa09f5bac440cfef96319d5c75f65e12d2997'
+    )
+    FeatureFlags = @(
+      'schema_internal',
+      'personal',
+      'set_binders',
+      'custom',
+      'shared',
+      'view_links',
+      'public',
+      'community',
+      'templates',
+      'notifications',
+      'pulse_milestones'
+    )
+    ExcludedFlags = @(
+      'set_binders',
+      'notifications',
+      'pulse_milestones'
+    )
+    ApplyArguments = @('db', 'push', '--linked', '--yes')
+    PreflightTtlHours = 4
+    BackupMaxAgeHours = 24
+    BackupRecoveryLagMinutes = 15
+  }
+}
+
+function Get-BinderRepoRootV1 {
+  [CmdletBinding()]
+  param()
+
+  return [System.IO.Path]::GetFullPath(
+    (Join-Path $PSScriptRoot '..\..')
+  )
+}
+
+function Get-BinderSha256StringV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string]$Value
+  )
+
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
+  return [Convert]::ToHexString(
+    [System.Security.Cryptography.SHA256]::HashData($bytes)
+  ).ToLowerInvariant()
+}
+
+function Get-BinderSha256FileV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $Path -PathType Leaf) "File not found: $Path"
+  return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-CanonicalSha256V1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Value
+  )
+
+  $json = $Value | ConvertTo-Json -Depth 32 -Compress
+  return Get-BinderSha256StringV1 -Value $json
+}
+
+function Get-BinderPackageFingerprintV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Manifest
+  )
+
+  $lines = [System.Collections.Generic.List[string]]::new()
+  $lines.Add("schema_version=$($Manifest.schema_version)")
+  $lines.Add("package_id=$($Manifest.package_id)")
+  $lines.Add("required_ancestor_sha=$($Manifest.required_ancestor_sha)")
+  $lines.Add("production_project_ref=$($Manifest.production_project_ref)")
+  $lines.Add("canonical_git_repository=$($Manifest.canonical_git_repository)")
+
+  foreach ($migration in @($Manifest.migrations)) {
+    $lines.Add(
+      'migration={0}|{1}|{2}|{3}|{4}|{5}|{6}' -f @(
+        $migration.version,
+        $migration.file,
+        $migration.sha256,
+        $migration.cumulative_tables,
+        $migration.cumulative_functions,
+        $migration.cumulative_indexes,
+        $migration.cumulative_rls_policies
+      )
+    )
+  }
+
+  foreach ($readback in @($Manifest.readback_sql)) {
+    $lines.Add(
+      'readback={0}|{1}|{2}' -f @(
+        $readback.phase,
+        $readback.file,
+        $readback.sha256
+      )
+    )
+  }
+
+  foreach ($property in $Manifest.final_expected_shape.PSObject.Properties) {
+    $value = if ($property.Value -is [System.Array]) {
+      @($property.Value) -join ','
+    } else {
+      [string]$property.Value
+    }
+    $lines.Add("shape.$($property.Name)=$value")
+  }
+
+  foreach ($flag in @($Manifest.feature_flags_must_remain_disabled)) {
+    $lines.Add("disabled_flag=$flag")
+  }
+  foreach ($flag in @($Manifest.excluded_from_rollout)) {
+    $lines.Add("excluded_flag=$flag")
+  }
+
+  return Get-BinderSha256StringV1 -Value ($lines -join "`n")
+}
+
+function Read-BinderPackageManifestV1 {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Get-BinderRepoRootV1)
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $path = Join-Path $RepoRoot $policy.ManifestRelativePath
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $path -PathType Leaf) "Package manifest not found: $path"
+
+  $manifest = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+  $fingerprint = Get-BinderPackageFingerprintV1 -Manifest $manifest
+
+  $expectedManifestProperties = @(
+    'schema_version',
+    'package_id',
+    'package_fingerprint_sha256',
+    'required_ancestor_sha',
+    'production_project_ref',
+    'canonical_git_repository',
+    'migrations',
+    'readback_sql',
+    'final_expected_shape',
+    'feature_flags_must_remain_disabled',
+    'excluded_from_rollout'
+  ) | Sort-Object
+  $actualManifestProperties = @(
+    $manifest.PSObject.Properties.Name | Sort-Object
+  )
+  Assert-BinderConditionV1 (
+    ($actualManifestProperties -join "`n") -ceq
+      ($expectedManifestProperties -join "`n")
+  ) 'Package manifest fields are missing or unexpected.'
+
+  Assert-BinderConditionV1 ($manifest.schema_version -eq $policy.SchemaVersion) 'Package manifest schema version mismatch.'
+  Assert-BinderConditionV1 ($manifest.package_id -ceq $policy.PackageId) 'Package ID mismatch.'
+  Assert-BinderConditionV1 ($manifest.production_project_ref -ceq $policy.ProjectRef) 'Package project ref mismatch.'
+  Assert-BinderConditionV1 ($manifest.canonical_git_repository -ceq $policy.CanonicalRepository) 'Package repository mismatch.'
+  Assert-BinderConditionV1 ($manifest.required_ancestor_sha -ceq $policy.RequiredAncestorSha) 'Package ancestor mismatch.'
+  Assert-BinderConditionV1 ($manifest.package_fingerprint_sha256 -ceq $fingerprint) 'Package manifest fingerprint is stale or invalid.'
+  Assert-BinderConditionV1 ($fingerprint -ceq $policy.PackageFingerprintSha256) 'Package fingerprint is not the reviewed V1 fingerprint.'
+  Assert-BinderConditionV1 (
+    (@($manifest.feature_flags_must_remain_disabled) -join "`n") -ceq
+      ($policy.FeatureFlags -join "`n")
+  ) 'Disabled feature-flag manifest is not exact.'
+  Assert-BinderConditionV1 (
+    (@($manifest.excluded_from_rollout) -join "`n") -ceq
+      ($policy.ExcludedFlags -join "`n")
+  ) 'Excluded feature-flag manifest is not exact.'
+
+  $expectedMigrationProperties = @(
+    'version',
+    'file',
+    'sha256',
+    'cumulative_tables',
+    'cumulative_functions',
+    'cumulative_indexes',
+    'cumulative_rls_policies'
+  ) | Sort-Object
+  foreach ($migration in @($manifest.migrations)) {
+    $actualMigrationProperties = @(
+      $migration.PSObject.Properties.Name | Sort-Object
+    )
+    Assert-BinderConditionV1 (
+      ($actualMigrationProperties -join "`n") -ceq
+        ($expectedMigrationProperties -join "`n")
+    ) 'Migration manifest fields are missing or unexpected.'
+  }
+
+  $expectedReadbackProperties = @('phase', 'file', 'sha256') | Sort-Object
+  foreach ($readback in @($manifest.readback_sql)) {
+    $actualReadbackProperties = @(
+      $readback.PSObject.Properties.Name | Sort-Object
+    )
+    Assert-BinderConditionV1 (
+      ($actualReadbackProperties -join "`n") -ceq
+        ($expectedReadbackProperties -join "`n")
+    ) 'Readback SQL manifest fields are missing or unexpected.'
+  }
+
+  return [pscustomobject]@{
+    Path = $path
+    Data = $manifest
+    FingerprintSha256 = $fingerprint
+    FileSha256 = Get-BinderSha256FileV1 -Path $path
+  }
+}
+
+function Remove-AnsiV1 {
+  [CmdletBinding()]
+  param(
+    [AllowEmptyString()]
+    [string]$Text = ''
+  )
+
+  return [regex]::Replace($Text, "`e\[[0-?]*[ -/]*[@-~]", '')
+}
+
+function Protect-BinderTranscriptV1 {
+  param(
+    [AllowEmptyString()]
+    [string]$Text = ''
+  )
+
+  $safe = Remove-AnsiV1 -Text $Text
+  $safe = [regex]::Replace(
+    $safe,
+    '(?i)\bpostgres(?:ql)?://[^\s''"]+',
+    '[REDACTED_DATABASE_URL]'
+  )
+  $safe = [regex]::Replace(
+    $safe,
+    '(?i)\bBearer\s+[A-Za-z0-9._~+/-]+=*',
+    'Bearer [REDACTED]'
+  )
+  $safe = [regex]::Replace(
+    $safe,
+    '\beyJ[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,}\b',
+    '[REDACTED_JWT]'
+  )
+  $safe = [regex]::Replace(
+    $safe,
+    '\bsb_(?:secret|publishable)_[A-Za-z0-9_-]+\b',
+    '[REDACTED_SUPABASE_KEY]'
+  )
+  $safe = [regex]::Replace(
+    $safe,
+    '\bsbp_[A-Za-z0-9_-]+\b',
+    '[REDACTED_SUPABASE_ACCESS_TOKEN]'
+  )
+  $safe = [regex]::Replace(
+    $safe,
+    '(?i)\b(access_token|apikey|password)=([^&\s]+)',
+    '$1=[REDACTED]'
+  )
+  return $safe
+}
+
+function Test-BinderRoutingEnvironmentNameV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return $Name -match (
+    '(?i)^(?:' +
+    'PG.*|' +
+    'DATABASE_URL|' +
+    'DIRECT_URL|' +
+    'DB_URL|' +
+    'PRISMA_DATABASE_URL|' +
+    'POSTGRES(?:QL)?_URL.*|' +
+    'SUPABASE_DB_.*|' +
+    'SUPABASE_API_(?:HOST|URL)|' +
+    'SUPABASE_INTERNAL_.*|' +
+    'SUPABASE_PROJECT_(?:ID|REF)|' +
+    'SUPABASE_CA_SKIP_VERIFY' +
+    ')$'
+  )
+}
+
+function Initialize-BinderProcessContainmentTypesV1 {
+  [CmdletBinding()]
+  param()
+
+  Assert-BinderConditionV1 $IsWindows (
+    'The production rollout process containment guard requires Windows.'
+  )
+  if ($null -ne ('Grookai.Vault.RolloutV1.BinderJob' -as [type])) {
+    return
+  }
+
+  Add-Type -Language CSharp -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+namespace Grookai.Vault.RolloutV1
+{
+    internal sealed class SafeJobHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        internal SafeJobHandle(IntPtr handle) : base(true)
+        {
+            SetHandle(handle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            return NativeMethods.CloseHandle(handle);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct JobObjectBasicLimitInformation
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct IoCounters
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct JobObjectExtendedLimitInformation
+    {
+        public JobObjectBasicLimitInformation BasicLimitInformation;
+        public IoCounters IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct JobObjectBasicAccountingInformation
+    {
+        public long TotalUserTime;
+        public long TotalKernelTime;
+        public long ThisPeriodTotalUserTime;
+        public long ThisPeriodTotalKernelTime;
+        public uint TotalPageFaultCount;
+        public uint TotalProcesses;
+        public uint ActiveProcesses;
+        public uint TotalTerminatedProcesses;
+    }
+
+    internal static class NativeMethods
+    {
+        internal const uint JobObjectLimitKillOnJobClose = 0x00002000;
+        internal const int JobObjectBasicAccountingInformationClass = 1;
+        internal const int JobObjectExtendedLimitInformationClass = 9;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr CreateJobObject(
+            IntPtr jobAttributes,
+            string name);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetInformationJobObject(
+            SafeJobHandle job,
+            int informationClass,
+            ref JobObjectExtendedLimitInformation information,
+            uint informationLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool QueryInformationJobObject(
+            SafeJobHandle job,
+            int informationClass,
+            out JobObjectBasicAccountingInformation information,
+            uint informationLength,
+            IntPtr returnLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool AssignProcessToJobObject(
+            SafeJobHandle job,
+            IntPtr process);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool TerminateJobObject(
+            SafeJobHandle job,
+            uint exitCode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool CloseHandle(IntPtr handle);
+    }
+
+    public sealed class BinderJob : IDisposable
+    {
+        private SafeJobHandle _handle;
+
+        public BinderJob()
+        {
+            IntPtr rawHandle = NativeMethods.CreateJobObject(
+                IntPtr.Zero,
+                null);
+            if (rawHandle == IntPtr.Zero)
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "CreateJobObject failed.");
+            }
+
+            _handle = new SafeJobHandle(rawHandle);
+            try
+            {
+                var information =
+                    new JobObjectExtendedLimitInformation();
+                information.BasicLimitInformation.LimitFlags =
+                    NativeMethods.JobObjectLimitKillOnJobClose;
+                uint size = checked((uint)Marshal.SizeOf(
+                    typeof(JobObjectExtendedLimitInformation)));
+                if (!NativeMethods.SetInformationJobObject(
+                    _handle,
+                    NativeMethods.JobObjectExtendedLimitInformationClass,
+                    ref information,
+                    size))
+                {
+                    throw new Win32Exception(
+                        Marshal.GetLastWin32Error(),
+                        "SetInformationJobObject failed.");
+                }
+            }
+            catch
+            {
+                _handle.Dispose();
+                _handle = null;
+                throw;
+            }
+        }
+
+        private SafeJobHandle Handle
+        {
+            get
+            {
+                if (_handle == null || _handle.IsClosed)
+                {
+                    throw new ObjectDisposedException(
+                        nameof(BinderJob));
+                }
+                return _handle;
+            }
+        }
+
+        public void Assign(Process process)
+        {
+            if (process == null)
+            {
+                throw new ArgumentNullException(nameof(process));
+            }
+            if (!NativeMethods.AssignProcessToJobObject(
+                Handle,
+                process.Handle))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "AssignProcessToJobObject failed.");
+            }
+        }
+
+        public int GetActiveProcessCount()
+        {
+            JobObjectBasicAccountingInformation information;
+            uint size = checked((uint)Marshal.SizeOf(
+                typeof(JobObjectBasicAccountingInformation)));
+            if (!NativeMethods.QueryInformationJobObject(
+                Handle,
+                NativeMethods.JobObjectBasicAccountingInformationClass,
+                out information,
+                size,
+                IntPtr.Zero))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "QueryInformationJobObject failed.");
+            }
+            return checked((int)information.ActiveProcesses);
+        }
+
+        public void Terminate(uint exitCode)
+        {
+            if (!NativeMethods.TerminateJobObject(
+                Handle,
+                exitCode))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "TerminateJobObject failed.");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_handle != null)
+            {
+                _handle.Dispose();
+                _handle = null;
+            }
+        }
+    }
+
+    public sealed class BinderBoundedTextCapture
+    {
+        private readonly object _sync = new object();
+        private readonly StringBuilder _text = new StringBuilder();
+        private readonly int _maximumCharacters;
+        private readonly Task _completion;
+        private long _charactersObserved;
+        private bool _truncated;
+        private string _error;
+
+        public BinderBoundedTextCapture(
+            TextReader reader,
+            int maximumCharacters)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+            if (maximumCharacters < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(maximumCharacters));
+            }
+            _maximumCharacters = maximumCharacters;
+            _completion = CaptureAsync(reader);
+        }
+
+        private async Task CaptureAsync(TextReader reader)
+        {
+            var buffer = new char[4096];
+            try
+            {
+                while (true)
+                {
+                    int read = await reader.ReadAsync(
+                        buffer,
+                        0,
+                        buffer.Length).ConfigureAwait(false);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    lock (_sync)
+                    {
+                        _charactersObserved += read;
+                        int remaining =
+                            _maximumCharacters - _text.Length;
+                        if (remaining > 0)
+                        {
+                            _text.Append(
+                                buffer,
+                                0,
+                                Math.Min(remaining, read));
+                        }
+                        if (read > remaining)
+                        {
+                            _truncated = true;
+                        }
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                lock (_sync)
+                {
+                    _error =
+                        exception.GetType().Name +
+                        ": " +
+                        exception.Message;
+                }
+            }
+        }
+
+        public bool WaitForCompletion(int timeoutMilliseconds)
+        {
+            if (timeoutMilliseconds < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(timeoutMilliseconds));
+            }
+            try
+            {
+                return _completion.Wait(timeoutMilliseconds);
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        public bool Completed
+        {
+            get { return _completion.IsCompleted; }
+        }
+
+        public bool CompletedSuccessfully
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return
+                        _completion.IsCompleted &&
+                        String.IsNullOrEmpty(_error);
+                }
+            }
+        }
+
+        public string Text
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _text.ToString();
+                }
+            }
+        }
+
+        public long CharactersObserved
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _charactersObserved;
+                }
+            }
+        }
+
+        public bool Truncated
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _truncated;
+                }
+            }
+        }
+
+        public string Error
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _error;
+                }
+            }
+        }
+    }
+}
+'@
+}
+
+function Set-BinderProcessLifecycleFieldV1 {
+  param(
+    [object]$Lifecycle,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [AllowNull()]
+    [object]$Value
+  )
+
+  if ($null -eq $Lifecycle) {
+    return
+  }
+  if ($Lifecycle -is [System.Collections.IDictionary]) {
+    $Lifecycle[$Name] = $Value
+    return
+  }
+
+  $property = $Lifecycle.PSObject.Properties[$Name]
+  if ($null -eq $property) {
+    Add-Member `
+      -InputObject $Lifecycle `
+      -MemberType NoteProperty `
+      -Name $Name `
+      -Value $Value
+  } else {
+    $property.Value = $Value
+  }
+}
+
+function Set-BinderProcessLifecycleV1 {
+  param(
+    [object]$Lifecycle,
+
+    [Parameter(Mandatory = $true)]
+    [System.Collections.IDictionary]$Values
+  )
+
+  foreach ($entry in $Values.GetEnumerator()) {
+    Set-BinderProcessLifecycleFieldV1 `
+      -Lifecycle $Lifecycle `
+      -Name ([string]$entry.Key) `
+      -Value $entry.Value
+  }
+}
+
+function Get-BinderSupervisorEncodedCommandV1 {
+  [CmdletBinding()]
+  param()
+
+  $supervisor = @'
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$payloadName = 'GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1'
+$gate = $null
+$child = $null
+$exitCode = 250
+try {
+  $encodedPayload = [Environment]::GetEnvironmentVariable(
+    $payloadName,
+    [EnvironmentVariableTarget]::Process
+  )
+  if ([string]::IsNullOrWhiteSpace($encodedPayload)) {
+    throw 'Supervisor payload is missing.'
+  }
+  [Environment]::SetEnvironmentVariable(
+    $payloadName,
+    $null,
+    [EnvironmentVariableTarget]::Process
+  )
+  $payloadJson = [Text.Encoding]::UTF8.GetString(
+    [Convert]::FromBase64String($encodedPayload)
+  )
+  $payload = $payloadJson | ConvertFrom-Json
+  $gate = [Threading.EventWaitHandle]::OpenExisting(
+    [string]$payload.GateName
+  )
+  if (-not $gate.WaitOne(600000)) {
+    throw 'Supervisor gate was not released within ten minutes.'
+  }
+
+  $start = [Diagnostics.ProcessStartInfo]::new()
+  $start.FileName = [string]$payload.FilePath
+  $start.WorkingDirectory = [string]$payload.WorkingDirectory
+  $start.UseShellExecute = $false
+  $start.CreateNoWindow = $true
+  $start.RedirectStandardOutput = $true
+  $start.RedirectStandardError = $true
+  foreach ($argument in @($payload.Arguments)) {
+    [void]$start.ArgumentList.Add([string]$argument)
+  }
+
+  $child = [Diagnostics.Process]::new()
+  $child.StartInfo = $start
+  if (-not $child.Start()) {
+    throw 'Supervisor could not start the reviewed executable.'
+  }
+  $stdoutCopy = $child.StandardOutput.BaseStream.CopyToAsync(
+    [Console]::OpenStandardOutput()
+  )
+  $stderrCopy = $child.StandardError.BaseStream.CopyToAsync(
+    [Console]::OpenStandardError()
+  )
+  $child.WaitForExit()
+  $exitCode = $child.ExitCode
+  $copies = [Threading.Tasks.Task]::WhenAll(
+    [Threading.Tasks.Task[]]@($stdoutCopy, $stderrCopy)
+  )
+  $copies.GetAwaiter().GetResult()
+} catch {
+  $exitCode = 250
+  [Console]::Error.WriteLine(
+    'Contained supervisor failure: ' + $_.Exception.Message
+  )
+} finally {
+  if ($null -ne $child) {
+    $child.Dispose()
+  }
+  if ($null -ne $gate) {
+    $gate.Dispose()
+  }
+}
+[Environment]::Exit($exitCode)
+'@
+
+  return [Convert]::ToBase64String(
+    [Text.Encoding]::Unicode.GetBytes($supervisor)
+  )
+}
+
+function Wait-BinderContainedTreeV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Diagnostics.Process]$RootProcess,
+
+    [Parameter(Mandatory = $true)]
+    [object]$Job,
+
+    [Parameter(Mandatory = $true)]
+    [int]$TimeoutMilliseconds
+  )
+
+  Assert-BinderConditionV1 (
+    $TimeoutMilliseconds -ge 0
+  ) 'Containment wait timeout cannot be negative.'
+  $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+  $rootExited = $false
+  $processTreeEmpty = $false
+  $queryError = $null
+
+  while ($true) {
+    try {
+      $rootExited = $RootProcess.HasExited
+    } catch {
+      $rootExited = $false
+    }
+    try {
+      $processTreeEmpty = ($Job.GetActiveProcessCount() -eq 0)
+      $queryError = $null
+    } catch {
+      $processTreeEmpty = $false
+      $queryError = $_.Exception.Message
+    }
+
+    if ($rootExited -and $processTreeEmpty) {
+      break
+    }
+    $remaining = $TimeoutMilliseconds - [int]$stopwatch.ElapsedMilliseconds
+    if ($remaining -le 0) {
+      break
+    }
+    $slice = [Math]::Min(100, $remaining)
+    if (-not $rootExited) {
+      try {
+        [void]$RootProcess.WaitForExit($slice)
+      } catch {
+        [Threading.Thread]::Sleep($slice)
+      }
+    } else {
+      [Threading.Thread]::Sleep($slice)
+    }
+  }
+
+  return [pscustomobject][ordered]@{
+    RootExited = [bool]$rootExited
+    ProcessTreeEmpty = [bool]$processTreeEmpty
+    TerminationConfirmed = (
+      [bool]$rootExited -and
+      [bool]$processTreeEmpty
+    )
+    QueryError = $queryError
+  }
+}
+
+function Stop-BinderContainedTreeV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Diagnostics.Process]$RootProcess,
+
+    [Parameter(Mandatory = $true)]
+    [object]$Job,
+
+    [int]$ConfirmationTimeoutMilliseconds = 15000
+  )
+
+  $killSucceeded = $false
+  $killError = $null
+  try {
+    $Job.Terminate(1)
+    $killSucceeded = $true
+  } catch {
+    $killError = $_.Exception.Message
+  }
+  $confirmation = Wait-BinderContainedTreeV1 `
+    -RootProcess $RootProcess `
+    -Job $Job `
+    -TimeoutMilliseconds $ConfirmationTimeoutMilliseconds
+
+  return [pscustomobject][ordered]@{
+    KillAttempted = $true
+    KillRequestSucceeded = [bool]$killSucceeded
+    KillRequestError = $killError
+    RootExited = [bool]$confirmation.RootExited
+    ProcessTreeEmpty = [bool]$confirmation.ProcessTreeEmpty
+    TerminationConfirmed = [bool]$confirmation.TerminationConfirmed
+    QueryError = $confirmation.QueryError
+  }
+}
+
+function ConvertTo-BinderBoundedTranscriptV1 {
+  param(
+    [AllowEmptyString()]
+    [string]$Text = '',
+
+    [Parameter(Mandatory = $true)]
+    [int]$MaximumCharacters,
+
+    [Parameter(Mandatory = $true)]
+    [bool]$AlreadyTruncated
+  )
+
+  $protected = Protect-BinderTranscriptV1 -Text $Text
+  $truncated = (
+    $AlreadyTruncated -or
+    $protected.Length -gt $MaximumCharacters
+  )
+  if (-not $truncated) {
+    return [pscustomobject]@{
+      Text = $protected
+      Truncated = $false
+    }
+  }
+
+  $marker = "`n[output truncated by rollout guard]"
+  $available = [Math]::Max(0, $MaximumCharacters - $marker.Length)
+  $bounded = if ($protected.Length -gt $available) {
+    $protected.Substring(0, $available)
+  } else {
+    $protected
+  }
+  return [pscustomobject]@{
+    Text = $bounded + $marker
+    Truncated = $true
+  }
+}
+
+function Complete-BinderProcessOutputV1 {
+  param(
+    [object]$StdOutCapture,
+
+    [object]$StdErrCapture,
+
+    [int]$MaximumCharacters = 262144,
+
+    [int]$WaitMilliseconds = 5000
+  )
+
+  $stdoutWaited = if ($null -ne $StdOutCapture) {
+    $StdOutCapture.WaitForCompletion($WaitMilliseconds)
+  } else {
+    $false
+  }
+  $stderrWaited = if ($null -ne $StdErrCapture) {
+    $StdErrCapture.WaitForCompletion($WaitMilliseconds)
+  } else {
+    $false
+  }
+  $stdoutComplete = (
+    $stdoutWaited -and
+    $null -ne $StdOutCapture -and
+    $StdOutCapture.CompletedSuccessfully
+  )
+  $stderrComplete = (
+    $stderrWaited -and
+    $null -ne $StdErrCapture -and
+    $StdErrCapture.CompletedSuccessfully
+  )
+  $stdoutRaw = if ($null -ne $StdOutCapture) {
+    [string]$StdOutCapture.Text
+  } else {
+    ''
+  }
+  $stderrRaw = if ($null -ne $StdErrCapture) {
+    [string]$StdErrCapture.Text
+  } else {
+    ''
+  }
+  $stdout = ConvertTo-BinderBoundedTranscriptV1 `
+    -Text $stdoutRaw `
+    -MaximumCharacters $MaximumCharacters `
+    -AlreadyTruncated (
+      $null -ne $StdOutCapture -and
+      $StdOutCapture.Truncated
+    )
+  $stderr = ConvertTo-BinderBoundedTranscriptV1 `
+    -Text $stderrRaw `
+    -MaximumCharacters $MaximumCharacters `
+    -AlreadyTruncated (
+      $null -ne $StdErrCapture -and
+      $StdErrCapture.Truncated
+    )
+
+  return [pscustomobject][ordered]@{
+    StdOut = $stdout.Text
+    StdErr = $stderr.Text
+    StdOutCaptureCompleted = [bool]$stdoutComplete
+    StdErrCaptureCompleted = [bool]$stderrComplete
+    OutputCaptureCompleted = (
+      [bool]$stdoutComplete -and
+      [bool]$stderrComplete
+    )
+    StdOutTruncated = [bool]$stdout.Truncated
+    StdErrTruncated = [bool]$stderr.Truncated
+    OutputTruncated = (
+      [bool]$stdout.Truncated -or
+      [bool]$stderr.Truncated
+    )
+    StdOutCharactersObserved = if ($null -ne $StdOutCapture) {
+      [long]$StdOutCapture.CharactersObserved
+    } else {
+      0L
+    }
+    StdErrCharactersObserved = if ($null -ne $StdErrCapture) {
+      [long]$StdErrCapture.CharactersObserved
+    } else {
+      0L
+    }
+    StdOutCaptureError = if ($null -ne $StdOutCapture) {
+      [string]$StdOutCapture.Error
+    } else {
+      'capture_not_started'
+    }
+    StdErrCaptureError = if ($null -ne $StdErrCapture) {
+      [string]$StdErrCapture.Error
+    } else {
+      'capture_not_started'
+    }
+  }
+}
+
+function Invoke-BinderProcessV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkingDirectory,
+
+    [int]$TimeoutSeconds = 120,
+
+    [switch]$SanitizeDatabaseEnvironment,
+
+    [object]$ProcessLifecycle
+  )
+
+  Assert-BinderConditionV1 (
+    $TimeoutSeconds -gt 0
+  ) 'Process timeout must be positive.'
+  Initialize-BinderProcessContainmentTypesV1
+
+  $maximumOutputCharacters = 262144
+  $resolvedFilePath = [IO.Path]::GetFullPath($FilePath)
+  $resolvedWorkingDirectory = [IO.Path]::GetFullPath(
+    $WorkingDirectory
+  )
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $resolvedFilePath -PathType Leaf
+  ) "Unable to start command because its executable was not found: $resolvedFilePath"
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $resolvedWorkingDirectory -PathType Container
+  ) "Command working directory was not found: $resolvedWorkingDirectory"
+
+  $state = [ordered]@{
+    Started = $false
+    StartedAtUtc = $null
+    SupervisorProcessId = $null
+    TimedOut = $false
+    KillAttempted = $false
+    KillRequestSucceeded = $null
+    KillRequestError = $null
+    RootExited = $false
+    ProcessTreeEmpty = $false
+    TerminationConfirmed = $false
+    ExitCode = $null
+    EndedAtUtc = $null
+    StdOutCaptureCompleted = $false
+    StdErrCaptureCompleted = $false
+    OutputCaptureCompleted = $false
+    StdOutTruncated = $false
+    StdErrTruncated = $false
+    OutputTruncated = $false
+    StdOutCharactersObserved = 0L
+    StdErrCharactersObserved = 0L
+    StdOutCaptureError = $null
+    StdErrCaptureError = $null
+    StdOut = ''
+    StdErr = ''
+  }
+  Set-BinderProcessLifecycleV1 `
+    -Lifecycle $ProcessLifecycle `
+    -Values $state
+
+  $gate = $null
+  $job = $null
+  $process = $null
+  $stdoutCapture = $null
+  $stderrCapture = $null
+  $supervisorStarted = $false
+  $jobAssigned = $false
+  $output = $null
+
+  try {
+    $gateName = (
+      'Local\GrookaiBinderRolloutV1-' +
+      [guid]::NewGuid().ToString('N')
+    )
+    $createdNew = $false
+    $gate = [Threading.EventWaitHandle]::new(
+      $false,
+      [Threading.EventResetMode]::ManualReset,
+      $gateName,
+      [ref]$createdNew
+    )
+    Assert-BinderConditionV1 $createdNew (
+      'A unique rollout supervisor gate could not be created.'
+    )
+    $job = [Grookai.Vault.RolloutV1.BinderJob]::new()
+
+    $payload = [ordered]@{
+      GateName = $gateName
+      FilePath = $resolvedFilePath
+      WorkingDirectory = $resolvedWorkingDirectory
+      Arguments = @($Arguments)
+    }
+    $payloadJson = $payload | ConvertTo-Json -Depth 4 -Compress
+    $payloadBase64 = [Convert]::ToBase64String(
+      [Text.Encoding]::UTF8.GetBytes($payloadJson)
+    )
+    Assert-BinderConditionV1 (
+      $payloadBase64.Length -le 24000
+    ) 'Contained command payload is too large.'
+
+    $start = [System.Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+    $start.WorkingDirectory = $resolvedWorkingDirectory
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.RedirectStandardInput = $true
+    foreach ($argument in @(
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-EncodedCommand',
+      (Get-BinderSupervisorEncodedCommandV1)
+    )) {
+      [void]$start.ArgumentList.Add($argument)
+    }
+    if ($SanitizeDatabaseEnvironment) {
+      foreach ($name in @($start.Environment.Keys)) {
+        if (Test-BinderRoutingEnvironmentNameV1 -Name $name) {
+          [void]$start.Environment.Remove($name)
+        }
+      }
+    }
+    $start.Environment[
+      'GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1'
+    ] = $payloadBase64
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    Assert-BinderConditionV1 (
+      $process.Start()
+    ) "Unable to start contained supervisor for: $resolvedFilePath"
+    $supervisorStarted = $true
+    $state.SupervisorProcessId = $process.Id
+    Set-BinderProcessLifecycleV1 `
+      -Lifecycle $ProcessLifecycle `
+      -Values $state
+    $process.StandardInput.Close()
+    $stdoutCapture = [Grookai.Vault.RolloutV1.BinderBoundedTextCapture]::new(
+      $process.StandardOutput,
+      $maximumOutputCharacters
+    )
+    $stderrCapture = [Grookai.Vault.RolloutV1.BinderBoundedTextCapture]::new(
+      $process.StandardError,
+      $maximumOutputCharacters
+    )
+
+    $job.Assign($process)
+    $jobAssigned = $true
+    $startedAtUtc = [datetime]::UtcNow.ToString('o')
+    $state.Started = $true
+    $state.StartedAtUtc = $startedAtUtc
+    Set-BinderProcessLifecycleV1 `
+      -Lifecycle $ProcessLifecycle `
+      -Values $state
+    Assert-BinderConditionV1 ($gate.Set()) (
+      'Contained supervisor gate could not be released.'
+    )
+
+    $normalWait = Wait-BinderContainedTreeV1 `
+      -RootProcess $process `
+      -Job $job `
+      -TimeoutMilliseconds ($TimeoutSeconds * 1000)
+    $state.RootExited = [bool]$normalWait.RootExited
+    $state.ProcessTreeEmpty = [bool]$normalWait.ProcessTreeEmpty
+    $state.TerminationConfirmed = [bool]$normalWait.TerminationConfirmed
+
+    if (-not $state.TerminationConfirmed) {
+      $state.TimedOut = $true
+      $termination = Stop-BinderContainedTreeV1 `
+        -RootProcess $process `
+        -Job $job
+      $state.KillAttempted = $termination.KillAttempted
+      $state.KillRequestSucceeded =
+        $termination.KillRequestSucceeded
+      $state.KillRequestError = $termination.KillRequestError
+      $state.RootExited = $termination.RootExited
+      $state.ProcessTreeEmpty = $termination.ProcessTreeEmpty
+      $state.TerminationConfirmed =
+        $termination.TerminationConfirmed
+      if (-not $state.TerminationConfirmed) {
+        Set-BinderProcessLifecycleV1 `
+          -Lifecycle $ProcessLifecycle `
+          -Values $state
+        [Environment]::FailFast(
+          'Rollout process-tree termination could not be confirmed; ' +
+          'the kill-on-close Job Object handle is intentionally still open.'
+        )
+      }
+    }
+
+    if ($state.RootExited) {
+      $state.ExitCode = $process.ExitCode
+    }
+    $state.EndedAtUtc = [datetime]::UtcNow.ToString('o')
+    $output = Complete-BinderProcessOutputV1 `
+      -StdOutCapture $stdoutCapture `
+      -StdErrCapture $stderrCapture `
+      -MaximumCharacters $maximumOutputCharacters
+    foreach ($property in $output.PSObject.Properties) {
+      $state[$property.Name] = $property.Value
+    }
+    Set-BinderProcessLifecycleV1 `
+      -Lifecycle $ProcessLifecycle `
+      -Values $state
+
+    return [pscustomobject][ordered]@{
+      ExitCode = $state.ExitCode
+      TimedOut = [bool]$state.TimedOut
+      KillAttempted = [bool]$state.KillAttempted
+      KillRequestSucceeded = $state.KillRequestSucceeded
+      KillRequestError = $state.KillRequestError
+      RootExited = [bool]$state.RootExited
+      ProcessTreeEmpty = [bool]$state.ProcessTreeEmpty
+      TerminationConfirmed = [bool]$state.TerminationConfirmed
+      StdOut = $state.StdOut
+      StdErr = $state.StdErr
+      StdOutCaptureCompleted =
+        [bool]$state.StdOutCaptureCompleted
+      StdErrCaptureCompleted =
+        [bool]$state.StdErrCaptureCompleted
+      OutputCaptureCompleted =
+        [bool]$state.OutputCaptureCompleted
+      StdOutTruncated = [bool]$state.StdOutTruncated
+      StdErrTruncated = [bool]$state.StdErrTruncated
+      OutputTruncated = [bool]$state.OutputTruncated
+      StdOutCharactersObserved =
+        [long]$state.StdOutCharactersObserved
+      StdErrCharactersObserved =
+        [long]$state.StdErrCharactersObserved
+      StdOutCaptureError = $state.StdOutCaptureError
+      StdErrCaptureError = $state.StdErrCaptureError
+      Arguments = @($Arguments)
+      Started = $true
+      StartedAtUtc = $startedAtUtc
+      SupervisorProcessId = $state.SupervisorProcessId
+      EndedAtUtc = $state.EndedAtUtc
+    }
+  } catch {
+    $originalError = $_
+    if ($supervisorStarted) {
+      if ($jobAssigned) {
+        $termination = Stop-BinderContainedTreeV1 `
+          -RootProcess $process `
+          -Job $job
+        $state.KillAttempted = $termination.KillAttempted
+        $state.KillRequestSucceeded =
+          $termination.KillRequestSucceeded
+        $state.KillRequestError = $termination.KillRequestError
+        $state.RootExited = $termination.RootExited
+        $state.ProcessTreeEmpty = $termination.ProcessTreeEmpty
+        $state.TerminationConfirmed =
+          $termination.TerminationConfirmed
+        if (-not $state.TerminationConfirmed) {
+          Set-BinderProcessLifecycleV1 `
+            -Lifecycle $ProcessLifecycle `
+            -Values $state
+          [Environment]::FailFast(
+            'Exceptional rollout process-tree termination could not be ' +
+            'confirmed; the kill-on-close Job Object handle is ' +
+            'intentionally still open.'
+          )
+        }
+      } else {
+        $state.KillAttempted = $true
+        try {
+          if ($process.HasExited) {
+            $state.KillRequestSucceeded = $true
+          } else {
+            $process.Kill($true)
+            $state.KillRequestSucceeded = $true
+          }
+        } catch {
+          $state.KillRequestSucceeded = $false
+          $state.KillRequestError = $_.Exception.Message
+        }
+        $confirmation = Wait-BinderContainedTreeV1 `
+          -RootProcess $process `
+          -Job $job `
+          -TimeoutMilliseconds 5000
+        $state.RootExited = $confirmation.RootExited
+        $state.ProcessTreeEmpty =
+          $confirmation.ProcessTreeEmpty
+        $state.TerminationConfirmed =
+          $confirmation.TerminationConfirmed
+        if (-not $state.TerminationConfirmed) {
+          [Environment]::FailFast(
+            'The gated rollout supervisor could not be terminated ' +
+            'before Job Object assignment.'
+          )
+        }
+      }
+    }
+    if ($null -ne $process) {
+      try {
+        if ($process.HasExited) {
+          $state.ExitCode = $process.ExitCode
+        }
+      } catch {
+      }
+    }
+    if ($state.TerminationConfirmed) {
+      $state.EndedAtUtc = [datetime]::UtcNow.ToString('o')
+    }
+    $output = Complete-BinderProcessOutputV1 `
+      -StdOutCapture $stdoutCapture `
+      -StdErrCapture $stderrCapture `
+      -MaximumCharacters $maximumOutputCharacters
+    foreach ($property in $output.PSObject.Properties) {
+      $state[$property.Name] = $property.Value
+    }
+    Set-BinderProcessLifecycleV1 `
+      -Lifecycle $ProcessLifecycle `
+      -Values $state
+    throw $originalError
+  } finally {
+    if ($null -ne $process) {
+      $process.Dispose()
+    }
+    if ($null -ne $job) {
+      $job.Dispose()
+    }
+    if ($null -ne $gate) {
+      $gate.Dispose()
+    }
+  }
+}
+
+function Get-BinderCommandPathV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  Assert-BinderConditionV1 ($null -ne $command) "Required command is unavailable: $Name"
+  return $command.Source
+}
+
+function Get-BinderSupabaseExecutableV1 {
+  $launcherPath = Get-BinderCommandPathV1 -Name 'supabase'
+  $binaryPath = $launcherPath
+  $shimDescriptorPath = $null
+  $shimDescriptor = [System.IO.Path]::ChangeExtension(
+    $launcherPath,
+    '.shim'
+  )
+
+  if (Test-Path -LiteralPath $shimDescriptor -PathType Leaf) {
+    $shimDescriptorPath = [System.IO.Path]::GetFullPath($shimDescriptor)
+    $shimDescriptorItem = Get-Item -LiteralPath $shimDescriptorPath
+    Assert-BinderConditionV1 (
+      -not $shimDescriptorItem.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) 'Supabase shim descriptor must not be a reparse point.'
+    $descriptor = Get-Content -LiteralPath $shimDescriptor -Raw
+    $pathMatch = [regex]::Match(
+      $descriptor,
+      '(?m)^\s*path\s*=\s*"(?<path>[^"]+)"\s*$'
+    )
+    Assert-BinderConditionV1 $pathMatch.Success 'Supabase shim target could not be resolved.'
+    $candidate = [System.IO.Path]::GetFullPath(
+      $pathMatch.Groups['path'].Value
+    )
+    $candidateParent = Get-Item -LiteralPath (
+      Split-Path -Parent $candidate
+    )
+    if ($candidateParent.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )) {
+      $resolvedParent = $candidateParent.ResolveLinkTarget($true)
+      Assert-BinderConditionV1 ($null -ne $resolvedParent) 'Supabase binary parent link could not be resolved.'
+      $candidate = Join-Path $resolvedParent.FullName (
+        Split-Path -Leaf $candidate
+      )
+    }
+    Assert-BinderConditionV1 (Test-Path -LiteralPath $candidate -PathType Leaf) 'Resolved Supabase binary does not exist.'
+    $binaryPath = $candidate
+  }
+
+  return [pscustomobject]@{
+    LauncherPath = $launcherPath
+    BinaryPath = $binaryPath
+    ShimDescriptorPath = $shimDescriptorPath
+  }
+}
+
+function Invoke-BinderGitV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [int]$TimeoutSeconds = 60
+  )
+
+  return Invoke-BinderProcessV1 `
+    -FilePath (Get-BinderCommandPathV1 -Name 'git') `
+    -Arguments $Arguments `
+    -WorkingDirectory $RepoRoot `
+    -TimeoutSeconds $TimeoutSeconds
+}
+
+function Invoke-BinderSupabaseV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [int]$TimeoutSeconds = 120,
+
+    [object]$ProcessLifecycle,
+
+    [string]$ExecutablePath
+  )
+
+  $resolvedExecutablePath = if (
+    [string]::IsNullOrWhiteSpace($ExecutablePath)
+  ) {
+    (Get-BinderSupabaseExecutableV1).BinaryPath
+  } else {
+    [System.IO.Path]::GetFullPath($ExecutablePath)
+  }
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $resolvedExecutablePath -PathType Leaf
+  ) 'Resolved Supabase executable is missing.'
+  return Invoke-BinderProcessV1 `
+    -FilePath $resolvedExecutablePath `
+    -Arguments $Arguments `
+    -WorkingDirectory $RepoRoot `
+    -TimeoutSeconds $TimeoutSeconds `
+    -SanitizeDatabaseEnvironment `
+    -ProcessLifecycle $ProcessLifecycle
+}
+
+function Assert-BinderCommandSucceededV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Result,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $terminationConfirmed = (
+    $null -ne $Result.PSObject.Properties['TerminationConfirmed'] -and
+    $Result.TerminationConfirmed -eq $true
+  )
+  $outputCaptureCompleted = (
+    $null -ne $Result.PSObject.Properties['OutputCaptureCompleted'] -and
+    $Result.OutputCaptureCompleted -eq $true
+  )
+  if (
+    -not $terminationConfirmed -or
+    -not $outputCaptureCompleted -or
+    $Result.TimedOut -or
+    $Result.ExitCode -ne 0
+  ) {
+    $detail = ($Result.StdErr + "`n" + $Result.StdOut).Trim()
+    if (-not $terminationConfirmed) {
+      throw "$Label did not confirm root exit and an empty process tree. $detail"
+    }
+    if (-not $outputCaptureCompleted) {
+      throw "$Label output capture did not complete. $detail"
+    }
+    if ($Result.TimedOut) {
+      throw "$Label timed out; exit code $($Result.ExitCode). $detail"
+    }
+    throw "$Label failed with exit code $($Result.ExitCode). $detail"
+  }
+}
+
+function ConvertFrom-SupabaseMigrationListV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Text
+  )
+
+  $clean = Remove-AnsiV1 -Text $Text
+  $rows = [System.Collections.Generic.List[object]]::new()
+  foreach ($line in ($clean -split "`r?`n")) {
+    $match = [regex]::Match(
+      $line,
+      '^\s*(?<local>\d{8,14})?\s*\|\s*(?<remote>\d{8,14})?\s*\|\s*(?<time>.+?)\s*$'
+    )
+    if (-not $match.Success) {
+      continue
+    }
+    $local = $match.Groups['local'].Value
+    $remote = $match.Groups['remote'].Value
+    if ([string]::IsNullOrWhiteSpace($local) -and [string]::IsNullOrWhiteSpace($remote)) {
+      continue
+    }
+    $rows.Add([pscustomobject]@{
+      Local = $local
+      Remote = $remote
+      Time = $match.Groups['time'].Value.Trim()
+    })
+  }
+
+  Assert-BinderConditionV1 ($rows.Count -gt 0) 'Linked migration ledger contained no parseable rows.'
+
+  $shared = @($rows | Where-Object { $_.Local -and $_.Remote })
+  $localOnly = @($rows | Where-Object { $_.Local -and -not $_.Remote })
+  $remoteOnly = @($rows | Where-Object { -not $_.Local -and $_.Remote })
+
+  return [pscustomobject]@{
+    Rows = @($rows)
+    Shared = $shared
+    LocalOnly = $localOnly
+    RemoteOnly = $remoteOnly
+  }
+}
+
+function Assert-BinderLedgerV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Ledger,
+
+    [ValidateSet('PreApply', 'PostApply')]
+    [string]$ExpectedState
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  foreach ($row in @($Ledger.Shared)) {
+    Assert-BinderConditionV1 ($row.Local -ceq $row.Remote) "Linked ledger mismatch: $($row.Local) != $($row.Remote)."
+  }
+
+  $allLocal = @($Ledger.Rows | Where-Object Local | ForEach-Object Local)
+  $allRemote = @($Ledger.Rows | Where-Object Remote | ForEach-Object Remote)
+  Assert-BinderConditionV1 ((@($allLocal | Sort-Object -Unique).Count) -eq $allLocal.Count) 'Duplicate local migration IDs detected.'
+  Assert-BinderConditionV1 ((@($allRemote | Sort-Object -Unique).Count) -eq $allRemote.Count) 'Duplicate remote migration IDs detected.'
+  Assert-BinderConditionV1 ($Ledger.RemoteOnly.Count -eq 0) 'Remote-only migrations detected; stop without repair.'
+
+  if ($ExpectedState -eq 'PreApply') {
+    $actual = @($Ledger.LocalOnly | ForEach-Object Local)
+    Assert-BinderConditionV1 ($actual.Count -eq $policy.MigrationVersions.Count) 'Pending migration count is not exactly five.'
+    for ($index = 0; $index -lt $policy.MigrationVersions.Count; $index += 1) {
+      Assert-BinderConditionV1 ($actual[$index] -ceq $policy.MigrationVersions[$index]) "Pending migration order mismatch at position $index."
+    }
+    return
+  }
+
+  Assert-BinderConditionV1 ($Ledger.LocalOnly.Count -eq 0) 'Local-only migrations remain after apply.'
+  $sharedIds = @($Ledger.Shared | ForEach-Object Local)
+  foreach ($version in $policy.MigrationVersions) {
+    Assert-BinderConditionV1 ($sharedIds -contains $version) "Applied Binder migration missing from linked ledger: $version"
+  }
+}
+
+function Assert-ExactBinderPendingSetV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Ledger
+  )
+
+  Assert-BinderLedgerV1 -Ledger $Ledger -ExpectedState PreApply
+}
+
+function Assert-ExactBinderLedgerDeltaV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Before,
+
+    [Parameter(Mandatory = $true)]
+    [object]$After
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $beforeRemote = @(
+    $Before.Rows |
+      Where-Object Remote |
+      ForEach-Object Remote
+  )
+  $afterRemote = @(
+    $After.Rows |
+      Where-Object Remote |
+      ForEach-Object Remote
+  )
+  $beforeSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  foreach ($version in $beforeRemote) {
+    [void]$beforeSet.Add($version)
+  }
+  $afterSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  foreach ($version in $afterRemote) {
+    [void]$afterSet.Add($version)
+  }
+
+  foreach ($version in $beforeRemote) {
+    Assert-BinderConditionV1 (
+      $afterSet.Contains($version)
+    ) "Remote migration disappeared during apply: $version"
+  }
+  $delta = @(
+    $afterRemote |
+      Where-Object { -not $beforeSet.Contains($_) }
+  )
+  Assert-BinderConditionV1 (
+    $delta.Count -eq $policy.MigrationVersions.Count
+  ) 'Remote migration delta is not exactly five.'
+  for ($index = 0; $index -lt $policy.MigrationVersions.Count; $index += 1) {
+    Assert-BinderConditionV1 (
+      $delta[$index] -ceq $policy.MigrationVersions[$index]
+    ) "Remote migration delta mismatch at position $index."
+  }
+  Assert-BinderConditionV1 (
+    $afterRemote.Count -eq
+      ($beforeRemote.Count + $policy.MigrationVersions.Count)
+  ) 'Remote migration ledger changed outside the exact Binder delta.'
+}
+
+function ConvertFrom-SupabaseDryRunV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Text
+  )
+
+  $clean = Remove-AnsiV1 -Text $Text
+  $lower = $clean.ToLowerInvariant()
+  Assert-BinderConditionV1 (-not $lower.Contains('remote database is up to date')) 'Dry-run unexpectedly reported no pending migrations.'
+  Assert-BinderConditionV1 (-not [regex]::IsMatch($lower, '\b(error|failed|repair)\b')) 'Dry-run output contained a failure or repair marker.'
+
+  $ordered = [System.Collections.Generic.List[string]]::new()
+  $seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  foreach ($match in [regex]::Matches(
+    $clean,
+    '\b\d{14}_[A-Za-z0-9_.-]+\.sql\b'
+  )) {
+    if ($seen.Add($match.Value)) {
+      $ordered.Add($match.Value)
+    }
+  }
+
+  $policy = Get-BinderRolloutPolicyV1
+  Assert-BinderConditionV1 ($ordered.Count -eq $policy.MigrationFiles.Count) 'Dry-run did not identify exactly five migration files.'
+  for ($index = 0; $index -lt $policy.MigrationFiles.Count; $index += 1) {
+    Assert-BinderConditionV1 ($ordered[$index] -ceq $policy.MigrationFiles[$index]) "Dry-run migration order mismatch at position $index."
+  }
+
+  return [pscustomobject]@{
+    MigrationFiles = @($ordered)
+  }
+}
+
+function Assert-BinderSqlReadOnlyV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $sql = Get-Content -LiteralPath $Path -Raw
+  $withoutStringLiterals = [regex]::Replace(
+    $sql,
+    "'(?:''|[^'])*'",
+    "''"
+  )
+  $withoutComments = [regex]::Replace(
+    $withoutStringLiterals,
+    '(?ms)--.*?$|/\*.*?\*/',
+    ''
+  )
+  Assert-BinderConditionV1 ($withoutComments.TrimStart() -match '^(?i:with)\b') "Readback SQL must be one CTE SELECT statement: $Path"
+  Assert-BinderConditionV1 (-not $withoutComments.Contains(';')) "Readback SQL must contain exactly one prepared statement and no semicolon: $Path"
+  Assert-BinderConditionV1 (
+    -not [regex]::IsMatch(
+      $withoutComments,
+      '(?i)\b(insert|update|delete|merge|create|alter|drop|truncate|grant|revoke|copy|call|do|vacuum|analyze|refresh)\b'
+    )
+  ) "Mutation-capable SQL keyword detected in readback file: $Path"
+}
+
+function Get-BinderTrackedMigrationSetV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $migrationRoot = [System.IO.Path]::GetFullPath(
+    (Join-Path $RepoRoot 'supabase/migrations')
+  )
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $migrationRoot -PathType Container
+  ) 'Supabase migration directory was not found.'
+  $migrationRootItem = Get-Item -LiteralPath $migrationRoot
+  Assert-BinderConditionV1 (
+    -not $migrationRootItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'Supabase migration directory must not be a reparse point.'
+
+  $trackedResult = Invoke-BinderGitV1 `
+    -Arguments @(
+      'ls-files',
+      '--stage',
+      '--',
+      ':(top,glob)supabase/migrations/*.sql'
+    ) `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $trackedResult `
+    -Label 'tracked migration inventory'
+
+  $trackedRows = [System.Collections.Generic.List[object]]::new()
+  foreach ($line in ($trackedResult.StdOut -split "`r?`n")) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+      continue
+    }
+    $match = [regex]::Match(
+      $line,
+      '^(?<mode>\d{6}) (?<blob>[0-9a-f]{40,64}) (?<stage>\d+)\t(?<path>.+)$'
+    )
+    Assert-BinderConditionV1 $match.Success "Unparseable tracked migration row: $line"
+    Assert-BinderConditionV1 (
+      $match.Groups['mode'].Value -ceq '100644'
+    ) "Tracked migration is not a regular non-executable file: $line"
+    Assert-BinderConditionV1 (
+      $match.Groups['stage'].Value -ceq '0'
+    ) "Tracked migration has an unresolved index stage: $line"
+
+    $relativePath = $match.Groups['path'].Value.Replace('\', '/')
+    Assert-BinderConditionV1 (
+      $relativePath -cmatch
+        '^supabase/migrations/\d{8,14}_[A-Za-z0-9_.-]+\.sql$'
+    ) "Tracked top-level migration has an invalid path: $relativePath"
+    $trackedRows.Add([pscustomobject][ordered]@{
+      RelativePath = $relativePath
+      GitBlobSha = $match.Groups['blob'].Value
+    })
+  }
+  Assert-BinderConditionV1 (
+    $trackedRows.Count -gt 0
+  ) 'No tracked top-level Supabase migrations were found.'
+
+  $trackedRows = @(
+    $trackedRows |
+      Sort-Object -Property RelativePath -CaseSensitive
+  )
+  $workingRows = @(
+    Get-ChildItem -LiteralPath $migrationRoot -File -Filter '*.sql' -Force |
+      ForEach-Object {
+        $relativePath = (
+          'supabase/migrations/' + $_.Name
+        ).Replace('\', '/')
+        [pscustomobject][ordered]@{
+          RelativePath = $relativePath
+          FullPath = $_.FullName
+          Item = $_
+        }
+      } |
+      Sort-Object -Property RelativePath -CaseSensitive
+  )
+  Assert-BinderConditionV1 (
+    $workingRows.Count -eq $trackedRows.Count
+  ) 'Working migration set does not exactly match the tracked top-level SQL set.'
+  for ($index = 0; $index -lt $trackedRows.Count; $index += 1) {
+    Assert-BinderConditionV1 (
+      $workingRows[$index].RelativePath -ceq
+        $trackedRows[$index].RelativePath
+    ) "Working migration set drift at position $index."
+    Assert-BinderConditionV1 (
+      -not $workingRows[$index].Item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "Tracked migration must not be a reparse point: $($workingRows[$index].RelativePath)"
+  }
+
+  $entries = @(
+    for ($index = 0; $index -lt $trackedRows.Count; $index += 1) {
+      [pscustomobject][ordered]@{
+        RelativePath = $trackedRows[$index].RelativePath
+        FullPath = $workingRows[$index].FullPath
+        GitBlobSha = $trackedRows[$index].GitBlobSha
+        Sha256 = Get-BinderSha256FileV1 -Path $workingRows[$index].FullPath
+      }
+    }
+  )
+  $setFingerprint = Get-BinderSha256StringV1 -Value (
+    @(
+      $entries | ForEach-Object {
+        "$($_.RelativePath)|$($_.Sha256)"
+      }
+    ) -join "`n"
+  )
+
+  return [pscustomobject][ordered]@{
+    Count = $entries.Count
+    Sha256 = $setFingerprint
+    Entries = $entries
+  }
+}
+
+function Test-BinderSourceV1 {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Get-BinderRepoRootV1)
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $package = Read-BinderPackageManifestV1 -RepoRoot $RepoRoot
+  $trackedMigrationSet = Get-BinderTrackedMigrationSetV1 -RepoRoot $RepoRoot
+
+  Assert-BinderConditionV1 (@($package.Data.migrations).Count -eq 5) 'Package manifest must contain exactly five migrations.'
+  for ($index = 0; $index -lt $policy.MigrationFiles.Count; $index += 1) {
+    $entry = @($package.Data.migrations)[$index]
+    Assert-BinderConditionV1 ($entry.version -ceq $policy.MigrationVersions[$index]) "Manifest migration version mismatch at position $index."
+    Assert-BinderConditionV1 ($entry.file -ceq $policy.MigrationFiles[$index]) "Manifest migration filename mismatch at position $index."
+    Assert-BinderConditionV1 ($entry.sha256 -ceq $policy.MigrationSha256[$index]) "Manifest migration hash mismatch at position $index."
+
+    $path = Join-Path $RepoRoot "supabase/migrations/$($entry.file)"
+    $actualHash = Get-BinderSha256FileV1 -Path $path
+    Assert-BinderConditionV1 ($actualHash -ceq $entry.sha256) "Migration bytes have drifted: $($entry.file)"
+  }
+
+  $preflightSql = Join-Path $RepoRoot $policy.PreflightSqlRelativePath
+  $postApplySql = Join-Path $RepoRoot $policy.PostApplySqlRelativePath
+  $expectedReadbacks = @(
+    [pscustomobject]@{
+      Phase = 'pre_apply'
+      File = $policy.PreflightSqlRelativePath.Replace('\', '/')
+    },
+    [pscustomobject]@{
+      Phase = 'post_apply'
+      File = $policy.PostApplySqlRelativePath.Replace('\', '/')
+    }
+  )
+  Assert-BinderConditionV1 (@($package.Data.readback_sql).Count -eq 2) 'Package manifest must contain exactly two readback SQL files.'
+  for ($index = 0; $index -lt $expectedReadbacks.Count; $index += 1) {
+    $entry = @($package.Data.readback_sql)[$index]
+    Assert-BinderConditionV1 ($entry.phase -ceq $expectedReadbacks[$index].Phase) "Readback SQL phase mismatch at position $index."
+    Assert-BinderConditionV1 ($entry.file.Replace('\', '/') -ceq $expectedReadbacks[$index].File) "Readback SQL path mismatch at position $index."
+    $actualReadbackHash = Get-BinderSha256FileV1 -Path (
+      Join-Path $RepoRoot $entry.file
+    )
+    Assert-BinderConditionV1 ($actualReadbackHash -ceq $entry.sha256) "Readback SQL bytes have drifted: $($entry.file)"
+  }
+  Assert-BinderSqlReadOnlyV1 -Path $preflightSql
+  Assert-BinderSqlReadOnlyV1 -Path $postApplySql
+
+  $configPath = Join-Path $RepoRoot 'supabase/config.toml'
+  $config = Get-Content -LiteralPath $configPath -Raw
+  $projectMatch = [regex]::Match(
+    $config,
+    '(?m)^\s*project_id\s*=\s*"(?<ref>[^"]+)"\s*$'
+  )
+  Assert-BinderConditionV1 ($projectMatch.Success) 'supabase/config.toml has no project_id.'
+  Assert-BinderConditionV1 ($projectMatch.Groups['ref'].Value -ceq $policy.ProjectRef) 'supabase/config.toml project_id is not production.'
+
+  $originResult = Invoke-BinderGitV1 -Arguments @('remote', 'get-url', 'origin') -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $originResult -Label 'git remote get-url origin'
+  $origin = $originResult.StdOut.Trim()
+  $normalizedOrigin = $origin `
+    -replace '^https://github\.com/', '' `
+    -replace '^git@github\.com:', '' `
+    -replace '\.git$', ''
+  Assert-BinderConditionV1 ($normalizedOrigin -ceq $policy.CanonicalRepository) 'Git origin is not the canonical Grookai Vault repository.'
+
+  $ancestorResult = Invoke-BinderGitV1 `
+    -Arguments @('cat-file', '-e', "$($policy.RequiredAncestorSha)^{commit}") `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $ancestorResult -Label 'required ancestor lookup'
+
+  $supabaseExecutable = Get-BinderSupabaseExecutableV1
+  $versionResult = Invoke-BinderProcessV1 `
+    -FilePath $supabaseExecutable.BinaryPath `
+    -Arguments @('--version') `
+    -WorkingDirectory $RepoRoot `
+    -TimeoutSeconds 30
+  Assert-BinderCommandSucceededV1 -Result $versionResult -Label 'supabase --version'
+  $version = $versionResult.StdOut.Trim()
+  Assert-BinderConditionV1 ($version -ceq $policy.SupportedSupabaseCliVersion) "Supabase CLI must be exactly $($policy.SupportedSupabaseCliVersion); found $version."
+  $launcherSha256 = Get-BinderSha256FileV1 -Path $supabaseExecutable.LauncherPath
+  $binarySha256 = Get-BinderSha256FileV1 -Path $supabaseExecutable.BinaryPath
+  Assert-BinderConditionV1 (
+    -not [string]::IsNullOrWhiteSpace(
+      [string]$supabaseExecutable.ShimDescriptorPath
+    )
+  ) 'The reviewed Supabase Scoop shim descriptor is missing.'
+  $shimDescriptorSha256 = Get-BinderSha256FileV1 `
+    -Path $supabaseExecutable.ShimDescriptorPath
+  Assert-BinderConditionV1 (
+    $launcherSha256 -ceq $policy.SupabaseCliLauncherSha256
+  ) 'Supabase CLI launcher is not the reviewed binary.'
+  Assert-BinderConditionV1 (
+    $binarySha256 -ceq $policy.SupabaseCliBinarySha256
+  ) 'Supabase CLI binary is not the reviewed binary.'
+  Assert-BinderConditionV1 (
+    $shimDescriptorSha256 -ceq
+      $policy.SupabaseCliShimDescriptorSha256
+  ) 'Supabase CLI shim descriptor is not the reviewed descriptor.'
+
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    PackageId = $policy.PackageId
+    PackageFingerprintSha256 = $package.FingerprintSha256
+    PackageManifestFileSha256 = $package.FileSha256
+    ProjectRef = $policy.ProjectRef
+    SupabaseCliVersion = $version
+    SupabaseCliLauncherSha256 = $launcherSha256
+    SupabaseCliBinarySha256 = $binarySha256
+    SupabaseCliShimDescriptorSha256 = $shimDescriptorSha256
+    TrackedMigrationCount = $trackedMigrationSet.Count
+    TrackedMigrationSetSha256 = $trackedMigrationSet.Sha256
+    MigrationFiles = @(
+      for ($index = 0; $index -lt $policy.MigrationFiles.Count; $index += 1) {
+        [pscustomobject][ordered]@{
+          version = $policy.MigrationVersions[$index]
+          file = $policy.MigrationFiles[$index]
+          sha256 = $policy.MigrationSha256[$index]
+        }
+      }
+    )
+  }
+}
+
+function Assert-BinderRepositoryStateV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedHeadSha
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  Assert-BinderConditionV1 ($ExpectedHeadSha -cmatch '^[0-9a-f]{40}$') 'ExpectedHeadSha must be a lowercase 40-character commit SHA.'
+
+  $status = Invoke-BinderGitV1 `
+    -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $status -Label 'git status'
+  Assert-BinderConditionV1 ([string]::IsNullOrWhiteSpace($status.StdOut)) 'Production rollout requires a completely clean worktree.'
+
+  $head = Invoke-BinderGitV1 -Arguments @('rev-parse', 'HEAD') -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $head -Label 'git rev-parse HEAD'
+  Assert-BinderConditionV1 ($head.StdOut.Trim() -ceq $ExpectedHeadSha) 'Current HEAD does not match the reviewed rollout SHA.'
+
+  $branch = Invoke-BinderGitV1 -Arguments @('branch', '--show-current') -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $branch -Label 'git branch --show-current'
+  Assert-BinderConditionV1 ($branch.StdOut.Trim() -ceq 'main') 'Production rollout must run from the main branch.'
+
+  $remote = Invoke-BinderGitV1 `
+    -Arguments @('ls-remote', 'origin', 'refs/heads/main') `
+    -RepoRoot $RepoRoot `
+    -TimeoutSeconds 60
+  Assert-BinderCommandSucceededV1 -Result $remote -Label 'git ls-remote origin main'
+  $remoteSha = (($remote.StdOut.Trim() -split '\s+')[0])
+  Assert-BinderConditionV1 ($remoteSha -ceq $ExpectedHeadSha) 'origin/main does not match the reviewed rollout SHA.'
+
+  $ancestor = Invoke-BinderGitV1 `
+    -Arguments @('merge-base', '--is-ancestor', $policy.RequiredAncestorSha, $ExpectedHeadSha) `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $ancestor -Label 'Binder required ancestor check'
+
+  return [pscustomobject][ordered]@{
+    HeadSha = $ExpectedHeadSha
+    OriginMainSha = $remoteSha
+    Branch = 'main'
+    Clean = $true
+  }
+}
+
+function Assert-BinderNoRoutingOverridesV1 {
+  $present = @(
+    foreach ($entry in Get-ChildItem Env:) {
+      if (Test-BinderRoutingEnvironmentNameV1 -Name $entry.Name) {
+        $entry.Name
+      }
+    }
+  )
+  Assert-BinderConditionV1 ($present.Count -eq 0) "Database routing overrides are forbidden for this rollout: $($present -join ', ')"
+}
+
+function Assert-ProjectBindingV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  Assert-BinderNoRoutingOverridesV1
+
+  $linkedRefPath = Join-Path $RepoRoot 'supabase/.temp/project-ref'
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $linkedRefPath -PathType Leaf) 'This worktree is not explicitly linked; refusing to link automatically.'
+  $linkedRef = (Get-Content -LiteralPath $linkedRefPath -Raw).Trim()
+  Assert-BinderConditionV1 ($linkedRef -ceq $policy.ProjectRef) 'Linked Supabase project ref is not production.'
+
+  Assert-BinderConditionV1 (-not [string]::IsNullOrWhiteSpace($env:SUPABASE_URL)) 'SUPABASE_URL is required for independent project binding.'
+  try {
+    $supabaseUri = [uri]$env:SUPABASE_URL
+  } catch {
+    throw 'SUPABASE_URL is not a valid absolute URL.'
+  }
+  Assert-BinderConditionV1 ($supabaseUri.Scheme -ceq 'https') 'SUPABASE_URL must use HTTPS.'
+  Assert-BinderConditionV1 ($supabaseUri.Host -ceq "$($policy.ProjectRef).supabase.co") 'SUPABASE_URL host is not the production project.'
+  Assert-BinderConditionV1 ($supabaseUri.IsDefaultPort -or $supabaseUri.Port -eq 443) 'SUPABASE_URL must use the standard HTTPS port.'
+  Assert-BinderConditionV1 ([string]::IsNullOrWhiteSpace($supabaseUri.UserInfo)) 'SUPABASE_URL must not contain credentials.'
+  Assert-BinderConditionV1 ($supabaseUri.AbsolutePath -ceq '/') 'SUPABASE_URL must be the exact project origin without a path.'
+  Assert-BinderConditionV1 ([string]::IsNullOrWhiteSpace($supabaseUri.Query)) 'SUPABASE_URL must not contain a query.'
+  Assert-BinderConditionV1 ([string]::IsNullOrWhiteSpace($supabaseUri.Fragment)) 'SUPABASE_URL must not contain a fragment.'
+
+  $projectsResult = Invoke-BinderSupabaseV1 `
+    -Arguments @('projects', 'list', '--output', 'json', '--agent', 'no') `
+    -RepoRoot $RepoRoot `
+    -TimeoutSeconds 60
+  Assert-BinderCommandSucceededV1 -Result $projectsResult -Label 'supabase projects list'
+  $projects = @($projectsResult.StdOut | ConvertFrom-Json)
+  $matches = @($projects | Where-Object {
+    ($_.ref -ceq $policy.ProjectRef -or $_.id -ceq $policy.ProjectRef) -and
+    $_.status -ceq 'ACTIVE_HEALTHY'
+  })
+  Assert-BinderConditionV1 ($matches.Count -eq 1) 'Production project was not identified exactly once as ACTIVE_HEALTHY.'
+  $databaseHost = [string]$matches[0].database.host
+  Assert-BinderConditionV1 ($databaseHost -ceq "db.$($policy.ProjectRef).supabase.co") 'Project database host does not match production.'
+
+  return [pscustomobject][ordered]@{
+    ProjectRef = $policy.ProjectRef
+    ApiHost = $supabaseUri.Host
+    DatabaseHost = $databaseHost
+    Status = [string]$matches[0].status
+  }
+}
+
+function Test-BackupEvidenceV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [datetime]$NowUtc = [datetime]::UtcNow
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  $rootPath = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd('\', '/')
+  Assert-BinderConditionV1 (-not $fullPath.StartsWith("$rootPath\", [System.StringComparison]::OrdinalIgnoreCase)) 'Backup evidence must be outside the repository.'
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $fullPath -PathType Leaf) 'Backup evidence file does not exist.'
+
+  $evidence = Get-Content -LiteralPath $fullPath -Raw | ConvertFrom-Json
+  $allowedProperties = @(
+    'schema_version',
+    'project_ref',
+    'backup_kind',
+    'verified_at_utc',
+    'recoverable_through_utc',
+    'evidence_reference',
+    'restore_path_reviewed',
+    'operator'
+  )
+  $actualProperties = @($evidence.PSObject.Properties.Name | Sort-Object)
+  $expectedProperties = @($allowedProperties | Sort-Object)
+  Assert-BinderConditionV1 (($actualProperties -join "`n") -ceq ($expectedProperties -join "`n")) 'Backup evidence fields are missing or unexpected.'
+  Assert-BinderConditionV1 ($evidence.schema_version -eq 1) 'Backup evidence schema version mismatch.'
+  Assert-BinderConditionV1 ($evidence.project_ref -ceq $policy.ProjectRef) 'Backup evidence project mismatch.'
+  Assert-BinderConditionV1 (@('supabase_pitr', 'supabase_platform_backup', 'verified_logical_backup') -ccontains $evidence.backup_kind) 'Unsupported backup evidence kind.'
+  Assert-BinderConditionV1 ($evidence.restore_path_reviewed -eq $true) 'Backup restore path has not been reviewed.'
+  Assert-BinderConditionV1 (-not [string]::IsNullOrWhiteSpace($evidence.evidence_reference)) 'Backup evidence reference is blank.'
+  Assert-BinderConditionV1 (-not [string]::IsNullOrWhiteSpace($evidence.operator)) 'Backup evidence operator is blank.'
+
+  $verifiedAt = [datetime]::Parse(
+    [string]$evidence.verified_at_utc,
+    [cultureinfo]::InvariantCulture,
+    [System.Globalization.DateTimeStyles]::AdjustToUniversal
+  )
+  $recoverableThrough = [datetime]::Parse(
+    [string]$evidence.recoverable_through_utc,
+    [cultureinfo]::InvariantCulture,
+    [System.Globalization.DateTimeStyles]::AdjustToUniversal
+  )
+  Assert-BinderConditionV1 ($verifiedAt -le $NowUtc.AddMinutes(5)) 'Backup verification time is in the future.'
+  Assert-BinderConditionV1 ($verifiedAt -ge $NowUtc.AddHours(-$policy.BackupMaxAgeHours)) 'Backup verification is stale.'
+  Assert-BinderConditionV1 ($recoverableThrough -le $NowUtc.AddMinutes(5)) 'Backup recovery horizon is in the future.'
+  Assert-BinderConditionV1 ($recoverableThrough -ge $NowUtc.AddMinutes(-$policy.BackupRecoveryLagMinutes)) 'Backup recovery horizon is too old.'
+
+  return [pscustomobject][ordered]@{
+    Path = $fullPath
+    Sha256 = Get-BinderSha256FileV1 -Path $fullPath
+    Kind = [string]$evidence.backup_kind
+    VerifiedAtUtc = $verifiedAt.ToString('o')
+    RecoverableThroughUtc = $recoverableThrough.ToString('o')
+    EvidenceReference = [string]$evidence.evidence_reference
+    RestorePathReviewed = $true
+    Operator = [string]$evidence.operator
+  }
+}
+
+function Get-BinderWorktreePathsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $result = Invoke-BinderGitV1 -Arguments @('worktree', 'list', '--porcelain') -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $result -Label 'git worktree list'
+  return @(
+    foreach ($line in ($result.StdOut -split "`r?`n")) {
+      if ($line.StartsWith('worktree ')) {
+        [System.IO.Path]::GetFullPath($line.Substring(9).Trim()).TrimEnd('\', '/')
+      }
+    }
+  )
+}
+
+function Assert-BinderArtifactRootV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [bool]$MustExist
+  )
+
+  Assert-BinderConditionV1 ([System.IO.Path]::IsPathFullyQualified($Path)) 'ArtifactRoot must be an absolute path.'
+  $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\', '/')
+  if ($MustExist) {
+    Assert-BinderConditionV1 (Test-Path -LiteralPath $fullPath -PathType Container) 'ArtifactRoot does not exist.'
+  } else {
+    Assert-BinderConditionV1 (-not (Test-Path -LiteralPath $fullPath)) 'ArtifactRoot must not already exist.'
+  }
+
+  foreach ($worktree in (Get-BinderWorktreePathsV1 -RepoRoot $RepoRoot)) {
+    $insideWorktree = (
+      $fullPath.Equals(
+        $worktree,
+        [System.StringComparison]::OrdinalIgnoreCase
+      ) -or
+      $fullPath.StartsWith(
+        "$worktree\",
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    )
+    Assert-BinderConditionV1 (-not $insideWorktree) "ArtifactRoot must be outside every Git worktree: $worktree"
+  }
+
+  $cursor = if (Test-Path -LiteralPath $fullPath) {
+    $fullPath
+  } else {
+    Split-Path -Parent $fullPath
+  }
+  while ($cursor -and -not (Test-Path -LiteralPath $cursor)) {
+    $parent = Split-Path -Parent $cursor
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -ceq $cursor) {
+      break
+    }
+    $cursor = $parent
+  }
+  while ($cursor -and (Test-Path -LiteralPath $cursor)) {
+    $item = Get-Item -LiteralPath $cursor
+    Assert-BinderConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "ArtifactRoot path contains a reparse point: $cursor"
+    $parent = Split-Path -Parent $cursor
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -ceq $cursor) {
+      break
+    }
+    $cursor = $parent
+  }
+
+  return $fullPath
+}
+
+function New-BinderArtifactRootV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $fullPath = Assert-BinderArtifactRootV1 `
+    -Path $Path `
+    -RepoRoot $RepoRoot `
+    -MustExist $false
+  [void][System.IO.Directory]::CreateDirectory($fullPath)
+  [void](Assert-BinderArtifactRootV1 `
+    -Path $fullPath `
+    -RepoRoot $RepoRoot `
+    -MustExist $true)
+  return $fullPath
+}
+
+function Write-BinderAtomicTextV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string]$Value
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  Assert-BinderConditionV1 (-not (Test-Path -LiteralPath $fullPath)) "Evidence file already exists: $fullPath"
+  $directory = Split-Path -Parent $fullPath
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $directory -PathType Container) "Evidence directory does not exist: $directory"
+  $temporaryPath = Join-Path $directory (
+    '.binder-rollout-' + [guid]::NewGuid().ToString('N') + '.tmp'
+  )
+  try {
+    [System.IO.File]::WriteAllText(
+      $temporaryPath,
+      $Value,
+      [System.Text.UTF8Encoding]::new($false)
+    )
+    [System.IO.File]::Move(
+      $temporaryPath,
+      $fullPath,
+      $false
+    )
+  } finally {
+    if (Test-Path -LiteralPath $temporaryPath) {
+      Remove-Item -LiteralPath $temporaryPath -Force
+    }
+  }
+}
+
+function Write-BinderJsonV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [object]$Value
+  )
+
+  $json = $Value | ConvertTo-Json -Depth 32
+  Write-BinderAtomicTextV1 `
+    -Path $Path `
+    -Value ($json + [Environment]::NewLine)
+}
+
+function Write-BinderTextV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [AllowEmptyString()]
+    [string]$Value = ''
+  )
+
+  Write-BinderAtomicTextV1 -Path $Path -Value $Value
+}
+
+function Write-BinderChecksumsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Root
+  )
+
+  $checksumPath = Join-Path $Root 'checksums.sha256'
+  Assert-BinderConditionV1 (-not (Test-Path -LiteralPath $checksumPath)) 'Checksum bundle already exists.'
+  $lines = @(
+    Get-ChildItem -LiteralPath $Root -File -Recurse |
+      Where-Object { $_.FullName -cne $checksumPath } |
+      Sort-Object FullName |
+      ForEach-Object {
+        $relative = [System.IO.Path]::GetRelativePath(
+          $Root,
+          $_.FullName
+        ).Replace('\', '/')
+        "$(Get-BinderSha256FileV1 -Path $_.FullName)  $relative"
+      }
+  )
+  Write-BinderTextV1 `
+    -Path $checksumPath `
+    -Value (($lines -join "`n") + "`n")
+}
+
+function Assert-BinderSafeStageRootV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [bool]$MustExist
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\', '/')
+  $temporaryRoot = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::GetTempPath()
+  ).TrimEnd('\', '/')
+  Assert-BinderConditionV1 (
+    (Split-Path -Parent $fullPath).Equals(
+      $temporaryRoot,
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  ) 'Staged Supabase root must be a direct child of the OS temporary directory.'
+  Assert-BinderConditionV1 (
+    (Split-Path -Leaf $fullPath) -cmatch
+      '^grookai-binder-rollout-v1-[0-9a-f]{32}$'
+  ) 'Staged Supabase root name is invalid.'
+  $temporaryRootItem = Get-Item -LiteralPath $temporaryRoot
+  Assert-BinderConditionV1 (
+    -not $temporaryRootItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'OS temporary directory must not be a reparse point.'
+  if ($MustExist) {
+    Assert-BinderConditionV1 (
+      Test-Path -LiteralPath $fullPath -PathType Container
+    ) 'Staged Supabase root no longer exists.'
+    $item = Get-Item -LiteralPath $fullPath
+    Assert-BinderConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) 'Staged Supabase root must not be a reparse point.'
+  } else {
+    Assert-BinderConditionV1 (
+      -not (Test-Path -LiteralPath $fullPath)
+    ) 'Staged Supabase root already exists.'
+  }
+  return $fullPath
+}
+
+function Restore-BinderDirectoryAclV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Sddl
+  )
+
+  $acl = Get-Acl -LiteralPath $Path
+  $acl.SetSecurityDescriptorSddlForm($Sddl)
+  Set-Acl -LiteralPath $Path -AclObject $acl
+}
+
+function Protect-BinderStagedMigrationDirectoryV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  Assert-BinderConditionV1 $IsWindows 'Production staging requires Windows ACL enforcement.'
+  $acl = Get-Acl -LiteralPath $Path
+  $originalSddl = $acl.Sddl
+  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+  Assert-BinderConditionV1 (
+    $null -ne $identity
+  ) 'Current Windows identity SID could not be resolved.'
+  $rights = (
+    [System.Security.AccessControl.FileSystemRights]::CreateFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::CreateDirectories -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteData -bor
+    [System.Security.AccessControl.FileSystemRights]::AppendData -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::Delete
+  )
+  $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+    $identity,
+    $rights,
+    (
+      [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+      [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+    ),
+    [System.Security.AccessControl.PropagationFlags]::None,
+    [System.Security.AccessControl.AccessControlType]::Deny
+  )
+  $probePath = Join-Path $Path (
+    '.write-denial-probe-' + [guid]::NewGuid().ToString('N') + '.sql'
+  )
+  try {
+    [void]$acl.AddAccessRule($rule)
+    Set-Acl -LiteralPath $Path -AclObject $acl
+
+    $creationDenied = $false
+    try {
+      $probe = [System.IO.File]::Open(
+        $probePath,
+        [System.IO.FileMode]::CreateNew,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+      )
+      $probe.Dispose()
+    } catch {
+      $exception = $_.Exception
+      $creationDenied = (
+        $exception -is [System.UnauthorizedAccessException] -or
+        $exception.InnerException -is [System.UnauthorizedAccessException]
+      )
+      if (-not $creationDenied) {
+        throw
+      }
+    }
+    Assert-BinderConditionV1 $creationDenied 'Staged migration directory still permits file creation.'
+    Assert-BinderConditionV1 (
+      -not (Test-Path -LiteralPath $probePath)
+    ) 'Staged migration ACL probe unexpectedly created a file.'
+    return $originalSddl
+  } catch {
+    try {
+      Restore-BinderDirectoryAclV1 -Path $Path -Sddl $originalSddl
+    } catch {
+    }
+    if (Test-Path -LiteralPath $probePath) {
+      Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
+    }
+    throw
+  }
+}
+
+function Get-BinderSealedStageManifestV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Stage
+  )
+
+  [void](Assert-BinderSafeStageRootV1 -Path $Stage.Root -MustExist $true)
+  $expectedEntries = @(
+    $Stage.MigrationEntries |
+      Sort-Object -Property RelativePath -CaseSensitive
+  )
+  $actualFiles = @(
+    Get-ChildItem `
+      -LiteralPath $Stage.MigrationDirectory `
+      -File `
+      -Filter '*.sql' `
+      -Force |
+      Sort-Object -Property Name -CaseSensitive
+  )
+  Assert-BinderConditionV1 (
+    $actualFiles.Count -eq $expectedEntries.Count
+  ) 'Sealed staged migration file count is not exact.'
+
+  $sealedEntries = @(
+    for ($index = 0; $index -lt $expectedEntries.Count; $index += 1) {
+      $expected = $expectedEntries[$index]
+      $actual = $actualFiles[$index]
+      $expectedLeaf = Split-Path -Leaf ([string]$expected.RelativePath)
+      Assert-BinderConditionV1 (
+        $actual.Name -ceq $expectedLeaf
+      ) "Sealed staged migration set drift at position $index."
+      Assert-BinderConditionV1 (
+        -not $actual.Attributes.HasFlag(
+          [System.IO.FileAttributes]::ReparsePoint
+        )
+      ) "Sealed staged migration is a reparse point: $($actual.Name)"
+      $actualHash = Get-BinderSha256FileV1 -Path $actual.FullName
+      Assert-BinderConditionV1 (
+        $actualHash -ceq [string]$expected.Sha256
+      ) "Sealed staged migration hash mismatch: $($actual.Name)"
+      [pscustomobject][ordered]@{
+        file = $actual.Name
+        sha256 = $actualHash
+      }
+    }
+  )
+  $setFingerprint = Get-BinderSha256StringV1 -Value (
+    @(
+      $sealedEntries | ForEach-Object {
+        "supabase/migrations/$($_.file)|$($_.sha256)"
+      }
+    ) -join "`n"
+  )
+  Assert-BinderConditionV1 (
+    $setFingerprint -ceq [string]$Stage.MigrationSetSha256
+  ) 'Sealed staged migration-set fingerprint mismatch.'
+
+  $configHash = Get-BinderSha256FileV1 -Path $Stage.ConfigPath
+  Assert-BinderConditionV1 (
+    $configHash -ceq [string]$Stage.ExpectedConfigSha256
+  ) 'Sealed staged Supabase config hash mismatch.'
+  $projectRef = (
+    Get-Content -LiteralPath $Stage.ProjectRefPath -Raw
+  ).Trim()
+  $policy = Get-BinderRolloutPolicyV1
+  Assert-BinderConditionV1 (
+    $projectRef -ceq $policy.ProjectRef
+  ) 'Sealed staged project ref changed.'
+
+  return [pscustomobject][ordered]@{
+    schema_version = 1
+    migration_count = $sealedEntries.Count
+    migration_set_sha256 = $setFingerprint
+    config_sha256 = $configHash
+    project_ref = $projectRef
+    migrations = $sealedEntries
+  }
+}
+
+function Close-BinderSupabaseStageV1 {
+  param(
+    [object]$Stage
+  )
+
+  if ($null -eq $Stage) {
+    return [pscustomobject][ordered]@{
+      Succeeded = $true
+      Root = $null
+      Message = ''
+    }
+  }
+
+  $messages = [System.Collections.Generic.List[string]]::new()
+  foreach ($stream in @($Stage.Streams)) {
+    if ($null -ne $stream) {
+      try {
+        $stream.Dispose()
+      } catch {
+        $messages.Add($_.Exception.Message)
+      }
+    }
+  }
+  if (-not (Test-Path -LiteralPath $Stage.Root)) {
+    try {
+      [void](Assert-BinderSafeStageRootV1 `
+        -Path $Stage.Root `
+        -MustExist $false)
+    } catch {
+      $messages.Add($_.Exception.Message)
+    }
+    return [pscustomobject][ordered]@{
+      Succeeded = ($messages.Count -eq 0)
+      Root = [string]$Stage.Root
+      Message = ($messages -join ' | ')
+    }
+  }
+  try {
+    $safeRoot = Assert-BinderSafeStageRootV1 `
+      -Path $Stage.Root `
+      -MustExist $true
+    foreach ($entry in @($Stage.OriginalMigrationFileAcls)) {
+      if (Test-Path -LiteralPath $entry.Path -PathType Leaf) {
+        Restore-BinderDirectoryAclV1 `
+          -Path $entry.Path `
+          -Sddl $entry.Sddl
+      }
+    }
+    if (-not [string]::IsNullOrWhiteSpace(
+      [string]$Stage.OriginalMigrationAclSddl
+    )) {
+      Restore-BinderDirectoryAclV1 `
+        -Path $Stage.MigrationDirectory `
+        -Sddl $Stage.OriginalMigrationAclSddl
+    }
+    Remove-Item -LiteralPath $safeRoot -Recurse -Force
+    Assert-BinderConditionV1 (
+      -not (Test-Path -LiteralPath $safeRoot)
+    ) 'Staged Supabase root was not removed.'
+  } catch {
+    $messages.Add($_.Exception.Message)
+  }
+
+  return [pscustomobject][ordered]@{
+    Succeeded = ($messages.Count -eq 0)
+    Root = [string]$Stage.Root
+    Message = ($messages -join ' | ')
+  }
+}
+
+function New-BinderSupabaseStageV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [object]$TrackedMigrationSet,
+
+    [object]$StageLifecycle
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $stageRoot = Join-Path (
+    [System.IO.Path]::GetTempPath()
+  ) (
+    'grookai-binder-rollout-v1-' + [guid]::NewGuid().ToString('N')
+  )
+  $stageRoot = Assert-BinderSafeStageRootV1 `
+    -Path $stageRoot `
+    -MustExist $false
+  $migrationDirectory = Join-Path $stageRoot 'supabase/migrations'
+  $tempDirectory = Join-Path $stageRoot 'supabase/.temp'
+  $stage = [pscustomobject][ordered]@{
+    Root = $stageRoot
+    MigrationDirectory = $migrationDirectory
+    OriginalMigrationAclSddl = $null
+    OriginalMigrationFileAcls = @()
+    Streams = @()
+    MigrationCount = 0
+    MigrationSetSha256 = ''
+    MigrationEntries = @()
+    ConfigPath = ''
+    ProjectRefPath = ''
+    ExpectedConfigSha256 = ''
+    SealedManifest = $null
+  }
+  if ($null -ne $StageLifecycle) {
+    $StageLifecycle.CreatedRoot = $stageRoot
+    $StageLifecycle.CleanupAttempted = $false
+    $StageLifecycle.CleanupSucceeded = $null
+    $StageLifecycle.CleanupMessage = ''
+  }
+
+  try {
+    [void][System.IO.Directory]::CreateDirectory($migrationDirectory)
+    [void][System.IO.Directory]::CreateDirectory($tempDirectory)
+    [void](Assert-BinderSafeStageRootV1 -Path $stageRoot -MustExist $true)
+
+    $sourceConfig = Join-Path $RepoRoot 'supabase/config.toml'
+    $sourceProjectRef = Join-Path $RepoRoot 'supabase/.temp/project-ref'
+    Assert-BinderConditionV1 (
+      Test-Path -LiteralPath $sourceConfig -PathType Leaf
+    ) 'Supabase config is missing while staging.'
+    Assert-BinderConditionV1 (
+      Test-Path -LiteralPath $sourceProjectRef -PathType Leaf
+    ) 'Linked project ref is missing while staging.'
+    $stagedConfig = Join-Path $stageRoot 'supabase/config.toml'
+    $stagedProjectRef = Join-Path $tempDirectory 'project-ref'
+    [System.IO.File]::Copy($sourceConfig, $stagedConfig, $false)
+    [System.IO.File]::Copy($sourceProjectRef, $stagedProjectRef, $false)
+    $sourceConfigHash = Get-BinderSha256FileV1 -Path $sourceConfig
+    Assert-BinderConditionV1 (
+      (Get-BinderSha256FileV1 -Path $stagedConfig) -ceq
+        $sourceConfigHash
+    ) 'Staged Supabase config hash mismatch.'
+    Assert-BinderConditionV1 (
+      (Get-Content -LiteralPath $stagedProjectRef -Raw).Trim() -ceq
+        $policy.ProjectRef
+    ) 'Staged project ref is not production.'
+
+    $stagedEntries = [System.Collections.Generic.List[object]]::new()
+    foreach ($entry in @($TrackedMigrationSet.Entries)) {
+      $leaf = Split-Path -Leaf ([string]$entry.RelativePath)
+      Assert-BinderConditionV1 (
+        $leaf -cmatch '^\d{8,14}_[A-Za-z0-9_.-]+\.sql$'
+      ) "Invalid migration entry supplied to staging: $($entry.RelativePath)"
+      $destination = Join-Path $migrationDirectory $leaf
+      [System.IO.File]::Copy(
+        [string]$entry.FullPath,
+        $destination,
+        $false
+      )
+      $actualHash = Get-BinderSha256FileV1 -Path $destination
+      Assert-BinderConditionV1 (
+        $actualHash -ceq [string]$entry.Sha256
+      ) "Staged migration hash mismatch: $leaf"
+      $stagedEntries.Add([pscustomobject][ordered]@{
+        RelativePath = "supabase/migrations/$leaf"
+        Sha256 = $actualHash
+        FullPath = $destination
+      })
+    }
+    $stagedEntries = @(
+      $stagedEntries |
+        Sort-Object -Property RelativePath -CaseSensitive
+    )
+    $stagedFiles = @(
+      Get-ChildItem -LiteralPath $migrationDirectory -File -Filter '*.sql' -Force |
+        Sort-Object -Property Name -CaseSensitive
+    )
+    Assert-BinderConditionV1 (
+      $stagedFiles.Count -eq @($TrackedMigrationSet.Entries).Count
+    ) 'Staged migration file count is not exact.'
+    $stageFingerprint = Get-BinderSha256StringV1 -Value (
+      @(
+        $stagedEntries | ForEach-Object {
+          "$($_.RelativePath)|$($_.Sha256)"
+        }
+      ) -join "`n"
+    )
+    Assert-BinderConditionV1 (
+      $stageFingerprint -ceq [string]$TrackedMigrationSet.Sha256
+    ) 'Staged migration-set fingerprint mismatch.'
+
+    $stage.OriginalMigrationFileAcls = @(
+      $stagedEntries | ForEach-Object {
+        [pscustomobject][ordered]@{
+          Path = $_.FullPath
+          Sddl = (Get-Acl -LiteralPath $_.FullPath).Sddl
+        }
+      }
+    )
+    $stage.OriginalMigrationAclSddl =
+      Protect-BinderStagedMigrationDirectoryV1 -Path $migrationDirectory
+    $streams = [System.Collections.Generic.List[System.IO.FileStream]]::new()
+    $stage.Streams = $streams
+    foreach ($path in @(
+      @($stagedEntries | ForEach-Object FullPath) +
+      @($stagedConfig, $stagedProjectRef)
+    )) {
+      $item = Get-Item -LiteralPath $path
+      Assert-BinderConditionV1 (
+        -not $item.Attributes.HasFlag(
+          [System.IO.FileAttributes]::ReparsePoint
+        )
+      ) "Staged source file must not be a reparse point: $path"
+      $streams.Add([System.IO.File]::Open(
+        $path,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::Read
+      ))
+    }
+    $stage.Streams = @($streams)
+    $stage.MigrationCount = $stagedEntries.Count
+    $stage.MigrationSetSha256 = $stageFingerprint
+    $stage.MigrationEntries = $stagedEntries
+    $stage.ConfigPath = $stagedConfig
+    $stage.ProjectRefPath = $stagedProjectRef
+    $stage.ExpectedConfigSha256 = $sourceConfigHash
+    $stage.SealedManifest = Get-BinderSealedStageManifestV1 -Stage $stage
+    return $stage
+  } catch {
+    $originalMessage = $_.Exception.Message
+    $cleanup = Close-BinderSupabaseStageV1 -Stage $stage
+    if ($null -ne $StageLifecycle) {
+      $StageLifecycle.CleanupAttempted = $true
+      $StageLifecycle.CleanupSucceeded = [bool]$cleanup.Succeeded
+      $StageLifecycle.CleanupMessage = [string]$cleanup.Message
+    }
+    if (-not $cleanup.Succeeded) {
+      throw (
+        "$originalMessage Staged source cleanup also failed at " +
+        "$($cleanup.Root): $($cleanup.Message)"
+      )
+    }
+    throw
+  }
+}
+
+function Get-BinderLedgerV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('PreApply', 'PostApply')]
+    [string]$ExpectedState,
+
+    [string]$ExecutablePath
+  )
+
+  $result = Invoke-BinderSupabaseV1 `
+    -Arguments @('migration', 'list', '--linked', '--agent', 'no') `
+    -RepoRoot $RepoRoot `
+    -TimeoutSeconds 90 `
+    -ExecutablePath $ExecutablePath
+  Assert-BinderCommandSucceededV1 -Result $result -Label 'linked migration ledger'
+  $ledger = ConvertFrom-SupabaseMigrationListV1 -Text $result.StdOut
+  Assert-BinderLedgerV1 -Ledger $ledger -ExpectedState $ExpectedState
+  return [pscustomobject]@{
+    Command = $result
+    Ledger = $ledger
+  }
+}
+
+function Invoke-BinderReadbackV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('PreApply', 'PostApply')]
+    [string]$ExpectedState,
+
+    [string]$ExecutablePath
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $relativePath = if ($ExpectedState -eq 'PreApply') {
+    $policy.PreflightSqlRelativePath
+  } else {
+    $policy.PostApplySqlRelativePath
+  }
+  $expectedSqlSha256 = if ($ExpectedState -eq 'PreApply') {
+    $policy.PreflightSqlSha256
+  } else {
+    $policy.PostApplySqlSha256
+  }
+  $sqlPath = Join-Path $RepoRoot $relativePath
+  $sqlItem = Get-Item -LiteralPath $sqlPath
+  Assert-BinderConditionV1 (
+    -not $sqlItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) "$ExpectedState readback SQL must not be a reparse point."
+  $sqlSeal = [System.IO.File]::Open(
+    $sqlPath,
+    [System.IO.FileMode]::Open,
+    [System.IO.FileAccess]::Read,
+    [System.IO.FileShare]::Read
+  )
+  try {
+    Assert-BinderConditionV1 (
+      (Get-BinderSha256FileV1 -Path $sqlPath) -ceq $expectedSqlSha256
+    ) "$ExpectedState readback SQL bytes are not the reviewed bytes."
+    Assert-BinderSqlReadOnlyV1 -Path $sqlPath
+
+    $result = Invoke-BinderSupabaseV1 `
+      -Arguments @(
+        'db',
+        'query',
+        '--linked',
+        '--file',
+        $sqlPath,
+        '--output',
+        'json',
+        '--agent',
+        'no'
+      ) `
+      -RepoRoot $RepoRoot `
+      -TimeoutSeconds 45 `
+      -ExecutablePath $ExecutablePath
+    Assert-BinderCommandSucceededV1 -Result $result -Label "$ExpectedState linked catalog readback"
+
+    $rows = @($result.StdOut | ConvertFrom-Json)
+    Assert-BinderConditionV1 ($rows.Count -eq 1) "$ExpectedState readback must return exactly one row."
+    Assert-BinderConditionV1 ($null -ne $rows[0].rollout_readback) "$ExpectedState readback payload is missing."
+    $report = $rows[0].rollout_readback
+    Assert-BinderConditionV1 ($report.read_only -eq $true) "$ExpectedState readback did not identify itself as read-only."
+    Assert-BinderConditionV1 ($report.ok -eq $true) "$ExpectedState readback failed its catalog contract."
+
+    return [pscustomobject]@{
+      Command = $result
+      Report = $report
+      ReportSha256 = Get-CanonicalSha256V1 -Value $report
+    }
+  } finally {
+    $sqlSeal.Dispose()
+  }
+}
+
+function Get-BinderDryRunV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $result = Invoke-BinderSupabaseV1 `
+    -Arguments @('db', 'push', '--dry-run', '--linked', '--agent', 'no') `
+    -RepoRoot $RepoRoot `
+    -TimeoutSeconds 120
+  Assert-BinderCommandSucceededV1 -Result $result -Label 'linked migration dry-run'
+  $parsed = ConvertFrom-SupabaseDryRunV1 -Text ($result.StdOut + "`n" + $result.StdErr)
+  return [pscustomobject]@{
+    Command = $result
+    Parsed = $parsed
+  }
+}
+
+function New-BinderPreflightCommandPlanV1 {
+  [CmdletBinding()]
+  param()
+
+  return @(
+    [pscustomobject]@{ Tool = 'supabase'; Arguments = @('projects', 'list', '--output', 'json', '--agent', 'no'); MutatesRemote = $false },
+    [pscustomobject]@{ Tool = 'supabase'; Arguments = @('migration', 'list', '--linked', '--agent', 'no'); MutatesRemote = $false },
+    [pscustomobject]@{ Tool = 'supabase'; Arguments = @('db', 'query', '--linked', '--file', '<reviewed-preflight-sql>', '--output', 'json', '--agent', 'no'); MutatesRemote = $false },
+    [pscustomobject]@{ Tool = 'supabase'; Arguments = @('db', 'push', '--dry-run', '--linked', '--agent', 'no'); MutatesRemote = $false }
+  )
+}
+
+function New-BinderApplyCommandPlanV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$AuthorizationValidated
+  )
+
+  Assert-BinderConditionV1 $AuthorizationValidated 'Apply command plan cannot be constructed before authorization validation.'
+  $policy = Get-BinderRolloutPolicyV1
+  return @(
+    [pscustomobject]@{
+      Tool = 'supabase'
+      Arguments = @($policy.ApplyArguments)
+      MutatesRemote = $true
+    }
+  )
+}
+
+function Invoke-BinderProductionPreflightV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedHeadSha,
+
+    [Parameter(Mandatory = $true)]
+    [string]$BackupEvidencePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactRoot,
+
+    [string]$RepoRoot = (Get-BinderRepoRootV1)
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
+  $repository = Assert-BinderRepositoryStateV1 -RepoRoot $RepoRoot -ExpectedHeadSha $ExpectedHeadSha
+  $project = Assert-ProjectBindingV1 -RepoRoot $RepoRoot
+  $backup = Test-BackupEvidenceV1 -Path $BackupEvidencePath -RepoRoot $RepoRoot
+  $evidenceRoot = New-BinderArtifactRootV1 -Path $ArtifactRoot -RepoRoot $RepoRoot
+
+  try {
+    $ledger = Get-BinderLedgerV1 -RepoRoot $RepoRoot -ExpectedState PreApply
+    $readback = Invoke-BinderReadbackV1 -RepoRoot $RepoRoot -ExpectedState PreApply
+    $dryRun = Get-BinderDryRunV1 -RepoRoot $RepoRoot
+
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'source.json') -Value $source
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'repository.json') -Value $repository
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'project-binding.json') -Value $project
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'backup-evidence.digest.json') -Value $backup
+    Write-BinderTextV1 -Path (Join-Path $evidenceRoot 'ledger.before.txt') -Value $ledger.Command.StdOut
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'ledger.before.json') -Value $ledger.Ledger
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'readback.before.json') -Value $readback.Report
+    Write-BinderTextV1 -Path (Join-Path $evidenceRoot 'dry-run.stdout.txt') -Value $dryRun.Command.StdOut
+    Write-BinderTextV1 -Path (Join-Path $evidenceRoot 'dry-run.stderr.txt') -Value $dryRun.Command.StdErr
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'dry-run.parsed.json') -Value $dryRun.Parsed
+
+    $created = [datetime]::UtcNow
+    $manifestCore = [ordered]@{
+      schema_version = 1
+      package_id = $policy.PackageId
+      status = 'pass'
+      created_at_utc = $created.ToString('o')
+      expires_at_utc = $created.AddHours($policy.PreflightTtlHours).ToString('o')
+      project_ref = $policy.ProjectRef
+      package_fingerprint_sha256 = $policy.PackageFingerprintSha256
+      package_manifest_file_sha256 = $source.PackageManifestFileSha256
+      head_sha = $repository.HeadSha
+      origin_main_sha = $repository.OriginMainSha
+      supabase_cli_version = $source.SupabaseCliVersion
+      supabase_cli_launcher_sha256 = $source.SupabaseCliLauncherSha256
+      supabase_cli_binary_sha256 = $source.SupabaseCliBinarySha256
+      supabase_cli_shim_descriptor_sha256 =
+        $source.SupabaseCliShimDescriptorSha256
+      tracked_migration_count = $source.TrackedMigrationCount
+      tracked_migration_set_sha256 = $source.TrackedMigrationSetSha256
+      migration_files = $source.MigrationFiles
+      pending_versions = @($ledger.Ledger.LocalOnly | ForEach-Object Local)
+      dry_run_files = @($dryRun.Parsed.MigrationFiles)
+      preapply_readback_sha256 = $readback.ReportSha256
+      stable_catalog_fingerprint_sha256 = [string]$readback.Report.checks.stable_catalog_fingerprint_sha256
+      backup_evidence_path = $backup.Path
+      backup_evidence_sha256 = $backup.Sha256
+      apply_argv = @($policy.ApplyArguments)
+    }
+    $manifestFingerprint = Get-CanonicalSha256V1 -Value $manifestCore
+    $preflightManifest = [ordered]@{}
+    foreach ($entry in $manifestCore.GetEnumerator()) {
+      $preflightManifest[$entry.Key] = $entry.Value
+    }
+    $preflightManifest['manifest_fingerprint_sha256'] = $manifestFingerprint
+
+    $manifestPath = Join-Path $evidenceRoot 'preflight-manifest.json'
+    Write-BinderJsonV1 -Path $manifestPath -Value $preflightManifest
+    $manifestFileSha = Get-BinderSha256FileV1 -Path $manifestPath
+    Write-BinderTextV1 -Path (Join-Path $evidenceRoot 'preflight-manifest.sha256') -Value ($manifestFileSha + [Environment]::NewLine)
+
+    $approval = "APPLY-COLLABORATIVE-BINDERS-V1::$($policy.ProjectRef)::$ExpectedHeadSha::$manifestFingerprint"
+    $backupApproval = "BACKUP-VERIFIED::$($policy.ProjectRef)::$($backup.Sha256)"
+    Write-BinderTextV1 -Path (Join-Path $evidenceRoot 'approval.txt') -Value (
+      "GROOKAI_BINDER_PROD_APPLY_ACK=$approval`n" +
+      "GROOKAI_BINDER_PROD_BACKUP_ACK=$backupApproval`n"
+    )
+    Write-BinderChecksumsV1 -Root $evidenceRoot
+
+    return [pscustomobject][ordered]@{
+      Status = 'pass'
+      ArtifactRoot = $evidenceRoot
+      ManifestPath = $manifestPath
+      ManifestFingerprintSha256 = $manifestFingerprint
+      ExpiresAtUtc = $preflightManifest.expires_at_utc
+    }
+  } catch {
+    Write-BinderJsonV1 -Path (Join-Path $evidenceRoot 'STOP-incident.json') -Value ([ordered]@{
+      status = 'stop'
+      phase = 'preflight'
+      recorded_at_utc = [datetime]::UtcNow.ToString('o')
+      message = $_.Exception.Message
+    })
+    try {
+      Write-BinderChecksumsV1 -Root $evidenceRoot
+    } catch {
+    }
+    throw
+  }
+}
+
+function Read-BinderPreflightManifestV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $fullPath -PathType Leaf) 'Preflight manifest was not found.'
+  $sidecar = Join-Path (Split-Path -Parent $fullPath) 'preflight-manifest.sha256'
+  Assert-BinderConditionV1 (Test-Path -LiteralPath $sidecar -PathType Leaf) 'Preflight manifest hash sidecar was not found.'
+  $expectedFileHash = (Get-Content -LiteralPath $sidecar -Raw).Trim()
+  Assert-BinderConditionV1 ($expectedFileHash -cmatch '^[0-9a-f]{64}$') 'Preflight manifest hash sidecar is invalid.'
+  Assert-BinderConditionV1 ((Get-BinderSha256FileV1 -Path $fullPath) -ceq $expectedFileHash) 'Preflight manifest file hash mismatch.'
+
+  $manifest = Get-Content -LiteralPath $fullPath -Raw | ConvertFrom-Json
+  $core = [ordered]@{}
+  foreach ($property in $manifest.PSObject.Properties) {
+    if ($property.Name -cne 'manifest_fingerprint_sha256') {
+      $core[$property.Name] = $property.Value
+    }
+  }
+  $fingerprint = Get-CanonicalSha256V1 -Value $core
+  Assert-BinderConditionV1 ($fingerprint -ceq $manifest.manifest_fingerprint_sha256) 'Preflight manifest fingerprint mismatch.'
+
+  return [pscustomobject]@{
+    Path = $fullPath
+    Data = $manifest
+    FingerprintSha256 = $fingerprint
+  }
+}
+
+function Test-PreflightManifestV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [datetime]$NowUtc = [datetime]::UtcNow
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $manifest = Read-BinderPreflightManifestV1 -Path $Path
+  $data = $manifest.Data
+
+  Assert-BinderConditionV1 ($data.schema_version -eq 1) 'Preflight manifest schema mismatch.'
+  Assert-BinderConditionV1 ($data.package_id -ceq $policy.PackageId) 'Preflight package mismatch.'
+  Assert-BinderConditionV1 ($data.status -ceq 'pass') 'Preflight status is not pass.'
+  Assert-BinderConditionV1 ($data.project_ref -ceq $policy.ProjectRef) 'Preflight project mismatch.'
+  Assert-BinderConditionV1 ($data.package_fingerprint_sha256 -ceq $policy.PackageFingerprintSha256) 'Preflight package fingerprint mismatch.'
+  Assert-BinderConditionV1 ($data.head_sha -cmatch '^[0-9a-f]{40}$') 'Preflight HEAD is invalid.'
+  Assert-BinderConditionV1 ($data.head_sha -ceq $data.origin_main_sha) 'Preflight HEAD and origin/main differ.'
+  Assert-BinderConditionV1 ($data.supabase_cli_version -ceq $policy.SupportedSupabaseCliVersion) 'Preflight CLI version mismatch.'
+  Assert-BinderConditionV1 ($data.supabase_cli_launcher_sha256 -ceq $policy.SupabaseCliLauncherSha256) 'Preflight CLI launcher hash mismatch.'
+  Assert-BinderConditionV1 ($data.supabase_cli_binary_sha256 -ceq $policy.SupabaseCliBinarySha256) 'Preflight CLI binary hash mismatch.'
+  Assert-BinderConditionV1 ($data.supabase_cli_shim_descriptor_sha256 -ceq $policy.SupabaseCliShimDescriptorSha256) 'Preflight CLI shim descriptor hash mismatch.'
+  Assert-BinderConditionV1 ((@($data.apply_argv) -join "`n") -ceq ($policy.ApplyArguments -join "`n")) 'Preflight apply argv drifted.'
+  Assert-BinderConditionV1 ($data.stable_catalog_fingerprint_sha256 -cmatch '^[0-9a-f]{64}$') 'Stable catalog fingerprint is missing or invalid.'
+  Assert-BinderConditionV1 ($data.tracked_migration_count -gt 0) 'Tracked migration count is invalid.'
+  Assert-BinderConditionV1 ($data.tracked_migration_set_sha256 -cmatch '^[0-9a-f]{64}$') 'Tracked migration-set fingerprint is invalid.'
+
+  $created = [datetime]::Parse([string]$data.created_at_utc).ToUniversalTime()
+  $expires = [datetime]::Parse([string]$data.expires_at_utc).ToUniversalTime()
+  Assert-BinderConditionV1 ($created -le $NowUtc.AddMinutes(5)) 'Preflight creation time is in the future.'
+  Assert-BinderConditionV1 ($expires -gt $NowUtc) 'Preflight manifest has expired.'
+  Assert-BinderConditionV1 ($expires -le $created.AddHours($policy.PreflightTtlHours)) 'Preflight validity exceeds four hours.'
+
+  return $manifest
+}
+
+function Assert-BinderApplyAuthorizationV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreflightManifest,
+
+    [Parameter(Mandatory = $true)]
+    [bool]$ConfirmProduction
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  Assert-BinderConditionV1 $ConfirmProduction 'Apply requires -ConfirmProduction.'
+  $expectedApply = "APPLY-COLLABORATIVE-BINDERS-V1::$($policy.ProjectRef)::$($PreflightManifest.head_sha)::$($PreflightManifest.manifest_fingerprint_sha256)"
+  $expectedBackup = "BACKUP-VERIFIED::$($policy.ProjectRef)::$($PreflightManifest.backup_evidence_sha256)"
+  Assert-BinderConditionV1 ($env:GROOKAI_BINDER_PROD_APPLY_ACK -ceq $expectedApply) 'Production apply acknowledgement is missing or not exact.'
+  Assert-BinderConditionV1 ($env:GROOKAI_BINDER_PROD_BACKUP_ACK -ceq $expectedBackup) 'Production backup acknowledgement is missing or not exact.'
+  return $true
+}
+
+function Open-BinderApplySealV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [object]$PreflightManifestEnvelope,
+
+    [Parameter(Mandatory = $true)]
+    [object]$PreflightManifest,
+
+    [Parameter(Mandatory = $true)]
+    [object]$TrackedMigrationSet,
+
+    [Parameter(Mandatory = $true)]
+    [object]$SupabaseExecutable
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $paths = [System.Collections.Generic.List[string]]::new()
+  Assert-BinderConditionV1 (
+    $TrackedMigrationSet.Count -eq $PreflightManifest.tracked_migration_count
+  ) 'Tracked migration count changed before the apply seal.'
+  Assert-BinderConditionV1 (
+    $TrackedMigrationSet.Sha256 -ceq
+      $PreflightManifest.tracked_migration_set_sha256
+  ) 'Tracked migration-set fingerprint changed before the apply seal.'
+  foreach ($migration in @($TrackedMigrationSet.Entries)) {
+    $paths.Add([string]$migration.FullPath)
+  }
+  foreach ($path in @(
+    (Join-Path $RepoRoot 'supabase/config.toml'),
+    (Join-Path $RepoRoot 'supabase/.temp/project-ref'),
+    (Join-Path $RepoRoot $policy.ManifestRelativePath),
+    (Join-Path $RepoRoot $policy.PreflightSqlRelativePath),
+    (Join-Path $RepoRoot $policy.PostApplySqlRelativePath),
+    $SupabaseExecutable.LauncherPath,
+    $SupabaseExecutable.BinaryPath,
+    $PreflightManifestEnvelope.Path,
+    (Join-Path (
+      Split-Path -Parent $PreflightManifestEnvelope.Path
+    ) 'preflight-manifest.sha256'),
+    [string]$PreflightManifest.backup_evidence_path
+  )) {
+    $paths.Add([System.IO.Path]::GetFullPath($path))
+  }
+  if (-not [string]::IsNullOrWhiteSpace(
+    [string]$SupabaseExecutable.ShimDescriptorPath
+  )) {
+    $paths.Add(
+      [System.IO.Path]::GetFullPath(
+        [string]$SupabaseExecutable.ShimDescriptorPath
+      )
+    )
+  }
+
+  $streams = [System.Collections.Generic.List[System.IO.FileStream]]::new()
+  try {
+    foreach ($path in @($paths | Sort-Object -Unique)) {
+      Assert-BinderConditionV1 (Test-Path -LiteralPath $path -PathType Leaf) "Apply seal file is missing: $path"
+      $item = Get-Item -LiteralPath $path
+      Assert-BinderConditionV1 (
+        -not $item.Attributes.HasFlag(
+          [System.IO.FileAttributes]::ReparsePoint
+        )
+      ) "Apply seal refuses a reparse-point file: $path"
+      $stream = [System.IO.File]::Open(
+        $path,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::Read
+      )
+      $streams.Add($stream)
+    }
+    return @($streams)
+  } catch {
+    foreach ($stream in $streams) {
+      $stream.Dispose()
+    }
+    throw
+  }
+}
+
+function Close-BinderApplySealV1 {
+  param(
+    [object[]]$Streams
+  )
+
+  foreach ($stream in @($Streams)) {
+    if ($null -ne $stream) {
+      $stream.Dispose()
+    }
+  }
+}
+
+function Assert-BinderFinalLocalSealV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [object]$PreflightManifest
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 ($source.PackageManifestFileSha256 -ceq $PreflightManifest.package_manifest_file_sha256) 'Package manifest changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.SupabaseCliLauncherSha256 -ceq $PreflightManifest.supabase_cli_launcher_sha256) 'Supabase launcher changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.SupabaseCliBinarySha256 -ceq $PreflightManifest.supabase_cli_binary_sha256) 'Supabase binary changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.SupabaseCliShimDescriptorSha256 -ceq $PreflightManifest.supabase_cli_shim_descriptor_sha256) 'Supabase shim descriptor changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.TrackedMigrationCount -eq $PreflightManifest.tracked_migration_count) 'Tracked migration count changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.TrackedMigrationSetSha256 -ceq $PreflightManifest.tracked_migration_set_sha256) 'Tracked migration-set fingerprint changed at the final apply seal.'
+
+  $status = Invoke-BinderGitV1 `
+    -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $status -Label 'final sealed git status'
+  Assert-BinderConditionV1 ([string]::IsNullOrWhiteSpace($status.StdOut)) 'Worktree changed before the production push.'
+
+  $head = Invoke-BinderGitV1 -Arguments @('rev-parse', 'HEAD') -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 -Result $head -Label 'final sealed HEAD'
+  Assert-BinderConditionV1 ($head.StdOut.Trim() -ceq $PreflightManifest.head_sha) 'HEAD changed before the production push.'
+
+  $linkedRef = (
+    Get-Content -LiteralPath (
+      Join-Path $RepoRoot 'supabase/.temp/project-ref'
+    ) -Raw
+  ).Trim()
+  Assert-BinderConditionV1 ($linkedRef -ceq $policy.ProjectRef) 'Linked project changed before the production push.'
+
+  $manifestFileHash = Get-BinderSha256FileV1 -Path $PreflightManifest.backup_evidence_path
+  Assert-BinderConditionV1 ($manifestFileHash -ceq $PreflightManifest.backup_evidence_sha256) 'Backup evidence changed before the production push.'
+}
+
+function Invoke-BinderProductionApplyV1 {
+  [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ManifestPath,
+
+    [Parameter(Mandatory = $true)]
+    [bool]$ConfirmProduction,
+
+    [string]$RepoRoot = (Get-BinderRepoRootV1)
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $manifestEnvelope = Test-PreflightManifestV1 -Path $ManifestPath
+  $manifest = $manifestEnvelope.Data
+  if (-not $PSCmdlet.ShouldProcess(
+    "Supabase production project $($policy.ProjectRef)",
+    'apply the exact Collaborative Binders V1 migration package'
+  )) {
+    return [pscustomobject][ordered]@{
+      status = 'not_applied'
+      package_id = $policy.PackageId
+      project_ref = $policy.ProjectRef
+      mutation_possible = $false
+    }
+  }
+  $artifactRoot = Assert-BinderArtifactRootV1 `
+    -Path (Split-Path -Parent $manifestEnvelope.Path) `
+    -RepoRoot $RepoRoot `
+    -MustExist $true
+  $applyRoot = Join-Path $artifactRoot (
+    'apply-' + [datetime]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+  )
+  Assert-BinderConditionV1 (-not (Test-Path -LiteralPath $applyRoot)) 'Apply evidence directory already exists.'
+  [void][System.IO.Directory]::CreateDirectory($applyRoot)
+  $pushAttempted = $false
+  $push = $null
+  $pushLifecycle = [pscustomobject][ordered]@{
+    Started = $false
+    StartedAtUtc = $null
+    SupervisorProcessId = $null
+    TimedOut = $false
+    KillAttempted = $false
+    KillRequestSucceeded = $null
+    KillRequestError = $null
+    RootExited = $false
+    ProcessTreeEmpty = $false
+    TerminationConfirmed = $false
+    ExitCode = $null
+    EndedAtUtc = $null
+    StdOutCaptureCompleted = $false
+    StdErrCaptureCompleted = $false
+    OutputCaptureCompleted = $false
+    StdOutTruncated = $false
+    StdErrTruncated = $false
+    OutputTruncated = $false
+    StdOutCharactersObserved = 0L
+    StdErrCharactersObserved = 0L
+    StdOutCaptureError = $null
+    StdErrCaptureError = $null
+    StdOut = ''
+    StdErr = ''
+  }
+  $pushSucceeded = $false
+  $sealStreams = @()
+  $supabaseExecutable = $null
+  $stage = $null
+  $stageCleanup = $null
+  $stageLifecycle = [pscustomobject][ordered]@{
+    CreatedRoot = $null
+    CleanupAttempted = $false
+    CleanupSucceeded = $null
+    CleanupMessage = ''
+  }
+
+  try {
+    $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 ($source.PackageManifestFileSha256 -ceq $manifest.package_manifest_file_sha256) 'Package manifest bytes changed after preflight.'
+    Assert-BinderConditionV1 ($source.SupabaseCliLauncherSha256 -ceq $manifest.supabase_cli_launcher_sha256) 'Supabase CLI launcher changed after preflight.'
+    Assert-BinderConditionV1 ($source.SupabaseCliBinarySha256 -ceq $manifest.supabase_cli_binary_sha256) 'Supabase CLI binary changed after preflight.'
+    Assert-BinderConditionV1 ($source.SupabaseCliShimDescriptorSha256 -ceq $manifest.supabase_cli_shim_descriptor_sha256) 'Supabase CLI shim descriptor changed after preflight.'
+    Assert-BinderConditionV1 ($source.TrackedMigrationCount -eq $manifest.tracked_migration_count) 'Tracked migration count changed after preflight.'
+    Assert-BinderConditionV1 ($source.TrackedMigrationSetSha256 -ceq $manifest.tracked_migration_set_sha256) 'Tracked migration-set fingerprint changed after preflight.'
+    [void](Assert-BinderRepositoryStateV1 -RepoRoot $RepoRoot -ExpectedHeadSha $manifest.head_sha)
+    [void](Assert-ProjectBindingV1 -RepoRoot $RepoRoot)
+
+    $backup = Test-BackupEvidenceV1 -Path $manifest.backup_evidence_path -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 ($backup.Sha256 -ceq $manifest.backup_evidence_sha256) 'Backup evidence changed after preflight.'
+
+    $ledgerBefore = Get-BinderLedgerV1 -RepoRoot $RepoRoot -ExpectedState PreApply
+    Write-BinderTextV1 `
+      -Path (Join-Path $applyRoot 'ledger.before.txt') `
+      -Value $ledgerBefore.Command.StdOut
+    Write-BinderJsonV1 `
+      -Path (Join-Path $applyRoot 'ledger.before.json') `
+      -Value $ledgerBefore.Ledger
+    $readbackBefore = Invoke-BinderReadbackV1 -RepoRoot $RepoRoot -ExpectedState PreApply
+    Assert-BinderConditionV1 ($readbackBefore.ReportSha256 -ceq $manifest.preapply_readback_sha256) 'Production pre-apply catalog changed after preflight.'
+    $dryRun = Get-BinderDryRunV1 -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 (
+      (@($dryRun.Parsed.MigrationFiles) -join "`n") -ceq (@($manifest.dry_run_files) -join "`n")
+    ) 'Migration dry-run changed after preflight.'
+
+    $authorized = Assert-BinderApplyAuthorizationV1 `
+      -PreflightManifest $manifest `
+      -ConfirmProduction $ConfirmProduction
+    $trackedMigrationSet = Get-BinderTrackedMigrationSetV1 -RepoRoot $RepoRoot
+    $supabaseExecutable = Get-BinderSupabaseExecutableV1
+    $sealStreams = Open-BinderApplySealV1 `
+      -RepoRoot $RepoRoot `
+      -PreflightManifestEnvelope $manifestEnvelope `
+      -PreflightManifest $manifest `
+      -TrackedMigrationSet $trackedMigrationSet `
+      -SupabaseExecutable $supabaseExecutable
+    Assert-BinderFinalLocalSealV1 `
+      -RepoRoot $RepoRoot `
+      -PreflightManifest $manifest
+    $plan = New-BinderApplyCommandPlanV1 -AuthorizationValidated $authorized
+    Assert-BinderConditionV1 ($plan.Count -eq 1) 'Apply plan must contain exactly one command.'
+
+    $stage = New-BinderSupabaseStageV1 `
+      -RepoRoot $RepoRoot `
+      -TrackedMigrationSet $trackedMigrationSet `
+      -StageLifecycle $stageLifecycle
+    try {
+      Assert-BinderConditionV1 (
+        $stage.MigrationSetSha256 -ceq
+          $manifest.tracked_migration_set_sha256
+      ) 'Immutable staged migration-set fingerprint mismatch.'
+      Write-BinderJsonV1 `
+        -Path (Join-Path $applyRoot 'sealed-source-manifest.json') `
+        -Value $stage.SealedManifest
+      $pushAttempted = $true
+      $push = Invoke-BinderSupabaseV1 `
+        -Arguments @($plan[0].Arguments) `
+        -RepoRoot $stage.Root `
+        -TimeoutSeconds 900 `
+        -ProcessLifecycle $pushLifecycle `
+        -ExecutablePath $supabaseExecutable.BinaryPath
+      $pushSucceeded = (
+        $push.Started -eq $true -and
+        $push.TerminationConfirmed -eq $true -and
+        -not $push.TimedOut -and
+        $push.ExitCode -eq 0
+      )
+    } finally {
+      if (
+        $pushLifecycle.Started -and
+        -not $pushLifecycle.TerminationConfirmed
+      ) {
+        [Environment]::FailFast(
+          'Staged-source cleanup was blocked because rollout ' +
+          'process-tree termination was not confirmed.'
+        )
+      }
+      if ($null -ne $stage) {
+        $stageCleanup = Close-BinderSupabaseStageV1 -Stage $stage
+        $stageLifecycle.CleanupAttempted = $true
+        $stageLifecycle.CleanupSucceeded =
+          [bool]$stageCleanup.Succeeded
+        $stageLifecycle.CleanupMessage =
+          [string]$stageCleanup.Message
+        $stage = $null
+      }
+    }
+    if ($null -ne $push) {
+      Write-BinderTextV1 -Path (Join-Path $applyRoot 'db-push.stdout.txt') -Value $push.StdOut
+      Write-BinderTextV1 -Path (Join-Path $applyRoot 'db-push.stderr.txt') -Value $push.StdErr
+    }
+    Assert-BinderConditionV1 (
+      $null -ne $stageCleanup -and $stageCleanup.Succeeded
+    ) "Immutable staged Supabase source cleanup failed: $($stageCleanup.Message)"
+    Assert-BinderConditionV1 ($null -ne $push) 'Production push did not return a process result.'
+    Assert-BinderCommandSucceededV1 -Result $push -Label 'production Binder migration push'
+
+    $ledgerAfter = Get-BinderLedgerV1 `
+      -RepoRoot $RepoRoot `
+      -ExpectedState PostApply `
+      -ExecutablePath $supabaseExecutable.BinaryPath
+    Assert-ExactBinderLedgerDeltaV1 `
+      -Before $ledgerBefore.Ledger `
+      -After $ledgerAfter.Ledger
+    $readbackAfter = Invoke-BinderReadbackV1 `
+      -RepoRoot $RepoRoot `
+      -ExpectedState PostApply `
+      -ExecutablePath $supabaseExecutable.BinaryPath
+    Assert-BinderConditionV1 (
+      [string]$readbackAfter.Report.checks.stable_catalog_fingerprint_sha256 -ceq
+        [string]$manifest.stable_catalog_fingerprint_sha256
+    ) 'Stable Trust/Vault/Pulse/card-event catalog changed outside the reviewed delta.'
+    Write-BinderTextV1 -Path (Join-Path $applyRoot 'ledger.after.txt') -Value $ledgerAfter.Command.StdOut
+    Write-BinderJsonV1 -Path (Join-Path $applyRoot 'ledger.after.json') -Value $ledgerAfter.Ledger
+    Write-BinderJsonV1 -Path (Join-Path $applyRoot 'readback.after.json') -Value $readbackAfter.Report
+
+    $result = [ordered]@{
+      status = 'pass'
+      package_id = $policy.PackageId
+      project_ref = $policy.ProjectRef
+      head_sha = $manifest.head_sha
+      package_fingerprint_sha256 = $policy.PackageFingerprintSha256
+      completed_at_utc = [datetime]::UtcNow.ToString('o')
+      push_attempted = $pushAttempted
+      push_started = [bool]$pushLifecycle.Started
+      push_started_at_utc = $pushLifecycle.StartedAtUtc
+      push_supervisor_process_id =
+        $pushLifecycle.SupervisorProcessId
+      push_ended_at_utc = $pushLifecycle.EndedAtUtc
+      push_succeeded = $pushSucceeded
+      push_timed_out = [bool]$pushLifecycle.TimedOut
+      push_kill_attempted = [bool]$pushLifecycle.KillAttempted
+      push_kill_request_succeeded =
+        $pushLifecycle.KillRequestSucceeded
+      push_kill_request_error = $pushLifecycle.KillRequestError
+      push_root_exited = [bool]$pushLifecycle.RootExited
+      push_process_tree_empty =
+        [bool]$pushLifecycle.ProcessTreeEmpty
+      push_termination_confirmed =
+        [bool]$pushLifecycle.TerminationConfirmed
+      push_exit_code = $pushLifecycle.ExitCode
+      push_output_capture_completed =
+        [bool]$pushLifecycle.OutputCaptureCompleted
+      push_stdout_truncated =
+        [bool]$pushLifecycle.StdOutTruncated
+      push_stderr_truncated =
+        [bool]$pushLifecycle.StdErrTruncated
+      mutation_possible = [bool]$pushLifecycle.Started
+      feature_flags_enabled = 0
+      excluded_flags = @($policy.ExcludedFlags)
+    }
+    Write-BinderJsonV1 -Path (Join-Path $applyRoot 'apply-result.json') -Value $result
+    Write-BinderChecksumsV1 -Root $applyRoot
+    return [pscustomobject]$result
+  } catch {
+    if (
+      $pushLifecycle.Started -and
+      -not $pushLifecycle.TerminationConfirmed
+    ) {
+      [Environment]::FailFast(
+        'Rollout incident handling was blocked because process-tree ' +
+        'termination was not confirmed.'
+      )
+    }
+    $diagnostic = [ordered]@{
+      status = 'stop'
+      package_id = $policy.PackageId
+      project_ref = $policy.ProjectRef
+      recorded_at_utc = [datetime]::UtcNow.ToString('o')
+      message = $_.Exception.Message
+      push_attempted = $pushAttempted
+      push_started = [bool]$pushLifecycle.Started
+      push_started_at_utc = $pushLifecycle.StartedAtUtc
+      push_supervisor_process_id =
+        $pushLifecycle.SupervisorProcessId
+      push_ended_at_utc = $pushLifecycle.EndedAtUtc
+      push_succeeded = if ($null -ne $push) {
+        [bool]$pushSucceeded
+      } elseif ($pushLifecycle.Started) {
+        $null
+      } else {
+        $false
+      }
+      push_exit_code = $pushLifecycle.ExitCode
+      push_timed_out = [bool]$pushLifecycle.TimedOut
+      push_kill_attempted = [bool]$pushLifecycle.KillAttempted
+      push_kill_request_succeeded =
+        $pushLifecycle.KillRequestSucceeded
+      push_kill_request_error = $pushLifecycle.KillRequestError
+      push_root_exited = [bool]$pushLifecycle.RootExited
+      push_process_tree_empty =
+        [bool]$pushLifecycle.ProcessTreeEmpty
+      push_termination_confirmed =
+        [bool]$pushLifecycle.TerminationConfirmed
+      push_output_capture_completed =
+        [bool]$pushLifecycle.OutputCaptureCompleted
+      push_stdout_truncated =
+        [bool]$pushLifecycle.StdOutTruncated
+      push_stderr_truncated =
+        [bool]$pushLifecycle.StdErrTruncated
+      mutation_possible = [bool]$pushLifecycle.Started
+      staged_source_cleanup_succeeded = if ($null -ne $stageCleanup) {
+        [bool]$stageCleanup.Succeeded
+      } elseif ($stageLifecycle.CleanupAttempted) {
+        [bool]$stageLifecycle.CleanupSucceeded
+      } elseif ($null -eq $stageLifecycle.CreatedRoot) {
+        $true
+      } else {
+        $false
+      }
+      staged_source_cleanup_message = if ($null -ne $stageCleanup) {
+        [string]$stageCleanup.Message
+      } else {
+        [string]$stageLifecycle.CleanupMessage
+      }
+      staged_source_cleanup_root = if (
+        (
+          $null -ne $stageCleanup -and
+          -not $stageCleanup.Succeeded
+        ) -or (
+          $stageLifecycle.CleanupAttempted -and
+          -not $stageLifecycle.CleanupSucceeded
+        )
+      ) {
+        [string]$stageLifecycle.CreatedRoot
+      } else {
+        $null
+      }
+      automatic_retry = $false
+      automatic_repair = $false
+      feature_flags_state = if ($pushLifecycle.Started) {
+        'unknown_until_diagnostic_readback'
+      } else {
+        'unchanged_by_rollout_guard'
+      }
+    }
+    if (
+      $pushLifecycle.Started -and
+      $pushLifecycle.TerminationConfirmed
+    ) {
+      if ($null -eq $push) {
+        Write-BinderTextV1 `
+          -Path (Join-Path $applyRoot 'db-push.stdout.txt') `
+          -Value ([string]$pushLifecycle.StdOut)
+        Write-BinderTextV1 `
+          -Path (Join-Path $applyRoot 'db-push.stderr.txt') `
+          -Value ([string]$pushLifecycle.StdErr)
+      }
+      try {
+        $diagnosticLedger = Invoke-BinderSupabaseV1 `
+          -Arguments @('migration', 'list', '--linked', '--agent', 'no') `
+          -RepoRoot $RepoRoot `
+          -TimeoutSeconds 90 `
+          -ExecutablePath $supabaseExecutable.BinaryPath
+        Write-BinderTextV1 -Path (Join-Path $applyRoot 'diagnostic-ledger.txt') -Value $diagnosticLedger.StdOut
+        if ($diagnosticLedger.ExitCode -eq 0 -and -not $diagnosticLedger.TimedOut) {
+          $parsedDiagnosticLedger = ConvertFrom-SupabaseMigrationListV1 -Text $diagnosticLedger.StdOut
+          Write-BinderJsonV1 -Path (Join-Path $applyRoot 'diagnostic-ledger.json') -Value $parsedDiagnosticLedger
+        }
+      } catch {
+      }
+      try {
+        $diagnosticSqlPath = Join-Path $RepoRoot $policy.PostApplySqlRelativePath
+        Assert-BinderConditionV1 (
+          (Get-BinderSha256FileV1 -Path $diagnosticSqlPath) -ceq
+            $policy.PostApplySqlSha256
+        ) 'Diagnostic readback SQL bytes are not the reviewed bytes.'
+        Assert-BinderSqlReadOnlyV1 -Path $diagnosticSqlPath
+        $diagnosticReadback = Invoke-BinderSupabaseV1 `
+          -Arguments @(
+            'db',
+            'query',
+            '--linked',
+            '--file',
+            $diagnosticSqlPath,
+            '--output',
+            'json',
+            '--agent',
+            'no'
+          ) `
+          -RepoRoot $RepoRoot `
+          -TimeoutSeconds 45 `
+          -ExecutablePath $supabaseExecutable.BinaryPath
+        Write-BinderTextV1 -Path (Join-Path $applyRoot 'diagnostic-readback.stdout.txt') -Value $diagnosticReadback.StdOut
+        Write-BinderTextV1 -Path (Join-Path $applyRoot 'diagnostic-readback.stderr.txt') -Value $diagnosticReadback.StdErr
+      } catch {
+      }
+    }
+    Write-BinderJsonV1 -Path (Join-Path $applyRoot 'STOP-incident.json') -Value $diagnostic
+    try {
+      Write-BinderChecksumsV1 -Root $applyRoot
+    } catch {
+    }
+    throw
+  } finally {
+    if (
+      $pushLifecycle.Started -and
+      -not $pushLifecycle.TerminationConfirmed
+    ) {
+      [Environment]::FailFast(
+        'Apply-seal cleanup was blocked because rollout process-tree ' +
+        'termination was not confirmed.'
+      )
+    }
+    Close-BinderApplySealV1 -Streams $sealStreams
+  }
+}
+
+Export-ModuleMember -Function @(
+  'Get-BinderRolloutPolicyV1',
+  'Get-CanonicalSha256V1',
+  'Remove-AnsiV1',
+  'ConvertFrom-SupabaseMigrationListV1',
+  'ConvertFrom-SupabaseDryRunV1',
+  'Assert-ExactBinderPendingSetV1',
+  'Assert-ProjectBindingV1',
+  'Test-BackupEvidenceV1',
+  'Test-PreflightManifestV1',
+  'Assert-BinderApplyAuthorizationV1',
+  'Test-BinderSourceV1',
+  'Invoke-BinderReadbackV1',
+  'Invoke-BinderProductionPreflightV1',
+  'Invoke-BinderProductionApplyV1'
+)

--- a/scripts/ops/collaborative_binders_production_apply_v1.ps1
+++ b/scripts/ops/collaborative_binders_production_apply_v1.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ManifestPath,
+
+  [switch]$ConfirmProduction
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
+Import-Module $modulePath -Force
+
+$target = 'Supabase production project ycdxbpibncqcchqiihfz'
+$action = 'Apply the exact five Collaborative Binders V1 migrations once; leave every feature flag disabled'
+
+if ($PSCmdlet.ShouldProcess($target, $action)) {
+  $result = Invoke-BinderProductionApplyV1 `
+    -ManifestPath $ManifestPath `
+    -ConfirmProduction $ConfirmProduction.IsPresent `
+    -Confirm:$false
+  $result | ConvertTo-Json -Depth 12
+}

--- a/scripts/ops/collaborative_binders_production_manifest_v1.json
+++ b/scripts/ops/collaborative_binders_production_manifest_v1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "package_id": "COLLABORATIVE-BINDERS-DB-V1",
+  "package_fingerprint_sha256": "14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9",
+  "required_ancestor_sha": "34caa07324587815040957f9adde1f771ebfc85a",
+  "production_project_ref": "ycdxbpibncqcchqiihfz",
+  "canonical_git_repository": "OriginalSoseji/grookai_vault",
+  "migrations": [
+    {
+      "version": "20260723100000",
+      "file": "20260723100000_collaborative_binders_schema_v1.sql",
+      "sha256": "7e83ab8bb83e5b938fbec758b21f8cae2b4a71427a6600c54c5f773c974bae33",
+      "cumulative_tables": 19,
+      "cumulative_functions": 17,
+      "cumulative_indexes": 61,
+      "cumulative_rls_policies": 19
+    },
+    {
+      "version": "20260723101000",
+      "file": "20260723101000_collaborative_binders_core_rpcs_v1.sql",
+      "sha256": "eb9ca9898bca12b127f4b79aff9df81259efe74fa1029487ea133e94e8a67a7d",
+      "cumulative_tables": 19,
+      "cumulative_functions": 44,
+      "cumulative_indexes": 61,
+      "cumulative_rls_policies": 19
+    },
+    {
+      "version": "20260723102000",
+      "file": "20260723102000_collaborative_binders_collaboration_rpcs_v1.sql",
+      "sha256": "680580044161936c8a382e5209e2cc54369943e13f1a3ae2ed41c299532cf3bf",
+      "cumulative_tables": 19,
+      "cumulative_functions": 65,
+      "cumulative_indexes": 61,
+      "cumulative_rls_policies": 19
+    },
+    {
+      "version": "20260723103000",
+      "file": "20260723103000_collaborative_binders_read_rpcs_v1.sql",
+      "sha256": "73dab7009f059267dcc571fcb6ec79cffdb23b728fc5bf04cd81397a06bcd6fb",
+      "cumulative_tables": 19,
+      "cumulative_functions": 99,
+      "cumulative_indexes": 61,
+      "cumulative_rls_policies": 19
+    },
+    {
+      "version": "20260723104000",
+      "file": "20260723104000_collaborative_binders_service_rpcs_v1.sql",
+      "sha256": "2edbef712d6b228c73b504498a6aa09f5bac440cfef96319d5c75f65e12d2997",
+      "cumulative_tables": 21,
+      "cumulative_functions": 124,
+      "cumulative_indexes": 65,
+      "cumulative_rls_policies": 22
+    }
+  ],
+  "readback_sql": [
+    {
+      "phase": "pre_apply",
+      "file": "scripts/ops/sql/collaborative_binders_production_preflight_v1.sql",
+      "sha256": "268458ed8a4a16dc513b55b6d0e5b3b03c301320e55a9ab4887a135c7652800d"
+    },
+    {
+      "phase": "post_apply",
+      "file": "scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql",
+      "sha256": "5125b0d89f5b3d36c66f98863f0b69b9c6df55561dfb54303437d47d8731f1a1"
+    }
+  ],
+  "final_expected_shape": {
+    "tables": 21,
+    "functions": 124,
+    "indexes": 65,
+    "rls_policies": 22,
+    "feature_flags": 11,
+    "enabled_feature_flags": 0,
+    "public_execute_functions": 0,
+    "anonymous_raw_privileges": 0,
+    "anonymous_raw_sequence_privileges": 0,
+    "authenticated_raw_mutations": 0,
+    "authenticated_raw_sequence_privileges": 0,
+    "authenticated_raw_select_tables": [
+      "binder_refresh_signals"
+    ],
+    "realtime_tables": [
+      "binder_refresh_signals"
+    ]
+  },
+  "feature_flags_must_remain_disabled": [
+    "schema_internal",
+    "personal",
+    "set_binders",
+    "custom",
+    "shared",
+    "view_links",
+    "public",
+    "community",
+    "templates",
+    "notifications",
+    "pulse_milestones"
+  ],
+  "excluded_from_rollout": [
+    "set_binders",
+    "notifications",
+    "pulse_milestones"
+  ]
+}

--- a/scripts/ops/collaborative_binders_production_preflight_v1.ps1
+++ b/scripts/ops/collaborative_binders_production_preflight_v1.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param(
+  [switch]$ValidateSourceOnly,
+
+  [string]$ExpectedHeadSha,
+
+  [string]$BackupEvidencePath,
+
+  [string]$ArtifactRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
+Import-Module $modulePath -Force
+
+if ($ValidateSourceOnly) {
+  $result = Test-BinderSourceV1
+  $result | ConvertTo-Json -Depth 12
+  exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($ExpectedHeadSha)) {
+  throw '-ExpectedHeadSha is required unless -ValidateSourceOnly is used.'
+}
+if ([string]::IsNullOrWhiteSpace($BackupEvidencePath)) {
+  throw '-BackupEvidencePath is required unless -ValidateSourceOnly is used.'
+}
+if ([string]::IsNullOrWhiteSpace($ArtifactRoot)) {
+  throw '-ArtifactRoot is required unless -ValidateSourceOnly is used.'
+}
+
+$result = Invoke-BinderProductionPreflightV1 `
+  -ExpectedHeadSha $ExpectedHeadSha `
+  -BackupEvidencePath $BackupEvidencePath `
+  -ArtifactRoot $ArtifactRoot
+$result | ConvertTo-Json -Depth 12

--- a/scripts/ops/collaborative_binders_production_readback_v1.ps1
+++ b/scripts/ops/collaborative_binders_production_readback_v1.ps1
@@ -1,0 +1,28 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('PreApply', 'PostApply')]
+  [string]$ExpectedState,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ExpectedHeadSha
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
+Import-Module $modulePath -Force
+
+[void](Test-BinderSourceV1)
+$module = Get-Module CollaborativeBindersProductionRolloutV1
+& $module {
+  param($repoRoot, $headSha)
+  [void](Assert-BinderRepositoryStateV1 -RepoRoot $repoRoot -ExpectedHeadSha $headSha)
+  [void](Assert-ProjectBindingV1 -RepoRoot $repoRoot)
+} (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) $ExpectedHeadSha
+
+$result = Invoke-BinderReadbackV1 -RepoRoot (
+  Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+) -ExpectedState $ExpectedState
+$result.Report | ConvertTo-Json -Depth 20

--- a/scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql
+++ b/scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql
@@ -1,0 +1,1724 @@
+with
+binder_tables as (
+  select
+    c.oid,
+    c.relname,
+    c.relkind,
+    c.relpersistence,
+    c.relrowsecurity,
+    c.relforcerowsecurity,
+    c.relreplident,
+    c.relowner,
+    c.relacl
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'public'
+    and c.relkind in ('r', 'p')
+    and (
+      c.relname = 'binders'
+      or c.relname like 'binder\_%' escape '\'
+    )
+),
+unexpected_binder_named_relations as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'relation', n.nspname || '.' || c.relname,
+        'relkind', c.relkind
+      )
+      order by c.relname, c.relkind
+    ),
+    '[]'::jsonb
+  ) as value
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'public'
+    and (
+      c.relname = 'binders'
+      or c.relname like 'binder\_%' escape '\'
+    )
+    and c.relkind not in ('r', 'p')
+    and not (
+      c.relkind = 'i'
+      and exists (
+        select 1
+        from pg_index i
+        join binder_tables bt on bt.oid = i.indrelid
+        where i.indexrelid = c.oid
+      )
+    )
+    and not (
+      c.relkind = 'S'
+      and c.relname = 'binder_rate_limit_events_id_seq'
+    )
+),
+binder_identity_sequence as (
+  select
+    c.oid,
+    c.relowner,
+    c.relacl,
+    format('%I.%I', n.nspname, c.relname) as sequence_name,
+    c.relkind,
+    c.relpersistence,
+    pg_get_userbyid(c.relowner) as sequence_owner,
+    format_type(s.seqtypid, -1) as sequence_type,
+    s.seqstart,
+    s.seqincrement,
+    s.seqmin,
+    s.seqmax,
+    s.seqcache,
+    s.seqcycle,
+    d.deptype as ownership_dependency_type,
+    format(
+      '%I.%I',
+      owner_namespace.nspname,
+      owner_relation.relname
+    ) as owned_by_relation,
+    d.refobjsubid as owned_by_attnum,
+    owner_column.attname as owned_by_column
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  join pg_sequence s on s.seqrelid = c.oid
+  join pg_depend d
+    on d.classid = 'pg_class'::regclass
+   and d.objid = c.oid
+   and d.objsubid = 0
+   and d.refclassid = 'pg_class'::regclass
+   and d.refobjsubid > 0
+   and d.deptype in ('a', 'i')
+  join pg_class owner_relation on owner_relation.oid = d.refobjid
+  join pg_namespace owner_namespace
+    on owner_namespace.oid = owner_relation.relnamespace
+  join pg_attribute owner_column
+    on owner_column.attrelid = d.refobjid
+   and owner_column.attnum = d.refobjsubid
+  where n.nspname = 'public'
+    and c.relname = 'binder_rate_limit_events_id_seq'
+),
+binder_identity_sequence_shape_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              sequence_name,
+              relkind,
+              relpersistence,
+              sequence_owner,
+              sequence_type,
+              seqstart::text,
+              seqincrement::text,
+              seqmin::text,
+              seqmax::text,
+              seqcache::text,
+              seqcycle::text,
+              ownership_dependency_type,
+              owned_by_relation,
+              owned_by_attnum::text,
+              owned_by_column
+            ),
+            E'\x1e'
+            order by sequence_name
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from binder_identity_sequence
+),
+binder_identity_sequence_acl_fingerprint as (
+  select
+    count(*)::integer as acl_row_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              sequence_row.sequence_name,
+              grantor_role.rolname,
+              coalesce(grantee_role.rolname, 'PUBLIC'),
+              acl.privilege_type,
+              acl.is_grantable::text
+            ),
+            E'\x1e'
+            order by
+              sequence_row.sequence_name,
+              grantor_role.rolname,
+              coalesce(grantee_role.rolname, 'PUBLIC'),
+              acl.privilege_type,
+              acl.is_grantable
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from binder_identity_sequence sequence_row
+  cross join lateral aclexplode(
+    coalesce(sequence_row.relacl, acldefault('s', sequence_row.relowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+),
+schema_create_guard_roles(role_name) as (
+  values ('anon'), ('authenticated'), ('authenticator')
+),
+schema_create_guard_schemas(schema_name) as (
+  values ('public'), ('extensions')
+),
+unexpected_schema_create_privileges as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'role', expected_role.role_name,
+        'schema', expected_schema.schema_name,
+        'role_exists', role_row.oid is not null,
+        'schema_exists', schema_row.oid is not null,
+        'has_create', coalesce(
+          has_schema_privilege(role_row.oid, schema_row.oid, 'CREATE'),
+          false
+        )
+      )
+      order by expected_role.role_name, expected_schema.schema_name
+    ),
+    '[]'::jsonb
+  ) as value
+  from schema_create_guard_roles expected_role
+  cross join schema_create_guard_schemas expected_schema
+  left join pg_roles role_row on role_row.rolname = expected_role.role_name
+  left join pg_namespace schema_row
+    on schema_row.nspname = expected_schema.schema_name
+  where role_row.oid is null
+    or schema_row.oid is null
+    or has_schema_privilege(role_row.oid, schema_row.oid, 'CREATE')
+),
+realtime_publication_config_row as (
+  select
+    publication.pubname,
+    pg_get_userbyid(publication.pubowner) as owner_name,
+    publication.puballtables,
+    publication.pubinsert,
+    publication.pubupdate,
+    publication.pubdelete,
+    publication.pubtruncate,
+    publication.pubviaroot
+  from pg_publication publication
+  where publication.pubname = 'supabase_realtime'
+),
+realtime_publication_config_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              pubname,
+              owner_name,
+              puballtables::text,
+              pubinsert::text,
+              pubupdate::text,
+              pubdelete::text,
+              pubtruncate::text,
+              pubviaroot::text
+            ),
+            E'\x1e'
+            order by pubname
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from realtime_publication_config_row
+),
+realtime_binder_projection_rows as (
+  select
+    publication_table.pubname,
+    publication_table.schemaname,
+    publication_table.tablename,
+    coalesce(
+      array_to_string(publication_table.attnames, E'\x1d'),
+      ''
+    ) as projected_columns,
+    publication_table.rowfilter is null as row_filter_is_null,
+    coalesce(publication_table.rowfilter, '') as row_filter
+  from pg_publication_tables publication_table
+  where publication_table.pubname = 'supabase_realtime'
+    and publication_table.schemaname = 'public'
+    and (
+      publication_table.tablename = 'binders'
+      or publication_table.tablename like 'binder\_%' escape '\'
+    )
+),
+realtime_binder_projection_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              pubname,
+              schemaname,
+              tablename,
+              projected_columns,
+              row_filter_is_null::text,
+              row_filter
+            ),
+            E'\x1e'
+            order by schemaname, tablename
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from realtime_binder_projection_rows
+),
+unexpected_binder_named_types as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'type', n.nspname || '.' || t.typname,
+        'type_kind', t.typtype
+      )
+      order by t.typname, t.typtype
+    ),
+    '[]'::jsonb
+  ) as value
+  from pg_type t
+  join pg_namespace n on n.oid = t.typnamespace
+  where n.nspname = 'public'
+    and (
+      t.typname = 'binders'
+      or t.typname like 'binder\_%' escape '\'
+    )
+    and not exists (
+      select 1
+      from binder_tables bt
+      where bt.oid = t.typrelid
+    )
+),
+binder_table_shape_rows(object_name, object_part, payload) as (
+  select
+    'public.' || bt.relname,
+    'relation',
+    concat_ws(
+      E'\x1f',
+      pg_get_userbyid(bt.relowner),
+      bt.relkind,
+      bt.relpersistence,
+      bt.relrowsecurity::text,
+      bt.relforcerowsecurity::text,
+      bt.relreplident
+    )
+  from binder_tables bt
+
+  union all
+
+  select
+    'public.' || bt.relname,
+    'columns',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        a.attnum::text,
+        a.attname,
+        format_type(a.atttypid, a.atttypmod),
+        a.attnotnull::text,
+        a.attidentity,
+        a.attgenerated,
+        case
+          when a.attcollation = 0 then ''
+          else format(
+            '%I.%I',
+            collation_namespace.nspname,
+            collation_row.collname
+          )
+        end,
+        coalesce(
+          replace(
+            replace(
+              pg_get_expr(default_row.adbin, default_row.adrelid, true),
+              'public.',
+              ''
+            ),
+            'extensions.',
+            ''
+          ),
+          ''
+        )
+      ),
+      E'\x1e'
+      order by a.attnum
+    )
+  from binder_tables bt
+  join pg_attribute a
+    on a.attrelid = bt.oid
+   and a.attnum > 0
+   and not a.attisdropped
+  left join pg_attrdef default_row
+    on default_row.adrelid = a.attrelid
+   and default_row.adnum = a.attnum
+  left join pg_collation collation_row on collation_row.oid = a.attcollation
+  left join pg_namespace collation_namespace
+    on collation_namespace.oid = collation_row.collnamespace
+  group by bt.relname
+
+  union all
+
+  select
+    'public.' || bt.relname,
+    'constraints',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        constraint_row.conname,
+        constraint_row.contype,
+        constraint_row.condeferrable::text,
+        constraint_row.condeferred::text,
+        constraint_row.convalidated::text,
+        constraint_row.conislocal::text,
+        constraint_row.coninhcount::text,
+        constraint_row.connoinherit::text,
+        replace(
+          pg_get_constraintdef(constraint_row.oid, true),
+          'public.',
+          ''
+        )
+      ),
+      E'\x1e'
+      order by constraint_row.conname
+    )
+  from binder_tables bt
+  join pg_constraint constraint_row on constraint_row.conrelid = bt.oid
+  group by bt.relname
+),
+binder_table_shape_fingerprint as (
+  select
+    count(*)::integer as manifest_row_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(E'\x1f', object_name, object_part, payload),
+            E'\x1e'
+            order by object_name, object_part
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from binder_table_shape_rows
+),
+binder_functions as (
+  select
+    p.oid,
+    p.proowner,
+    p.proacl,
+    format(
+      '%I.%I(%s)',
+      n.nspname,
+      p.proname,
+      replace(pg_get_function_identity_arguments(p.oid), 'public.', '')
+    ) as signature,
+    replace(pg_get_function_arguments(p.oid), 'public.', '') as function_arguments,
+    replace(pg_get_function_result(p.oid), 'public.', '') as function_result,
+    pg_get_userbyid(p.proowner) as function_owner,
+    l.lanname,
+    p.prokind,
+    p.provolatile,
+    p.prosecdef,
+    p.proleakproof,
+    p.proisstrict,
+    p.proretset,
+    p.proparallel,
+    coalesce(array_to_string(p.proconfig, ','), '') as function_config,
+    p.procost,
+    p.prorows,
+    p.prosrc
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  join pg_language l on l.oid = p.prolang
+  where n.nspname = 'public'
+    and p.proname like 'binder\_%' escape '\'
+),
+function_fingerprint as (
+  select
+    count(*)::integer as function_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              signature,
+              function_arguments,
+              function_result,
+              function_owner,
+              lanname,
+              prokind,
+              provolatile::text,
+              prosecdef::text,
+              proleakproof::text,
+              proisstrict::text,
+              proretset::text,
+              proparallel,
+              function_config,
+              procost::text,
+              prorows::text,
+              prosrc
+            ),
+            E'\x1e'
+            order by signature
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from binder_functions
+),
+function_acl_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            bf.signature,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable::text
+          ),
+          E'\x1e'
+          order by
+            bf.signature,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from binder_functions bf
+  cross join lateral aclexplode(
+    coalesce(bf.proacl, acldefault('f', bf.proowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+),
+changed_external_function_targets(function_signature) as (
+  values
+    ('public.interest_graph_upsert_watch_v1(uuid,text,uuid,text,text)'),
+    ('public.interest_graph_emit_event_v1(text,text,uuid,uuid,uuid,jsonb,text,text)'),
+    ('public.interest_graph_log_emit_failure_v1(text,text,uuid,uuid,jsonb,text)'),
+    ('public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)'),
+    ('public.pulse_eligible_events_for_viewer_v1(uuid)'),
+    ('public.card_events_feed_v1(integer,timestamp with time zone,uuid)')
+),
+changed_external_functions as (
+  select
+    p.oid,
+    p.proowner,
+    p.proacl,
+    format(
+      '%I.%I(%s)',
+      n.nspname,
+      p.proname,
+      replace(pg_get_function_identity_arguments(p.oid), 'public.', '')
+    ) as signature,
+    replace(pg_get_function_arguments(p.oid), 'public.', '') as function_arguments,
+    replace(pg_get_function_result(p.oid), 'public.', '') as function_result,
+    pg_get_userbyid(p.proowner) as function_owner,
+    l.lanname,
+    p.prokind,
+    p.provolatile,
+    p.prosecdef,
+    p.proleakproof,
+    p.proisstrict,
+    p.proretset,
+    p.proparallel,
+    coalesce(array_to_string(p.proconfig, ','), '') as function_config,
+    p.procost,
+    p.prorows,
+    encode(
+      extensions.digest(convert_to(p.prosrc, 'UTF8'), 'sha256'),
+      'hex'
+    ) as body_sha256
+  from changed_external_function_targets target
+  join pg_proc p on p.oid = to_regprocedure(target.function_signature)
+  join pg_namespace n on n.oid = p.pronamespace
+  join pg_language l on l.oid = p.prolang
+),
+changed_external_function_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              signature,
+              function_arguments,
+              function_result,
+              function_owner,
+              lanname,
+              prokind,
+              provolatile,
+              prosecdef::text,
+              proleakproof::text,
+              proisstrict::text,
+              proretset::text,
+              proparallel,
+              function_config,
+              procost::text,
+              prorows::text,
+              body_sha256
+            ),
+            E'\x1e'
+            order by signature
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from changed_external_functions
+),
+changed_external_function_acl_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            changed.signature,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable::text
+          ),
+          E'\x1e'
+          order by
+            changed.signature,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from changed_external_functions changed
+  cross join lateral aclexplode(
+    coalesce(changed.proacl, acldefault('f', changed.proowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+),
+index_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            bt.relname,
+            ci.relname,
+            i.indisunique::text,
+            i.indisprimary::text,
+            i.indisvalid::text,
+            i.indisready::text,
+            replace(pg_get_indexdef(i.indexrelid), 'public.', '')
+          ),
+          E'\x1e'
+          order by bt.relname, ci.relname
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from pg_index i
+  join binder_tables bt on bt.oid = i.indrelid
+  join pg_class ci on ci.oid = i.indexrelid
+),
+binder_policy_rows as (
+  select
+    bt.relname,
+    p.polname,
+    p.polcmd,
+    p.polpermissive,
+    (
+      select string_agg(
+        coalesce(r.rolname, 'PUBLIC'),
+        ','
+        order by coalesce(r.rolname, 'PUBLIC')
+      )
+      from unnest(p.polroles) role_oid
+      left join pg_roles r on r.oid = role_oid
+    ) as role_names,
+    replace(
+      coalesce(pg_get_expr(p.polqual, p.polrelid, true), ''),
+      'public.',
+      ''
+    ) as using_expression,
+    replace(
+      coalesce(pg_get_expr(p.polwithcheck, p.polrelid, true), ''),
+      'public.',
+      ''
+    ) as check_expression
+  from pg_policy p
+  join binder_tables bt on bt.oid = p.polrelid
+),
+policy_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            relname,
+            polname,
+            polcmd,
+            polpermissive::text,
+            role_names,
+            using_expression,
+            check_expression
+          ),
+          E'\x1e'
+          order by relname, polname
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from binder_policy_rows
+),
+changed_external_policy_targets(relation_name, policy_name) as (
+  values
+    ('public.trust_reports', 'trust_reports_insert_reporter'),
+    ('public.card_events', 'card_events_visibility_select'),
+    ('public.card_events', 'card_events_actor_insert')
+),
+changed_external_policy_rows as (
+  select
+    n.nspname as schema_name,
+    c.relname as relation_name,
+    p.polname as policy_name,
+    p.polcmd,
+    p.polpermissive,
+    (
+      select string_agg(
+        coalesce(r.rolname, 'PUBLIC'),
+        ','
+        order by coalesce(r.rolname, 'PUBLIC')
+      )
+      from unnest(p.polroles) role_oid
+      left join pg_roles r on r.oid = role_oid
+    ) as role_names,
+    replace(
+      coalesce(pg_get_expr(p.polqual, p.polrelid, true), ''),
+      'public.',
+      ''
+    ) as using_expression,
+    replace(
+      coalesce(pg_get_expr(p.polwithcheck, p.polrelid, true), ''),
+      'public.',
+      ''
+    ) as check_expression
+  from changed_external_policy_targets target
+  join pg_class c on c.oid = to_regclass(target.relation_name)
+  join pg_namespace n on n.oid = c.relnamespace
+  join pg_policy p
+    on p.polrelid = c.oid
+   and p.polname = target.policy_name
+),
+changed_external_policy_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              schema_name,
+              relation_name,
+              policy_name,
+              polcmd,
+              polpermissive::text,
+              role_names,
+              using_expression,
+              check_expression
+            ),
+            E'\x1e'
+            order by schema_name, relation_name, policy_name
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from changed_external_policy_rows
+),
+trust_surface_constraint_row as (
+  select
+    n.nspname as schema_name,
+    c.relname as relation_name,
+    constraint_row.conname as constraint_name,
+    constraint_row.contype,
+    constraint_row.condeferrable,
+    constraint_row.condeferred,
+    constraint_row.convalidated,
+    constraint_row.conislocal,
+    constraint_row.coninhcount,
+    constraint_row.connoinherit,
+    replace(
+      pg_get_constraintdef(constraint_row.oid, true),
+      'public.',
+      ''
+    ) as definition
+  from pg_constraint constraint_row
+  join pg_class c on c.oid = constraint_row.conrelid
+  join pg_namespace n on n.oid = c.relnamespace
+  where constraint_row.conrelid = 'public.trust_reports'::regclass
+    and constraint_row.conname = 'trust_reports_surface_check'
+),
+trust_surface_constraint_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              schema_name,
+              relation_name,
+              constraint_name,
+              contype,
+              condeferrable::text,
+              condeferred::text,
+              convalidated::text,
+              conislocal::text,
+              coninhcount::text,
+              connoinherit::text,
+              definition
+            ),
+            E'\x1e'
+            order by schema_name, relation_name, constraint_name
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from trust_surface_constraint_row
+),
+changed_external_table_acl_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            n.nspname || '.' || c.relname,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable::text
+          ),
+          E'\x1e'
+          order by
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  cross join lateral aclexplode(
+    coalesce(c.relacl, acldefault('r', c.relowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+  where c.oid = 'public.card_events_emit_failures'::regclass
+),
+introduced_trigger_rows as (
+  select
+    c.relname,
+    t.tgname,
+    t.tgenabled,
+    fn.proname as function_name,
+    replace(pg_get_triggerdef(t.oid, true), 'public.', '') as definition
+  from pg_trigger t
+  join pg_class c on c.oid = t.tgrelid
+  join pg_namespace n on n.oid = c.relnamespace
+  join pg_proc fn on fn.oid = t.tgfoid
+  where n.nspname = 'public'
+    and not t.tgisinternal
+    and (
+      exists (
+        select 1
+        from binder_tables bt
+        where bt.oid = t.tgrelid
+      )
+      or t.tgname in (
+        'trg_trust_blocks_binder_effect_v1',
+        'trg_binder_vault_instance_update_v1',
+        'trg_binder_vault_instance_delete_v1',
+        'trg_binder_slab_identity_update_v1'
+      )
+    )
+),
+trigger_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            relname,
+            tgname,
+            tgenabled,
+            function_name,
+            definition
+          ),
+          E'\x1e'
+          order by relname, tgname
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from introduced_trigger_rows
+),
+table_acl_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            bt.relname,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable::text
+          ),
+          E'\x1e'
+          order by
+            bt.relname,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from binder_tables bt
+  cross join lateral aclexplode(
+    coalesce(bt.relacl, acldefault('r', bt.relowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+),
+stable_target_relations(relation_oid) as (
+  values
+    ('public.trust_reports'::regclass),
+    ('public.trust_blocks'::regclass),
+    ('public.vault_item_instances'::regclass),
+    ('public.slab_certs'::regclass),
+    ('public.watches'::regclass),
+    ('public.card_events'::regclass),
+    ('public.card_events_emit_failures'::regclass)
+),
+stable_manifests(object_name, object_part, payload) as (
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'columns',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        a.attnum,
+        a.attname,
+        format_type(a.atttypid, a.atttypmod),
+        a.attnotnull,
+        a.attidentity,
+        a.attgenerated,
+        coalesce(
+          replace(pg_get_expr(d.adbin, d.adrelid, true), 'public.', ''),
+          ''
+        )
+      ),
+      E'\x1e'
+      order by a.attnum
+    )
+  from stable_target_relations t
+  join pg_attribute a
+    on a.attrelid = t.relation_oid
+   and a.attnum > 0
+   and not a.attisdropped
+  left join pg_attrdef d
+    on d.adrelid = a.attrelid
+   and d.adnum = a.attnum
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_constraints',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        c.conname,
+        c.contype,
+        c.condeferrable,
+        c.condeferred,
+        replace(pg_get_constraintdef(c.oid, true), 'public.', '')
+      ),
+      E'\x1e'
+      order by c.conname
+    )
+  from stable_target_relations t
+  join pg_constraint c on c.conrelid = t.relation_oid
+  where not (
+    t.relation_oid = 'public.trust_reports'::regclass
+    and c.conname = 'trust_reports_surface_check'
+  )
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'indexes',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        ci.relname,
+        i.indisunique,
+        i.indisprimary,
+        i.indisvalid,
+        replace(pg_get_indexdef(i.indexrelid), 'public.', '')
+      ),
+      E'\x1e'
+      order by ci.relname
+    )
+  from stable_target_relations t
+  join pg_index i on i.indrelid = t.relation_oid
+  join pg_class ci on ci.oid = i.indexrelid
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_policies',
+    coalesce(
+      string_agg(
+        concat_ws(
+          E'\x1f',
+          p.polname,
+          p.polcmd,
+          p.polpermissive,
+          p.polroles::text,
+          replace(coalesce(pg_get_expr(p.polqual, p.polrelid, true), ''), 'public.', ''),
+          replace(coalesce(pg_get_expr(p.polwithcheck, p.polrelid, true), ''), 'public.', '')
+        ),
+        E'\x1e'
+        order by p.polname
+      ) filter (where p.oid is not null),
+      ''
+    )
+  from stable_target_relations t
+  left join pg_policy p
+    on p.polrelid = t.relation_oid
+   and p.polname not in (
+     'trust_reports_insert_reporter',
+     'card_events_visibility_select',
+     'card_events_actor_insert',
+     'card_events_emit_failures_owner_insert'
+   )
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_triggers',
+    coalesce(
+      string_agg(
+        concat_ws(
+          E'\x1f',
+          g.tgname,
+          replace(pg_get_triggerdef(g.oid, true), 'public.', '')
+        ),
+        E'\x1e'
+        order by g.tgname
+      ) filter (where g.oid is not null),
+      ''
+    )
+  from stable_target_relations t
+  left join pg_trigger g
+    on g.tgrelid = t.relation_oid
+   and not g.tgisinternal
+   and g.tgname not in (
+     'trg_trust_blocks_binder_effect_v1',
+     'trg_binder_vault_instance_update_v1',
+     'trg_binder_vault_instance_delete_v1',
+     'trg_binder_slab_identity_update_v1'
+   )
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'rls_replica',
+    concat_ws(E'\x1f', c.relrowsecurity, c.relforcerowsecurity, c.relreplident)
+  from stable_target_relations t
+  join pg_class c on c.oid = t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_acl',
+    coalesce(array_to_string(c.relacl, ','), '')
+  from stable_target_relations t
+  join pg_class c on c.oid = t.relation_oid
+  where t.relation_oid <> 'public.card_events_emit_failures'::regclass
+),
+stable_functions(object_name, object_part, payload) as (
+  select
+    format(
+      '%I.%I(%s)',
+      n.nspname,
+      p.proname,
+      replace(pg_get_function_identity_arguments(p.oid), 'public.', '')
+    ),
+    'function_shape_body',
+    concat_ws(
+      E'\x1f',
+      replace(pg_get_function_arguments(p.oid), 'public.', ''),
+      replace(pg_get_function_result(p.oid), 'public.', ''),
+      pg_get_userbyid(p.proowner),
+      l.lanname,
+      p.provolatile,
+      p.prosecdef,
+      p.proparallel,
+      coalesce(array_to_string(p.proconfig, ','), ''),
+      p.prosrc
+    )
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  join pg_language l on l.oid = p.prolang
+  where n.nspname = 'public'
+    and p.proname in (
+      'interest_graph_upsert_watch_v1',
+      'interest_graph_emit_event_v1',
+      'interest_graph_log_emit_failure_v1'
+    )
+),
+stable_catalog_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(E'\x1f', object_name, object_part, payload),
+          E'\x1e'
+          order by object_name, object_part
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from (
+    select * from stable_manifests
+    union all
+    select * from stable_functions
+  ) stable_rows
+),
+canonical_flags(flag_key) as (
+  values
+    ('community'),
+    ('custom'),
+    ('notifications'),
+    ('personal'),
+    ('public'),
+    ('pulse_milestones'),
+    ('schema_internal'),
+    ('set_binders'),
+    ('shared'),
+    ('templates'),
+    ('view_links')
+),
+flag_snapshot as (
+  select
+    count(f.flag_key)::integer as flag_count,
+    count(f.flag_key) filter (where f.enabled)::integer as enabled_flag_count,
+    coalesce(
+      jsonb_agg(f.flag_key order by f.flag_key) filter (where f.enabled),
+      '[]'::jsonb
+    ) as enabled_flags,
+    coalesce(
+      jsonb_agg(c.flag_key order by c.flag_key)
+        filter (where f.flag_key is null),
+      '[]'::jsonb
+    ) as missing_flags,
+    coalesce((
+      select jsonb_agg(x.flag_key order by x.flag_key)
+      from public.binder_feature_flags x
+      where not exists (
+        select 1
+        from canonical_flags expected
+        where expected.flag_key = x.flag_key
+      )
+    ), '[]'::jsonb) as unexpected_flags
+  from canonical_flags c
+  left join public.binder_feature_flags f using (flag_key)
+),
+raw_privileges as (
+  select
+    bt.relname,
+    r.rolname,
+    p.privilege_name
+  from binder_tables bt
+  cross join (
+    select oid, rolname
+    from pg_roles
+    where rolname in ('anon', 'authenticated')
+  ) r
+  cross join (
+    values
+      ('SELECT'),
+      ('INSERT'),
+      ('UPDATE'),
+      ('DELETE'),
+      ('TRUNCATE'),
+      ('REFERENCES'),
+      ('TRIGGER'),
+      ('MAINTAIN')
+  ) p(privilege_name)
+  where has_table_privilege(
+    r.oid,
+    bt.oid,
+    p.privilege_name
+  )
+),
+unexpected_raw_privileges as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', relname,
+        'role', rolname,
+        'privilege', privilege_name
+      )
+      order by relname, rolname, privilege_name
+    ),
+    '[]'::jsonb
+  ) as value
+  from raw_privileges
+  where not (
+    relname = 'binder_refresh_signals'
+    and rolname = 'authenticated'
+    and privilege_name = 'SELECT'
+  )
+),
+domain_counts(table_name, row_count) as (
+  select 'binders', count(*) from public.binders
+  union all select 'binder_members', count(*) from public.binder_members
+  union all select 'binder_progress_state', count(*) from public.binder_progress_state
+  union all select 'binder_custom_revisions', count(*) from public.binder_custom_revisions
+  union all select 'binder_custom_slots', count(*) from public.binder_custom_slots
+  union all select 'binder_invitations', count(*) from public.binder_invitations
+  union all select 'binder_view_links', count(*) from public.binder_view_links
+  union all select 'binder_join_requests', count(*) from public.binder_join_requests
+  union all select 'binder_owner_transfer_offers', count(*) from public.binder_owner_transfer_offers
+  union all select 'binder_contributions', count(*) from public.binder_contributions
+  union all select 'binder_activity_events', count(*) from public.binder_activity_events
+  union all select 'binder_progress_crossings', count(*) from public.binder_progress_crossings
+  union all select 'binder_legacy_watch_decisions', count(*) from public.binder_legacy_watch_decisions
+  union all select 'binder_templates', count(*) from public.binder_templates
+  union all select 'binder_template_versions', count(*) from public.binder_template_versions
+  union all select 'binder_template_adoptions', count(*) from public.binder_template_adoptions
+  union all select 'binder_idempotency_keys', count(*) from public.binder_idempotency_keys
+  union all select 'binder_rate_limit_events', count(*) from public.binder_rate_limit_events
+  union all select 'binder_template_version_reviews', count(*) from public.binder_template_version_reviews
+  union all select 'binder_refresh_signals', count(*) from public.binder_refresh_signals
+),
+nonempty_domain_tables as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object('table', table_name, 'rows', row_count)
+      order by table_name
+    ),
+    '[]'::jsonb
+  ) as value
+  from domain_counts
+  where row_count <> 0
+),
+external_snapshot as (
+  select
+    (
+      select coalesce(
+        jsonb_agg(
+          c.relname || '.' || t.tgname
+          order by c.relname, t.tgname
+        ),
+        '[]'::jsonb
+      )
+      from pg_trigger t
+      join pg_class c on c.oid = t.tgrelid
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public'
+        and not t.tgisinternal
+        and t.tgname in (
+          'trg_trust_blocks_binder_effect_v1',
+          'trg_binder_vault_instance_update_v1',
+          'trg_binder_vault_instance_delete_v1',
+          'trg_binder_slab_identity_update_v1'
+        )
+    ) as external_trigger_map,
+    coalesce((
+      select encode(
+        extensions.digest(convert_to(prosrc, 'UTF8'), 'sha256'),
+        'hex'
+      )
+      from pg_proc
+      where oid = to_regprocedure(
+        'public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)'
+      )
+    ), '') as pulse_base_body_sha256,
+    coalesce((
+      select encode(
+        extensions.digest(convert_to(prosrc, 'UTF8'), 'sha256'),
+        'hex'
+      )
+      from pg_proc
+      where oid = to_regprocedure(
+        'public.pulse_eligible_events_for_viewer_v1(uuid)'
+      )
+    ), '') as pulse_wrapper_body_sha256,
+    coalesce((
+      select encode(
+        extensions.digest(convert_to(prosrc, 'UTF8'), 'sha256'),
+        'hex'
+      )
+      from pg_proc
+      where oid = to_regprocedure(
+        'public.card_events_feed_v1(integer,timestamp with time zone,uuid)'
+      )
+    ), '') as card_events_feed_body_sha256,
+    coalesce((
+      select pg_get_constraintdef(oid, true)
+      from pg_constraint
+      where conrelid = 'public.trust_reports'::regclass
+        and conname = 'trust_reports_surface_check'
+    ), '') as trust_surface_constraint,
+    coalesce((
+      select pg_get_expr(polwithcheck, polrelid, true)
+      from pg_policy
+      where polrelid = 'public.trust_reports'::regclass
+        and polname = 'trust_reports_insert_reporter'
+    ), '') as trust_insert_policy,
+    replace(coalesce((
+      select pg_get_expr(polqual, polrelid, true)
+      from pg_policy
+      where polrelid = 'public.card_events'::regclass
+        and polname = 'card_events_visibility_select'
+    ), ''), 'public.', '') as card_events_select_policy,
+    replace(coalesce((
+      select pg_get_expr(polwithcheck, polrelid, true)
+      from pg_policy
+      where polrelid = 'public.card_events'::regclass
+        and polname = 'card_events_actor_insert'
+    ), ''), 'public.', '') as card_events_insert_policy,
+    not exists (
+      select 1
+      from pg_policy
+      where polrelid = 'public.card_events_emit_failures'::regclass
+        and polname = 'card_events_emit_failures_owner_insert'
+    ) and not has_table_privilege(
+      'authenticated',
+      'public.card_events_emit_failures',
+      'INSERT'
+    ) as card_event_failure_hardening_ok,
+    (
+      select bool_and(
+        has_function_privilege('service_role', signature, 'EXECUTE')
+        and not has_function_privilege('public', signature, 'EXECUTE')
+        and not has_function_privilege('anon', signature, 'EXECUTE')
+        and not has_function_privilege('authenticated', signature, 'EXECUTE')
+      )
+      from (
+        values
+          ('public.interest_graph_upsert_watch_v1(uuid,text,uuid,text,text)'::regprocedure),
+          ('public.interest_graph_emit_event_v1(text,text,uuid,uuid,uuid,jsonb,text,text)'::regprocedure),
+          ('public.interest_graph_log_emit_failure_v1(text,text,uuid,uuid,jsonb,text)'::regprocedure),
+          ('public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)'::regprocedure),
+          ('public.pulse_eligible_events_for_viewer_v1(uuid)'::regprocedure)
+      ) hardened(signature)
+    ) as hardened_function_grants_ok,
+    (
+      has_function_privilege(
+        'authenticated',
+        'public.card_events_feed_v1(integer,timestamp with time zone,uuid)',
+        'EXECUTE'
+      )
+      and has_function_privilege(
+        'service_role',
+        'public.card_events_feed_v1(integer,timestamp with time zone,uuid)',
+        'EXECUTE'
+      )
+      and not has_function_privilege(
+        'public',
+        'public.card_events_feed_v1(integer,timestamp with time zone,uuid)',
+        'EXECUTE'
+      )
+      and not has_function_privilege(
+        'anon',
+        'public.card_events_feed_v1(integer,timestamp with time zone,uuid)',
+        'EXECUTE'
+      )
+    ) as card_events_feed_grants_ok
+),
+snapshot as (
+  select
+    current_user as execution_role,
+    pg_catalog.current_setting('server_version_num')::integer
+      as server_version_num,
+    (
+      pg_catalog.current_setting('server_version_num')::integer / 10000
+    ) as server_major_version,
+    17::integer as required_server_major_version,
+    (
+      pg_catalog.current_setting('server_version_num')::integer / 10000 = 17
+    ) as server_major_version_ok,
+    (select count(*)::integer from binder_tables) as binder_table_count,
+    (
+      select value from unexpected_binder_named_relations
+    ) as unexpected_binder_named_relations,
+    (
+      select value from unexpected_binder_named_types
+    ) as unexpected_binder_named_types,
+    (
+      select manifest_row_count from binder_table_shape_fingerprint
+    ) as binder_table_shape_manifest_row_count,
+    (
+      select sha256 from binder_table_shape_fingerprint
+    ) as binder_table_shape_fingerprint_sha256,
+    (
+      select object_count from binder_identity_sequence_shape_fingerprint
+    ) as binder_identity_sequence_count,
+    (
+      select sha256 from binder_identity_sequence_shape_fingerprint
+    ) as binder_identity_sequence_shape_fingerprint_sha256,
+    (
+      select acl_row_count from binder_identity_sequence_acl_fingerprint
+    ) as binder_identity_sequence_acl_row_count,
+    (
+      select sha256 from binder_identity_sequence_acl_fingerprint
+    ) as binder_identity_sequence_acl_fingerprint_sha256,
+    (
+      select value from unexpected_schema_create_privileges
+    ) as unexpected_schema_create_privileges,
+    (
+      select object_count from realtime_publication_config_fingerprint
+    ) as realtime_publication_config_count,
+    (
+      select sha256 from realtime_publication_config_fingerprint
+    ) as realtime_publication_config_fingerprint_sha256,
+    (
+      select object_count from realtime_binder_projection_fingerprint
+    ) as realtime_binder_projection_count,
+    (
+      select sha256 from realtime_binder_projection_fingerprint
+    ) as realtime_binder_projection_fingerprint_sha256,
+    (select function_count from function_fingerprint) as binder_function_count,
+    (select sha256 from function_fingerprint) as binder_function_fingerprint_sha256,
+    (select sha256 from function_acl_fingerprint) as binder_function_acl_fingerprint_sha256,
+    (
+      select object_count from changed_external_function_fingerprint
+    ) as changed_external_function_count,
+    (
+      select sha256 from changed_external_function_fingerprint
+    ) as changed_external_function_fingerprint_sha256,
+    (
+      select sha256 from changed_external_function_acl_fingerprint
+    ) as changed_external_function_acl_fingerprint_sha256,
+    (select sha256 from index_fingerprint) as binder_index_fingerprint_sha256,
+    (select sha256 from policy_fingerprint) as binder_policy_fingerprint_sha256,
+    (
+      select object_count from changed_external_policy_fingerprint
+    ) as changed_external_policy_count,
+    (
+      select sha256 from changed_external_policy_fingerprint
+    ) as changed_external_policy_fingerprint_sha256,
+    (
+      select object_count from trust_surface_constraint_fingerprint
+    ) as trust_surface_constraint_count,
+    (
+      select sha256 from trust_surface_constraint_fingerprint
+    ) as trust_surface_constraint_fingerprint_sha256,
+    (select sha256 from trigger_fingerprint) as binder_trigger_fingerprint_sha256,
+    (select sha256 from table_acl_fingerprint) as binder_table_acl_fingerprint_sha256,
+    (
+      select sha256 from changed_external_table_acl_fingerprint
+    ) as changed_external_table_acl_fingerprint_sha256,
+    (select sha256 from stable_catalog_fingerprint) as stable_catalog_fingerprint_sha256,
+    (
+      select count(*)::integer
+      from pg_index i
+      join binder_tables bt on bt.oid = i.indrelid
+    ) as binder_index_count,
+    (
+      select count(*)::integer
+      from binder_tables
+      where relrowsecurity
+    ) as binder_rls_table_count,
+    (
+      select count(*)::integer
+      from pg_policy p
+      join binder_tables bt on bt.oid = p.polrelid
+    ) as binder_policy_count,
+    (
+      select count(*)::integer
+      from introduced_trigger_rows
+    ) as binder_trigger_count,
+    (
+      select count(*)::integer
+      from supabase_migrations.schema_migrations
+      where version::text = any(array[
+        '20260723100000',
+        '20260723101000',
+        '20260723102000',
+        '20260723103000',
+        '20260723104000'
+      ])
+    ) as applied_package_migration_count,
+    (
+      select count(*)::integer
+      from binder_functions
+      where function_config = 'search_path=public'
+    ) as search_path_public_count,
+    (
+      select count(*)::integer
+      from binder_functions
+      where function_config = 'search_path=pg_catalog'
+    ) as search_path_pg_catalog_count,
+    (
+      select count(*)::integer
+      from binder_functions
+      where function_config = 'search_path=public, extensions, pg_catalog'
+    ) as search_path_public_extensions_count,
+    (
+      select count(*)::integer
+      from binder_functions
+      where has_function_privilege('public', oid, 'EXECUTE')
+    ) as public_execute_functions,
+    (
+      select count(*)::integer
+      from binder_functions
+      where has_function_privilege('anon', oid, 'EXECUTE')
+    ) as anonymous_execute_functions,
+    (
+      select count(*)::integer
+      from binder_functions
+      where has_function_privilege('authenticated', oid, 'EXECUTE')
+    ) as authenticated_execute_functions,
+    (
+      select count(*)::integer
+      from binder_functions
+      where has_function_privilege('service_role', oid, 'EXECUTE')
+    ) as service_execute_functions,
+    (
+      select coalesce(jsonb_agg(tablename order by tablename), '[]'::jsonb)
+      from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and (
+          tablename = 'binders'
+          or tablename like 'binder\_%' escape '\'
+        )
+    ) as realtime_tables,
+    (
+      select relreplident = 'f' and relrowsecurity
+      from binder_tables
+      where relname = 'binder_refresh_signals'
+    ) as refresh_signal_replica_rls_ok,
+    (
+      select value from unexpected_raw_privileges
+    ) as unexpected_raw_privileges,
+    (
+      select value from nonempty_domain_tables
+    ) as nonempty_domain_tables,
+    exists (
+      select 1
+      from public.card_events
+      where event_type like 'binder\_%' escape '\'
+    ) as binder_card_event_data_exists,
+    exists (
+      select 1
+      from public.trust_reports
+      where surface in (
+        'binder',
+        'binder_contribution',
+        'binder_member',
+        'binder_invitation'
+      )
+    ) as binder_trust_report_data_exists,
+    fs.*,
+    es.*
+  from flag_snapshot fs
+  cross join external_snapshot es
+)
+select jsonb_build_object(
+  'package_id', 'COLLABORATIVE-BINDERS-DB-V1',
+  'phase', 'post_apply',
+  'read_only', true,
+  'ok',
+    execution_role = 'postgres'
+    and server_major_version_ok
+    and binder_table_count = 21
+    and unexpected_binder_named_relations = '[]'::jsonb
+    and unexpected_binder_named_types = '[]'::jsonb
+    and binder_table_shape_manifest_row_count = 63
+    and binder_table_shape_fingerprint_sha256 =
+      '18fb01a0c964976097a93b10204b453fa1d4ce7501086e2693c4aabd5b79689d'
+    and binder_identity_sequence_count = 1
+    and binder_identity_sequence_shape_fingerprint_sha256 =
+      '34634ae035a071553b71be8cf48ca10bf372a6cb95fcaa32d8be2eb811f22575'
+    and binder_identity_sequence_acl_row_count = 6
+    and binder_identity_sequence_acl_fingerprint_sha256 =
+      '4880f9e8d10d0e915f42dcff6c715ab879c67e4b816ae4ccc2efdaf4659c4fb4'
+    and unexpected_schema_create_privileges = '[]'::jsonb
+    and realtime_publication_config_count = 1
+    and realtime_publication_config_fingerprint_sha256 =
+      'c9e74db3d75a0cabc4ae97a90b0c45d637a3865c12498281398acceb01806191'
+    and realtime_binder_projection_count = 1
+    and realtime_binder_projection_fingerprint_sha256 =
+      '6a167a0721fd3cb2cf3351cea31e2efa59836cd7d2356219887b181d4a43db6e'
+    and binder_function_count = 124
+    and binder_function_fingerprint_sha256 =
+      '8b1f40cc62faa6e1c8e775c891a310088f8ac48d5d95ae68775224f1e26d9ca2'
+    and binder_function_acl_fingerprint_sha256 =
+      'f95c392f2d801c1b7cb429268edc21f8b4762f2d0826e640b884bb8669843909'
+    and changed_external_function_count = 6
+    and changed_external_function_fingerprint_sha256 =
+      'd79196cc1d693d0bbf3c220ccd350631819a53ccd3f54a7d05ac65232caf1e3f'
+    and changed_external_function_acl_fingerprint_sha256 =
+      'f65fafd844efadce756ad512ee44c0d694e249d2094def482c52465d1f7410fb'
+    and binder_index_count = 65
+    and binder_index_fingerprint_sha256 =
+      'ad46c7612efd3306a15a8a107181abfbaa0d14ca3d1ae426e452c2baef9fc4eb'
+    and binder_rls_table_count = 21
+    and binder_policy_count = 22
+    and binder_policy_fingerprint_sha256 =
+      '907c14c26a363413cabbd44976b0f3c9e3d256ebb5a292fef028911a59e964a8'
+    and changed_external_policy_count = 3
+    and changed_external_policy_fingerprint_sha256 =
+      '0bccdf04c5f21670cee2784aacfea713574fd95fd97e1753d926e3578ebc52a7'
+    and trust_surface_constraint_count = 1
+    and trust_surface_constraint_fingerprint_sha256 =
+      '334fa2f5d7e70d733e40dafa4047ae00cd320541219a9fa50b26a4be9d3382d0'
+    and binder_trigger_count = 22
+    and binder_trigger_fingerprint_sha256 =
+      'fe8061de9bf08d967d76dfdda3da8b5d62def879a9a997f8fff0e88d632e9622'
+    and binder_table_acl_fingerprint_sha256 =
+      '678d70ecc32c7e21c271ae25e8b207a6f9c9f7f56dbe901fdcad1f2e94c3a69d'
+    and changed_external_table_acl_fingerprint_sha256 =
+      '9dc7a29f8573d287af260265a90b7c86711ee4d78b30aa0c071d1bd23509ad29'
+    and stable_catalog_fingerprint_sha256 ~ '^[0-9a-f]{64}$'
+    and applied_package_migration_count = 5
+    and search_path_public_count = 117
+    and search_path_pg_catalog_count = 5
+    and search_path_public_extensions_count = 2
+    and public_execute_functions = 0
+    and anonymous_execute_functions = 8
+    and authenticated_execute_functions = 64
+    and service_execute_functions = 124
+    and flag_count = 11
+    and enabled_flag_count = 0
+    and missing_flags = '[]'::jsonb
+    and unexpected_flags = '[]'::jsonb
+    and realtime_tables = '["binder_refresh_signals"]'::jsonb
+    and refresh_signal_replica_rls_ok
+    and unexpected_raw_privileges = '[]'::jsonb
+    and nonempty_domain_tables = '[]'::jsonb
+    and not binder_card_event_data_exists
+    and not binder_trust_report_data_exists
+    and external_trigger_map = '[
+      "slab_certs.trg_binder_slab_identity_update_v1",
+      "trust_blocks.trg_trust_blocks_binder_effect_v1",
+      "vault_item_instances.trg_binder_vault_instance_delete_v1",
+      "vault_item_instances.trg_binder_vault_instance_update_v1"
+    ]'::jsonb
+    and pulse_base_body_sha256 =
+      '0d2508ab97d0d4a3be5e2fc21e3f610b8b2b6cd60b22ffdcde7c284fafa1aff2'
+    and pulse_wrapper_body_sha256 =
+      '2453b36246cd0bfc7c03adb2487d96fd82392b33f4673b0b7cc539b72cd53454'
+    and card_events_feed_body_sha256 =
+      'e5c297e16af3998555e2003bc246b0f08294a9df4e9038330e0ad8e43217690c'
+    and trust_surface_constraint =
+      'CHECK (surface = ANY (ARRAY[''profile''::text, ''message''::text, ''wall_card''::text, ''listing''::text, ''card''::text, ''gvvi''::text, ''other''::text, ''binder''::text, ''binder_contribution''::text, ''binder_member''::text, ''binder_invitation''::text]))'
+    and trust_insert_policy =
+      'auth.uid() = reporter_user_id AND (reported_user_id IS NULL OR auth.uid() <> reported_user_id) AND (surface <> ALL (ARRAY[''binder''::text, ''binder_contribution''::text, ''binder_member''::text, ''binder_invitation''::text]))'
+    and card_events_select_policy =
+      'binder_card_event_visible_to_viewer_v1(auth.uid(), event_type, card_print_id, actor_user_id, subject_user_id, visibility, payload, dedupe_key)'
+    and card_events_insert_policy =
+      'actor_user_id = auth.uid() AND jsonb_typeof(payload) = ''object''::text AND "left"(lower(btrim(event_type)), 7) <> ''binder_''::text'
+    and card_event_failure_hardening_ok
+    and hardened_function_grants_ok
+    and card_events_feed_grants_ok,
+  'checks', to_jsonb(snapshot)
+) as rollout_readback
+from snapshot

--- a/scripts/ops/sql/collaborative_binders_production_preflight_v1.sql
+++ b/scripts/ops/sql/collaborative_binders_production_preflight_v1.sql
@@ -1,0 +1,1242 @@
+with
+required_relations(relation_name) as (
+  values
+    ('auth.users'),
+    ('public.card_events'),
+    ('public.card_events_emit_failures'),
+    ('public.card_print_species'),
+    ('public.card_printings'),
+    ('public.card_prints'),
+    ('public.finish_keys'),
+    ('public.pokemon_species'),
+    ('public.public_profiles'),
+    ('public.sets'),
+    ('public.slab_certs'),
+    ('public.trust_blocks'),
+    ('public.trust_reports'),
+    ('public.vault_item_instances'),
+    ('public.vault_owners'),
+    ('public.watches')
+),
+required_columns(schema_name, table_name, column_name, data_type) as (
+  values
+    ('auth', 'users', 'id', 'uuid'),
+    ('public', 'pokemon_species', 'id', 'uuid'),
+    ('public', 'pokemon_species', 'active', 'boolean'),
+    ('public', 'pokemon_species', 'display_name', 'text'),
+    ('public', 'pokemon_species', 'slug', 'text'),
+    ('public', 'sets', 'id', 'uuid'),
+    ('public', 'sets', 'code', 'text'),
+    ('public', 'sets', 'name', 'text'),
+    ('public', 'sets', 'release_date', 'date'),
+    ('public', 'card_prints', 'id', 'uuid'),
+    ('public', 'card_prints', 'set_id', 'uuid'),
+    ('public', 'card_prints', 'gv_id', 'text'),
+    ('public', 'card_prints', 'name', 'text'),
+    ('public', 'card_prints', 'set_code', 'text'),
+    ('public', 'card_prints', 'number', 'text'),
+    ('public', 'card_prints', 'number_plain', 'text'),
+    ('public', 'card_prints', 'image_source', 'text'),
+    ('public', 'card_prints', 'image_path', 'text'),
+    ('public', 'card_printings', 'id', 'uuid'),
+    ('public', 'card_printings', 'card_print_id', 'uuid'),
+    ('public', 'card_printings', 'finish_key', 'text'),
+    ('public', 'card_printings', 'printing_gv_id', 'text'),
+    ('public', 'card_printings', 'image_source', 'text'),
+    ('public', 'card_printings', 'image_path', 'text'),
+    ('public', 'card_print_species', 'id', 'uuid'),
+    ('public', 'card_print_species', 'card_print_id', 'uuid'),
+    ('public', 'card_print_species', 'species_id', 'uuid'),
+    ('public', 'card_print_species', 'active', 'boolean'),
+    ('public', 'card_print_species', 'counts_for_completion', 'boolean'),
+    ('public', 'card_print_species', 'created_at', 'timestamp with time zone'),
+    ('public', 'slab_certs', 'id', 'uuid'),
+    ('public', 'slab_certs', 'card_print_id', 'uuid'),
+    ('public', 'vault_item_instances', 'id', 'uuid'),
+    ('public', 'vault_item_instances', 'user_id', 'uuid'),
+    ('public', 'vault_item_instances', 'gv_vi_id', 'text'),
+    ('public', 'vault_item_instances', 'card_print_id', 'uuid'),
+    ('public', 'vault_item_instances', 'card_printing_id', 'uuid'),
+    ('public', 'vault_item_instances', 'slab_cert_id', 'uuid'),
+    ('public', 'vault_item_instances', 'archived_at', 'timestamp with time zone'),
+    ('public', 'vault_item_instances', 'created_at', 'timestamp with time zone'),
+    ('public', 'vault_owners', 'user_id', 'uuid'),
+    ('public', 'vault_owners', 'owner_code', 'text'),
+    ('public', 'vault_owners', 'next_instance_index', 'bigint'),
+    ('public', 'watches', 'id', 'uuid'),
+    ('public', 'watches', 'user_id', 'uuid'),
+    ('public', 'watches', 'subject_type', 'text'),
+    ('public', 'watches', 'subject_id', 'uuid'),
+    ('public', 'watches', 'reason', 'text'),
+    ('public', 'watches', 'strength', 'double precision'),
+    ('public', 'watches', 'origin', 'text'),
+    ('public', 'watches', 'muted_at', 'timestamp with time zone'),
+    ('public', 'watches', 'created_at', 'timestamp with time zone'),
+    ('public', 'watches', 'updated_at', 'timestamp with time zone'),
+    ('public', 'trust_reports', 'id', 'uuid'),
+    ('public', 'trust_reports', 'reporter_user_id', 'uuid'),
+    ('public', 'trust_reports', 'reported_user_id', 'uuid'),
+    ('public', 'trust_reports', 'surface', 'text'),
+    ('public', 'trust_reports', 'surface_id', 'text'),
+    ('public', 'trust_reports', 'reason', 'text'),
+    ('public', 'trust_reports', 'details', 'text'),
+    ('public', 'trust_blocks', 'id', 'uuid'),
+    ('public', 'trust_blocks', 'user_id', 'uuid'),
+    ('public', 'trust_blocks', 'blocked_user_id', 'uuid'),
+    ('public', 'card_events', 'id', 'uuid'),
+    ('public', 'card_events', 'event_type', 'text'),
+    ('public', 'card_events', 'card_print_id', 'uuid'),
+    ('public', 'card_events', 'actor_user_id', 'uuid'),
+    ('public', 'card_events', 'subject_user_id', 'uuid'),
+    ('public', 'card_events', 'payload', 'jsonb'),
+    ('public', 'card_events', 'visibility', 'text'),
+    ('public', 'card_events', 'dedupe_key', 'text'),
+    ('public', 'card_events', 'created_at', 'timestamp with time zone'),
+    ('public', 'card_events_emit_failures', 'actor_user_id', 'uuid'),
+    ('public', 'card_events_emit_failures', 'event_type', 'text'),
+    ('public', 'card_events_emit_failures', 'card_print_id', 'uuid'),
+    ('public', 'card_events_emit_failures', 'source', 'text'),
+    ('public', 'card_events_emit_failures', 'error_message', 'text'),
+    ('public', 'card_events_emit_failures', 'payload', 'jsonb'),
+    ('public', 'public_profiles', 'user_id', 'uuid'),
+    ('public', 'public_profiles', 'slug', 'text'),
+    ('public', 'public_profiles', 'display_name', 'text'),
+    ('public', 'public_profiles', 'avatar_path', 'text'),
+    ('public', 'public_profiles', 'public_profile_enabled', 'boolean'),
+    ('public', 'public_profiles', 'vault_sharing_enabled', 'boolean'),
+    ('public', 'finish_keys', 'key', 'text'),
+    ('public', 'finish_keys', 'label', 'text')
+),
+required_functions(function_signature) as (
+  values
+    ('auth.uid()'),
+    ('auth.role()'),
+    ('extensions.gen_random_bytes(integer)'),
+    ('extensions.digest(bytea,text)'),
+    ('public.set_timestamp_updated_at()'),
+    ('public.generate_gv_vi_id_v1(text,bigint)'),
+    ('public.trust_block_exists_between_v1(uuid,uuid)'),
+    ('public.interest_graph_upsert_watch_v1(uuid,text,uuid,text,text)'),
+    ('public.interest_graph_emit_event_v1(text,text,uuid,uuid,uuid,jsonb,text,text)'),
+    ('public.interest_graph_log_emit_failure_v1(text,text,uuid,uuid,jsonb,text)'),
+    ('public.interest_graph_card_event_visible_to_viewer_v1(uuid,uuid,uuid,text)'),
+    ('public.interest_graph_collector_public_v1(uuid)'),
+    ('public.pulse_jsonb_uuid_v1(text)'),
+    ('public.pulse_eligible_events_for_viewer_v1(uuid)'),
+    ('public.card_events_feed_v1(integer,timestamp with time zone,uuid)')
+),
+required_function_bodies(function_signature, body_sha256) as (
+  values
+    (
+      'public.set_timestamp_updated_at()',
+      'effca6b411b3297f7616459dc92c7fb3c2f105009c46197eb634bf8c7fd9d9f1'
+    ),
+    (
+      'public.generate_gv_vi_id_v1(text,bigint)',
+      '66ac5c43619b15ea2a041694379120c42ea334c2e5eae60412124ae66382c55c'
+    ),
+    (
+      'public.trust_block_exists_between_v1(uuid,uuid)',
+      'f4605ed5e8267e9b4a98f47940a60429853de8da54892b511d6cba6a98a9c42c'
+    ),
+    (
+      'public.interest_graph_upsert_watch_v1(uuid,text,uuid,text,text)',
+      'a52d510f7723e2f6c99835802e9f6a4c7b892edb3438b39fbf9bc41a2800bff4'
+    ),
+    (
+      'public.interest_graph_emit_event_v1(text,text,uuid,uuid,uuid,jsonb,text,text)',
+      '421ebfa825613341ad8dc6035f603caabdd6ac7d7a67a77452defdc66d94fbd5'
+    ),
+    (
+      'public.interest_graph_log_emit_failure_v1(text,text,uuid,uuid,jsonb,text)',
+      '0fc54bb8ca8e1d882bd612d1cd54943e2db1558871e602587e647a0addb96fae'
+    ),
+    (
+      'public.interest_graph_card_event_visible_to_viewer_v1(uuid,uuid,uuid,text)',
+      '8d0c0f6ae184e55abc8029516b243e2dc798fca89801c5d1a779939c5b23d61d'
+    ),
+    (
+      'public.interest_graph_collector_public_v1(uuid)',
+      '80f72c99ce399db0598defefef0ea901255b57ccf3c34fd119fdae549d3c64b2'
+    ),
+    (
+      'public.pulse_jsonb_uuid_v1(text)',
+      '7f374bc05d0b12dcc3d64c4eb6a1ee2f69ee1886b56ab0141c06b265ad145d59'
+    )
+),
+required_roles(role_name) as (
+  values ('anon'), ('authenticated'), ('authenticator'), ('service_role')
+),
+external_trigger_names(trigger_name) as (
+  values
+    ('trg_trust_blocks_binder_effect_v1'),
+    ('trg_binder_vault_instance_update_v1'),
+    ('trg_binder_vault_instance_delete_v1'),
+    ('trg_binder_slab_identity_update_v1')
+),
+external_trigger_name_collisions as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'relation', n.nspname || '.' || c.relname,
+        'trigger', t.tgname
+      )
+      order by n.nspname, c.relname, t.tgname
+    ),
+    '[]'::jsonb
+  ) as value
+  from pg_trigger t
+  join pg_class c on c.oid = t.tgrelid
+  join pg_namespace n on n.oid = c.relnamespace
+  join external_trigger_names expected on expected.trigger_name = t.tgname
+  where n.nspname = 'public'
+    and not t.tgisinternal
+),
+schema_create_guard_roles(role_name) as (
+  values ('anon'), ('authenticated'), ('authenticator')
+),
+schema_create_guard_schemas(schema_name) as (
+  values ('public'), ('extensions')
+),
+unexpected_schema_create_privileges as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'role', expected_role.role_name,
+        'schema', expected_schema.schema_name,
+        'role_exists', role_row.oid is not null,
+        'schema_exists', schema_row.oid is not null,
+        'has_create', coalesce(
+          has_schema_privilege(role_row.oid, schema_row.oid, 'CREATE'),
+          false
+        )
+      )
+      order by expected_role.role_name, expected_schema.schema_name
+    ),
+    '[]'::jsonb
+  ) as value
+  from schema_create_guard_roles expected_role
+  cross join schema_create_guard_schemas expected_schema
+  left join pg_roles role_row on role_row.rolname = expected_role.role_name
+  left join pg_namespace schema_row
+    on schema_row.nspname = expected_schema.schema_name
+  where role_row.oid is null
+    or schema_row.oid is null
+    or has_schema_privilege(role_row.oid, schema_row.oid, 'CREATE')
+),
+unexpected_public_default_acl_grantees as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'default_owner', pg_get_userbyid(default_acl.defaclrole),
+        'schema', coalesce(n.nspname, '*'),
+        'object_type', default_acl.defaclobjtype,
+        'grantor', grantor_role.rolname,
+        'grantee', coalesce(grantee_role.rolname, 'PUBLIC'),
+        'privilege', acl.privilege_type,
+        'grantable', acl.is_grantable
+      )
+      order by
+        pg_get_userbyid(default_acl.defaclrole),
+        coalesce(n.nspname, '*'),
+        default_acl.defaclobjtype,
+        grantor_role.rolname,
+        coalesce(grantee_role.rolname, 'PUBLIC'),
+        acl.privilege_type,
+        acl.is_grantable
+    ),
+    '[]'::jsonb
+  ) as value
+  from pg_default_acl default_acl
+  left join pg_namespace n on n.oid = default_acl.defaclnamespace
+  cross join lateral aclexplode(default_acl.defaclacl) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+  where (
+      default_acl.defaclnamespace = 0
+      or n.nspname = 'public'
+    )
+    and coalesce(grantee_role.rolname, 'PUBLIC') not in (
+      'postgres',
+      'anon',
+      'authenticated',
+      'service_role'
+    )
+),
+reviewed_public_default_acl_rows as (
+  select
+    pg_get_userbyid(default_acl.defaclrole) as default_owner,
+    n.nspname as schema_name,
+    default_acl.defaclobjtype as object_type,
+    grantor_role.rolname as grantor_name,
+    coalesce(grantee_role.rolname, 'PUBLIC') as grantee_name,
+    acl.privilege_type,
+    acl.is_grantable
+  from pg_default_acl default_acl
+  join pg_namespace n on n.oid = default_acl.defaclnamespace
+  cross join lateral aclexplode(default_acl.defaclacl) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+  where pg_get_userbyid(default_acl.defaclrole) = 'postgres'
+    and n.nspname = 'public'
+    and default_acl.defaclobjtype in ('r', 'f', 'S')
+),
+reviewed_public_default_acl_fingerprint as (
+  select
+    count(*)::integer as row_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              default_owner,
+              schema_name,
+              object_type,
+              grantor_name,
+              grantee_name,
+              privilege_type,
+              is_grantable::text
+            ),
+            E'\x1e'
+            order by
+              default_owner,
+              schema_name,
+              object_type,
+              grantor_name,
+              grantee_name,
+              privilege_type,
+              is_grantable
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from reviewed_public_default_acl_rows
+),
+realtime_publication_config_row as (
+  select
+    publication.pubname,
+    pg_get_userbyid(publication.pubowner) as owner_name,
+    publication.puballtables,
+    publication.pubinsert,
+    publication.pubupdate,
+    publication.pubdelete,
+    publication.pubtruncate,
+    publication.pubviaroot
+  from pg_publication publication
+  where publication.pubname = 'supabase_realtime'
+),
+realtime_publication_config_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              pubname,
+              owner_name,
+              puballtables::text,
+              pubinsert::text,
+              pubupdate::text,
+              pubdelete::text,
+              pubtruncate::text,
+              pubviaroot::text
+            ),
+            E'\x1e'
+            order by pubname
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from realtime_publication_config_row
+),
+changed_external_function_targets(function_signature) as (
+  values
+    ('public.interest_graph_upsert_watch_v1(uuid,text,uuid,text,text)'),
+    ('public.interest_graph_emit_event_v1(text,text,uuid,uuid,uuid,jsonb,text,text)'),
+    ('public.interest_graph_log_emit_failure_v1(text,text,uuid,uuid,jsonb,text)'),
+    ('public.pulse_eligible_events_for_viewer_v1(uuid)'),
+    ('public.card_events_feed_v1(integer,timestamp with time zone,uuid)')
+),
+changed_external_functions as (
+  select
+    p.oid,
+    p.proowner,
+    p.proacl,
+    format(
+      '%I.%I(%s)',
+      n.nspname,
+      p.proname,
+      replace(pg_get_function_identity_arguments(p.oid), 'public.', '')
+    ) as signature,
+    replace(pg_get_function_arguments(p.oid), 'public.', '') as function_arguments,
+    replace(pg_get_function_result(p.oid), 'public.', '') as function_result,
+    pg_get_userbyid(p.proowner) as function_owner,
+    l.lanname,
+    p.prokind,
+    p.provolatile,
+    p.prosecdef,
+    p.proleakproof,
+    p.proisstrict,
+    p.proretset,
+    p.proparallel,
+    coalesce(array_to_string(p.proconfig, ','), '') as function_config,
+    p.procost,
+    p.prorows,
+    encode(
+      extensions.digest(convert_to(p.prosrc, 'UTF8'), 'sha256'),
+      'hex'
+    ) as body_sha256
+  from changed_external_function_targets target
+  join pg_proc p on p.oid = to_regprocedure(target.function_signature)
+  join pg_namespace n on n.oid = p.pronamespace
+  join pg_language l on l.oid = p.prolang
+),
+changed_external_function_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              signature,
+              function_arguments,
+              function_result,
+              function_owner,
+              lanname,
+              prokind,
+              provolatile,
+              prosecdef::text,
+              proleakproof::text,
+              proisstrict::text,
+              proretset::text,
+              proparallel,
+              function_config,
+              procost::text,
+              prorows::text,
+              body_sha256
+            ),
+            E'\x1e'
+            order by signature
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from changed_external_functions
+),
+changed_external_function_acl_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            changed.signature,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable::text
+          ),
+          E'\x1e'
+          order by
+            changed.signature,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from changed_external_functions changed
+  cross join lateral aclexplode(
+    coalesce(changed.proacl, acldefault('f', changed.proowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+),
+changed_external_policy_targets(relation_name, policy_name) as (
+  values
+    ('public.trust_reports', 'trust_reports_insert_reporter'),
+    ('public.card_events', 'card_events_visibility_select'),
+    ('public.card_events', 'card_events_actor_insert'),
+    (
+      'public.card_events_emit_failures',
+      'card_events_emit_failures_owner_insert'
+    )
+),
+changed_external_policy_rows as (
+  select
+    n.nspname as schema_name,
+    c.relname as relation_name,
+    p.polname as policy_name,
+    p.polcmd,
+    p.polpermissive,
+    (
+      select string_agg(
+        coalesce(r.rolname, 'PUBLIC'),
+        ','
+        order by coalesce(r.rolname, 'PUBLIC')
+      )
+      from unnest(p.polroles) role_oid
+      left join pg_roles r on r.oid = role_oid
+    ) as role_names,
+    replace(
+      coalesce(pg_get_expr(p.polqual, p.polrelid, true), ''),
+      'public.',
+      ''
+    ) as using_expression,
+    replace(
+      coalesce(pg_get_expr(p.polwithcheck, p.polrelid, true), ''),
+      'public.',
+      ''
+    ) as check_expression
+  from changed_external_policy_targets target
+  join pg_class c on c.oid = to_regclass(target.relation_name)
+  join pg_namespace n on n.oid = c.relnamespace
+  join pg_policy p
+    on p.polrelid = c.oid
+   and p.polname = target.policy_name
+),
+changed_external_policy_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              schema_name,
+              relation_name,
+              policy_name,
+              polcmd,
+              polpermissive::text,
+              role_names,
+              using_expression,
+              check_expression
+            ),
+            E'\x1e'
+            order by schema_name, relation_name, policy_name
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from changed_external_policy_rows
+),
+trust_surface_constraint_row as (
+  select
+    n.nspname as schema_name,
+    c.relname as relation_name,
+    constraint_row.conname as constraint_name,
+    constraint_row.contype,
+    constraint_row.condeferrable,
+    constraint_row.condeferred,
+    constraint_row.convalidated,
+    constraint_row.conislocal,
+    constraint_row.coninhcount,
+    constraint_row.connoinherit,
+    replace(
+      pg_get_constraintdef(constraint_row.oid, true),
+      'public.',
+      ''
+    ) as definition
+  from pg_constraint constraint_row
+  join pg_class c on c.oid = constraint_row.conrelid
+  join pg_namespace n on n.oid = c.relnamespace
+  where constraint_row.conrelid = 'public.trust_reports'::regclass
+    and constraint_row.conname = 'trust_reports_surface_check'
+),
+trust_surface_constraint_fingerprint as (
+  select
+    count(*)::integer as object_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          string_agg(
+            concat_ws(
+              E'\x1f',
+              schema_name,
+              relation_name,
+              constraint_name,
+              contype,
+              condeferrable::text,
+              condeferred::text,
+              convalidated::text,
+              conislocal::text,
+              coninhcount::text,
+              connoinherit::text,
+              definition
+            ),
+            E'\x1e'
+            order by schema_name, relation_name, constraint_name
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as sha256
+  from trust_surface_constraint_row
+),
+changed_external_table_acl_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(
+            E'\x1f',
+            n.nspname || '.' || c.relname,
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable::text
+          ),
+          E'\x1e'
+          order by
+            grantor_role.rolname,
+            coalesce(grantee_role.rolname, 'PUBLIC'),
+            acl.privilege_type,
+            acl.is_grantable
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  cross join lateral aclexplode(
+    coalesce(c.relacl, acldefault('r', c.relowner))
+  ) acl
+  left join pg_roles grantor_role on grantor_role.oid = acl.grantor
+  left join pg_roles grantee_role on grantee_role.oid = acl.grantee
+  where c.oid = 'public.card_events_emit_failures'::regclass
+),
+missing_relations as (
+  select coalesce(jsonb_agg(relation_name order by relation_name), '[]'::jsonb) as value
+  from required_relations rr
+  where not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname || '.' || c.relname = rr.relation_name
+      and c.relkind in ('r', 'p')
+  )
+),
+missing_columns as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'relation', schema_name || '.' || table_name,
+        'column', column_name,
+        'type', data_type
+      )
+      order by schema_name, table_name, column_name
+    ),
+    '[]'::jsonb
+  ) as value
+  from required_columns required
+  where not exists (
+    select 1
+    from pg_attribute a
+    join pg_class c on c.oid = a.attrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = required.schema_name
+      and c.relname = required.table_name
+      and c.relkind in ('r', 'p')
+      and a.attname = required.column_name
+      and a.attnum > 0
+      and not a.attisdropped
+      and format_type(a.atttypid, a.atttypmod) = required.data_type
+  )
+),
+missing_functions as (
+  select coalesce(jsonb_agg(function_signature order by function_signature), '[]'::jsonb) as value
+  from required_functions
+  where to_regprocedure(function_signature) is null
+),
+drifted_functions as (
+  select coalesce(
+    jsonb_agg(function_signature order by function_signature),
+    '[]'::jsonb
+  ) as value
+  from required_function_bodies required
+  where coalesce((
+    select encode(
+      extensions.digest(convert_to(p.prosrc, 'UTF8'), 'sha256'),
+      'hex'
+    )
+    from pg_proc p
+    where p.oid = to_regprocedure(required.function_signature)
+  ), '') <> required.body_sha256
+),
+missing_roles as (
+  select coalesce(jsonb_agg(role_name order by role_name), '[]'::jsonb) as value
+  from required_roles
+  where not exists (
+    select 1 from pg_roles where rolname = role_name
+  )
+),
+stable_target_relations(relation_oid) as (
+  values
+    ('public.trust_reports'::regclass),
+    ('public.trust_blocks'::regclass),
+    ('public.vault_item_instances'::regclass),
+    ('public.slab_certs'::regclass),
+    ('public.watches'::regclass),
+    ('public.card_events'::regclass),
+    ('public.card_events_emit_failures'::regclass)
+),
+stable_manifests(object_name, object_part, payload) as (
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'columns',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        a.attnum,
+        a.attname,
+        format_type(a.atttypid, a.atttypmod),
+        a.attnotnull,
+        a.attidentity,
+        a.attgenerated,
+        coalesce(
+          replace(pg_get_expr(d.adbin, d.adrelid, true), 'public.', ''),
+          ''
+        )
+      ),
+      E'\x1e'
+      order by a.attnum
+    )
+  from stable_target_relations t
+  join pg_attribute a
+    on a.attrelid = t.relation_oid
+   and a.attnum > 0
+   and not a.attisdropped
+  left join pg_attrdef d
+    on d.adrelid = a.attrelid
+   and d.adnum = a.attnum
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_constraints',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        c.conname,
+        c.contype,
+        c.condeferrable,
+        c.condeferred,
+        replace(pg_get_constraintdef(c.oid, true), 'public.', '')
+      ),
+      E'\x1e'
+      order by c.conname
+    )
+  from stable_target_relations t
+  join pg_constraint c on c.conrelid = t.relation_oid
+  where not (
+    t.relation_oid = 'public.trust_reports'::regclass
+    and c.conname = 'trust_reports_surface_check'
+  )
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'indexes',
+    string_agg(
+      concat_ws(
+        E'\x1f',
+        ci.relname,
+        i.indisunique,
+        i.indisprimary,
+        i.indisvalid,
+        replace(pg_get_indexdef(i.indexrelid), 'public.', '')
+      ),
+      E'\x1e'
+      order by ci.relname
+    )
+  from stable_target_relations t
+  join pg_index i on i.indrelid = t.relation_oid
+  join pg_class ci on ci.oid = i.indexrelid
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_policies',
+    coalesce(
+      string_agg(
+        concat_ws(
+          E'\x1f',
+          p.polname,
+          p.polcmd,
+          p.polpermissive,
+          p.polroles::text,
+          replace(coalesce(pg_get_expr(p.polqual, p.polrelid, true), ''), 'public.', ''),
+          replace(coalesce(pg_get_expr(p.polwithcheck, p.polrelid, true), ''), 'public.', '')
+        ),
+        E'\x1e'
+        order by p.polname
+      ) filter (where p.oid is not null),
+      ''
+    )
+  from stable_target_relations t
+  left join pg_policy p
+    on p.polrelid = t.relation_oid
+   and p.polname not in (
+     'trust_reports_insert_reporter',
+     'card_events_visibility_select',
+     'card_events_actor_insert',
+     'card_events_emit_failures_owner_insert'
+   )
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_triggers',
+    coalesce(
+      string_agg(
+        concat_ws(
+          E'\x1f',
+          g.tgname,
+          replace(pg_get_triggerdef(g.oid, true), 'public.', '')
+        ),
+        E'\x1e'
+        order by g.tgname
+      ) filter (where g.oid is not null),
+      ''
+    )
+  from stable_target_relations t
+  left join pg_trigger g
+    on g.tgrelid = t.relation_oid
+   and not g.tgisinternal
+   and g.tgname not in (
+     'trg_trust_blocks_binder_effect_v1',
+     'trg_binder_vault_instance_update_v1',
+     'trg_binder_vault_instance_delete_v1',
+     'trg_binder_slab_identity_update_v1'
+   )
+  group by t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'rls_replica',
+    concat_ws(E'\x1f', c.relrowsecurity, c.relforcerowsecurity, c.relreplident)
+  from stable_target_relations t
+  join pg_class c on c.oid = t.relation_oid
+
+  union all
+
+  select
+    replace(t.relation_oid::text, 'public.', ''),
+    'stable_acl',
+    coalesce(array_to_string(c.relacl, ','), '')
+  from stable_target_relations t
+  join pg_class c on c.oid = t.relation_oid
+  where t.relation_oid <> 'public.card_events_emit_failures'::regclass
+),
+stable_functions(object_name, object_part, payload) as (
+  select
+    format(
+      '%I.%I(%s)',
+      n.nspname,
+      p.proname,
+      replace(pg_get_function_identity_arguments(p.oid), 'public.', '')
+    ),
+    'function_shape_body',
+    concat_ws(
+      E'\x1f',
+      replace(pg_get_function_arguments(p.oid), 'public.', ''),
+      replace(pg_get_function_result(p.oid), 'public.', ''),
+      pg_get_userbyid(p.proowner),
+      l.lanname,
+      p.provolatile,
+      p.prosecdef,
+      p.proparallel,
+      coalesce(array_to_string(p.proconfig, ','), ''),
+      p.prosrc
+    )
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  join pg_language l on l.oid = p.prolang
+  where n.nspname = 'public'
+    and p.proname in (
+      'interest_graph_upsert_watch_v1',
+      'interest_graph_emit_event_v1',
+      'interest_graph_log_emit_failure_v1'
+    )
+),
+stable_catalog_fingerprint as (
+  select encode(
+    extensions.digest(
+      convert_to(
+        string_agg(
+          concat_ws(E'\x1f', object_name, object_part, payload),
+          E'\x1e'
+          order by object_name, object_part
+        ),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) as sha256
+  from (
+    select * from stable_manifests
+    union all
+    select * from stable_functions
+  ) stable_rows
+),
+snapshot as (
+  select
+    current_user as execution_role,
+    pg_catalog.current_setting('server_version_num')::integer
+      as server_version_num,
+    (
+      pg_catalog.current_setting('server_version_num')::integer / 10000
+    ) as server_major_version,
+    17::integer as required_server_major_version,
+    (
+      pg_catalog.current_setting('server_version_num')::integer / 10000 = 17
+    ) as server_major_version_ok,
+    (
+      select count(*)::integer
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public'
+        and (
+          c.relname = 'binders'
+          or c.relname like 'binder\_%' escape '\'
+        )
+    ) as binder_relation_collision_count,
+    (
+      select count(*)::integer
+      from pg_type t
+      join pg_namespace n on n.oid = t.typnamespace
+      where n.nspname = 'public'
+        and (
+          t.typname = 'binders'
+          or t.typname like 'binder\_%' escape '\'
+        )
+    ) as binder_type_collision_count,
+    (
+      select count(*)::integer
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'public'
+        and p.proname like 'binder\_%' escape '\'
+    ) as binder_function_count,
+    (
+      select value from external_trigger_name_collisions
+    ) as external_trigger_name_collisions,
+    (
+      select value from unexpected_public_default_acl_grantees
+    ) as unexpected_public_default_acl_grantees,
+    (
+      select value from unexpected_schema_create_privileges
+    ) as unexpected_schema_create_privileges,
+    (
+      select row_count from reviewed_public_default_acl_fingerprint
+    ) as reviewed_public_default_acl_row_count,
+    (
+      select sha256 from reviewed_public_default_acl_fingerprint
+    ) as reviewed_public_default_acl_fingerprint_sha256,
+    (
+      select object_count from realtime_publication_config_fingerprint
+    ) as realtime_publication_config_count,
+    (
+      select sha256 from realtime_publication_config_fingerprint
+    ) as realtime_publication_config_fingerprint_sha256,
+    (
+      select object_count from changed_external_function_fingerprint
+    ) as changed_external_function_count,
+    (
+      select sha256 from changed_external_function_fingerprint
+    ) as changed_external_function_fingerprint_sha256,
+    (
+      select sha256 from changed_external_function_acl_fingerprint
+    ) as changed_external_function_acl_fingerprint_sha256,
+    (
+      select object_count from changed_external_policy_fingerprint
+    ) as changed_external_policy_count,
+    (
+      select sha256 from changed_external_policy_fingerprint
+    ) as changed_external_policy_fingerprint_sha256,
+    (
+      select object_count from trust_surface_constraint_fingerprint
+    ) as trust_surface_constraint_count,
+    (
+      select sha256 from trust_surface_constraint_fingerprint
+    ) as trust_surface_constraint_fingerprint_sha256,
+    (
+      select sha256 from changed_external_table_acl_fingerprint
+    ) as changed_external_table_acl_fingerprint_sha256,
+    (
+      select count(*)::integer
+      from supabase_migrations.schema_migrations
+      where version::text = any(array[
+        '20260723100000',
+        '20260723101000',
+        '20260723102000',
+        '20260723103000',
+        '20260723104000'
+      ])
+    ) as applied_package_migration_count,
+    (
+      select max(version::text)
+      from supabase_migrations.schema_migrations
+    ) as migration_head,
+    (
+      select value from missing_relations
+    ) as missing_relations,
+    (
+      select value from missing_columns
+    ) as missing_columns,
+    (
+      select value from missing_functions
+    ) as missing_functions,
+    (
+      select value from drifted_functions
+    ) as drifted_functions,
+    (
+      select value from missing_roles
+    ) as missing_roles,
+    (
+      select sha256 from stable_catalog_fingerprint
+    ) as stable_catalog_fingerprint_sha256,
+    exists (
+      select 1
+      from pg_publication
+      where pubname = 'supabase_realtime'
+    ) as realtime_publication_exists,
+    exists (
+      select 1
+      from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and (
+          tablename = 'binders'
+          or tablename like 'binder\_%' escape '\'
+        )
+    ) as binder_realtime_object_exists,
+    exists (
+      select 1
+      from public.card_events
+      where event_type like 'binder\_%' escape '\'
+    ) as binder_card_event_data_exists,
+    exists (
+      select 1
+      from public.trust_reports
+      where surface in (
+        'binder',
+        'binder_contribution',
+        'binder_member',
+        'binder_invitation'
+      )
+    ) as binder_trust_report_data_exists,
+    to_regprocedure(
+      'public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)'
+    ) is not null as wrapped_pulse_function_exists,
+    coalesce((
+      select encode(
+        extensions.digest(convert_to(prosrc, 'UTF8'), 'sha256'),
+        'hex'
+      )
+      from pg_proc
+      where oid = to_regprocedure(
+        'public.pulse_eligible_events_for_viewer_v1(uuid)'
+      )
+    ), '') as pulse_body_sha256,
+    coalesce((
+      select encode(
+        extensions.digest(convert_to(prosrc, 'UTF8'), 'sha256'),
+        'hex'
+      )
+      from pg_proc
+      where oid = to_regprocedure(
+        'public.card_events_feed_v1(integer,timestamp with time zone,uuid)'
+      )
+    ), '') as card_events_feed_body_sha256,
+    coalesce((
+      select pg_get_constraintdef(oid, true)
+      from pg_constraint
+      where conrelid = 'public.trust_reports'::regclass
+        and conname = 'trust_reports_surface_check'
+    ), '') as trust_surface_constraint,
+    coalesce((
+      select pg_get_expr(polwithcheck, polrelid, true)
+      from pg_policy
+      where polrelid = 'public.trust_reports'::regclass
+        and polname = 'trust_reports_insert_reporter'
+    ), '') as trust_insert_policy
+    ,
+    replace(coalesce((
+      select pg_get_expr(polqual, polrelid, true)
+      from pg_policy
+      where polrelid = 'public.card_events'::regclass
+        and polname = 'card_events_visibility_select'
+    ), ''), 'public.', '') as card_events_select_policy,
+    replace(coalesce((
+      select pg_get_expr(polwithcheck, polrelid, true)
+      from pg_policy
+      where polrelid = 'public.card_events'::regclass
+        and polname = 'card_events_actor_insert'
+    ), ''), 'public.', '') as card_events_insert_policy,
+    exists (
+      select 1
+      from pg_policy
+      where polrelid = 'public.card_events_emit_failures'::regclass
+        and polname = 'card_events_emit_failures_owner_insert'
+    ) and has_table_privilege(
+      'authenticated',
+      'public.card_events_emit_failures',
+      'INSERT'
+    ) as card_event_failure_baseline_ok
+)
+select jsonb_build_object(
+  'package_id', 'COLLABORATIVE-BINDERS-DB-V1',
+  'phase', 'preflight',
+  'read_only', true,
+  'ok',
+    execution_role = 'postgres'
+    and server_major_version_ok
+    and binder_relation_collision_count = 0
+    and binder_type_collision_count = 0
+    and binder_function_count = 0
+    and external_trigger_name_collisions = '[]'::jsonb
+    and unexpected_public_default_acl_grantees = '[]'::jsonb
+    and unexpected_schema_create_privileges = '[]'::jsonb
+    and reviewed_public_default_acl_row_count = 48
+    and reviewed_public_default_acl_fingerprint_sha256 =
+      '0ecd7a35a5a81388d2742067a282d5c73763bfa40853255b7aa1e3c9a4cea9df'
+    and realtime_publication_config_count = 1
+    and realtime_publication_config_fingerprint_sha256 =
+      'c9e74db3d75a0cabc4ae97a90b0c45d637a3865c12498281398acceb01806191'
+    and changed_external_function_count = 5
+    and changed_external_function_fingerprint_sha256 =
+      '1595bcfc837d711491826c8dd13b32a0ab862501a59bae77521d31b8ef944b4e'
+    and changed_external_function_acl_fingerprint_sha256 =
+      '10d37e82eb251c900a92356dd672d33f549c4b9a04563a2d479c8e9ac0cb5143'
+    and changed_external_policy_count = 4
+    and changed_external_policy_fingerprint_sha256 =
+      'f8aad091d50312fff86405a5587d8a57b342396408d95a6356a78a550ce1feb0'
+    and trust_surface_constraint_count = 1
+    and trust_surface_constraint_fingerprint_sha256 =
+      '2bf3095b9f4111f7ac2fb29a93b1cb82598a0711faf33653bb46ee433c617406'
+    and changed_external_table_acl_fingerprint_sha256 =
+      '86d9e3364f604500e50bd84da120f4c53e62840f824653b2cb9f9425b7c67e5f'
+    and applied_package_migration_count = 0
+    and migration_head = '20260715120000'
+    and missing_relations = '[]'::jsonb
+    and missing_columns = '[]'::jsonb
+    and missing_functions = '[]'::jsonb
+    and drifted_functions = '[]'::jsonb
+    and missing_roles = '[]'::jsonb
+    and stable_catalog_fingerprint_sha256 ~ '^[0-9a-f]{64}$'
+    and realtime_publication_exists
+    and not binder_realtime_object_exists
+    and not binder_card_event_data_exists
+    and not binder_trust_report_data_exists
+    and not wrapped_pulse_function_exists
+    and pulse_body_sha256 =
+      '0d2508ab97d0d4a3be5e2fc21e3f610b8b2b6cd60b22ffdcde7c284fafa1aff2'
+    and card_events_feed_body_sha256 =
+      '71dfac930d7d2d8402c1c6e36699c49b39ed8588fb14e5798d94bd840de0f8a5'
+    and trust_surface_constraint =
+      'CHECK (surface = ANY (ARRAY[''profile''::text, ''message''::text, ''wall_card''::text, ''listing''::text, ''card''::text, ''gvvi''::text, ''other''::text]))'
+    and trust_insert_policy =
+      'auth.uid() = reporter_user_id AND (reported_user_id IS NULL OR auth.uid() <> reported_user_id)'
+    and card_events_select_policy =
+      'interest_graph_card_event_visible_to_viewer_v1(auth.uid(), actor_user_id, subject_user_id, visibility)'
+    and card_events_insert_policy =
+      'actor_user_id = auth.uid() AND jsonb_typeof(payload) = ''object''::text'
+    and card_event_failure_baseline_ok,
+  'checks', jsonb_build_object(
+    'execution_role', execution_role,
+    'server_version_num', server_version_num,
+    'server_major_version', server_major_version,
+    'required_server_major_version', required_server_major_version,
+    'server_major_version_ok', server_major_version_ok,
+    'binder_relation_collision_count', binder_relation_collision_count,
+    'binder_type_collision_count', binder_type_collision_count,
+    'binder_function_count', binder_function_count,
+    'external_trigger_name_collisions', external_trigger_name_collisions,
+    'unexpected_public_default_acl_grantees',
+      unexpected_public_default_acl_grantees,
+    'unexpected_schema_create_privileges',
+      unexpected_schema_create_privileges,
+    'reviewed_public_default_acl_row_count',
+      reviewed_public_default_acl_row_count,
+    'reviewed_public_default_acl_fingerprint_sha256',
+      reviewed_public_default_acl_fingerprint_sha256,
+    'realtime_publication_config_count',
+      realtime_publication_config_count,
+    'realtime_publication_config_fingerprint_sha256',
+      realtime_publication_config_fingerprint_sha256,
+    'changed_external_function_count', changed_external_function_count,
+    'changed_external_function_fingerprint_sha256',
+      changed_external_function_fingerprint_sha256,
+    'changed_external_function_acl_fingerprint_sha256',
+      changed_external_function_acl_fingerprint_sha256,
+    'changed_external_policy_count', changed_external_policy_count,
+    'changed_external_policy_fingerprint_sha256',
+      changed_external_policy_fingerprint_sha256,
+    'trust_surface_constraint_count', trust_surface_constraint_count,
+    'trust_surface_constraint_fingerprint_sha256',
+      trust_surface_constraint_fingerprint_sha256,
+    'changed_external_table_acl_fingerprint_sha256',
+      changed_external_table_acl_fingerprint_sha256,
+    'applied_package_migration_count', applied_package_migration_count,
+    'migration_head', migration_head,
+    'missing_relations', missing_relations,
+    'missing_columns', missing_columns,
+    'missing_functions', missing_functions,
+    'drifted_functions', drifted_functions,
+    'missing_roles', missing_roles,
+    'stable_catalog_fingerprint_sha256', stable_catalog_fingerprint_sha256,
+    'realtime_publication_exists', realtime_publication_exists,
+    'binder_realtime_object_exists', binder_realtime_object_exists,
+    'binder_card_event_data_exists', binder_card_event_data_exists,
+    'binder_trust_report_data_exists', binder_trust_report_data_exists,
+    'wrapped_pulse_function_exists', wrapped_pulse_function_exists,
+    'pulse_body_sha256', pulse_body_sha256,
+    'card_events_feed_body_sha256', card_events_feed_body_sha256,
+    'trust_surface_constraint', trust_surface_constraint,
+    'trust_insert_policy', trust_insert_policy,
+    'card_events_select_policy', card_events_select_policy,
+    'card_events_insert_policy', card_events_insert_policy,
+    'card_event_failure_baseline_ok', card_event_failure_baseline_ok
+  )
+) as rollout_readback
+from snapshot

--- a/supabase/migrations/20260723100000_collaborative_binders_schema_v1.sql
+++ b/supabase/migrations/20260723100000_collaborative_binders_schema_v1.sql
@@ -789,6 +789,13 @@ begin
 end;
 $$;
 
+-- Identity sequences inherit the platform's public-schema defaults separately
+-- from their owning tables. Keep the rate-limit counter service-only too.
+revoke all on sequence public.binder_rate_limit_events_id_seq
+from public, anon, authenticated;
+grant all on sequence public.binder_rate_limit_events_id_seq
+to service_role;
+
 -- Existing report authority is extended, not replaced. Direct authenticated
 -- insertion remains available only for the pre-existing surfaces; Binder
 -- surfaces must pass binder_report_v1.

--- a/supabase/tests/collaborative_binders_v1_test.sql
+++ b/supabase/tests/collaborative_binders_v1_test.sql
@@ -37,6 +37,54 @@ select ok(
   'authenticated cannot read raw Binder activity'
 );
 select ok(
+  not has_sequence_privilege(
+    'anon',
+    'public.binder_rate_limit_events_id_seq',
+    'select'
+  )
+  and not has_sequence_privilege(
+    'anon',
+    'public.binder_rate_limit_events_id_seq',
+    'update'
+  )
+  and not has_sequence_privilege(
+    'anon',
+    'public.binder_rate_limit_events_id_seq',
+    'usage'
+  )
+  and not has_sequence_privilege(
+    'authenticated',
+    'public.binder_rate_limit_events_id_seq',
+    'select'
+  )
+  and not has_sequence_privilege(
+    'authenticated',
+    'public.binder_rate_limit_events_id_seq',
+    'update'
+  )
+  and not has_sequence_privilege(
+    'authenticated',
+    'public.binder_rate_limit_events_id_seq',
+    'usage'
+  )
+  and has_sequence_privilege(
+    'service_role',
+    'public.binder_rate_limit_events_id_seq',
+    'select'
+  )
+  and has_sequence_privilege(
+    'service_role',
+    'public.binder_rate_limit_events_id_seq',
+    'update'
+  )
+  and has_sequence_privilege(
+    'service_role',
+    'public.binder_rate_limit_events_id_seq',
+    'usage'
+  ),
+  'Binder identity sequence is service-only'
+);
+select ok(
   not has_function_privilege(
     'authenticated',
     'public.interest_graph_emit_event_v1(text,text,uuid,uuid,uuid,jsonb,text,text)',

--- a/tests/contracts/collaborative_binders_process_containment_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_process_containment_v1.test.mjs
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+const MODULE_PATH = path.join(
+  REPO_ROOT,
+  "scripts",
+  "ops",
+  "CollaborativeBindersProductionRolloutV1.psm1",
+);
+
+function encodePowerShell(source) {
+  return Buffer.from(source, "utf16le").toString("base64");
+}
+
+function runContainmentHarness() {
+  const modulePath = Buffer.from(MODULE_PATH, "utf8").toString("base64");
+  const script = `
+$ErrorActionPreference = 'Stop'
+$modulePath = [Text.Encoding]::UTF8.GetString(
+  [Convert]::FromBase64String('${modulePath}')
+)
+Import-Module $modulePath -Force
+$module = Get-Module CollaborativeBindersProductionRolloutV1
+$pwsh = [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+$workingDirectory = (Get-Location).Path
+
+function Invoke-LocalContained {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Script,
+    [Parameter(Mandatory = $true)]
+    [int]$TimeoutSeconds,
+    [switch]$SanitizeDatabaseEnvironment
+  )
+
+  return & $module {
+    param(
+      [string]$Executable,
+      [string]$Directory,
+      [string]$TargetScript,
+      [int]$Timeout,
+      [bool]$Sanitize
+    )
+    if ($Sanitize) {
+      return Invoke-BinderProcessV1 \`
+        -FilePath $Executable \`
+        -Arguments @(
+          '-NoLogo',
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          $TargetScript
+        ) \`
+        -WorkingDirectory $Directory \`
+        -TimeoutSeconds $Timeout \`
+        -SanitizeDatabaseEnvironment
+    }
+    return Invoke-BinderProcessV1 \`
+      -FilePath $Executable \`
+      -Arguments @(
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        $TargetScript
+      ) \`
+      -WorkingDirectory $Directory \`
+      -TimeoutSeconds $Timeout
+  } $pwsh $workingDirectory $Script $TimeoutSeconds (
+    [bool]$SanitizeDatabaseEnvironment
+  )
+}
+
+$env:PGHOST = 'must-not-cross-the-contained-boundary'
+$normal = Invoke-LocalContained \`
+  -Script @'
+[Console]::Out.Write(
+  'contained-ok|' + [Environment]::GetEnvironmentVariable('PGHOST')
+)
+[Console]::Error.Write('contained-err')
+exit 7
+'@ \`
+  -TimeoutSeconds 10 \`
+  -SanitizeDatabaseEnvironment
+
+$timeout = Invoke-LocalContained \`
+  -Script @'
+[Console]::Out.WriteLine('before-timeout-out')
+[Console]::Error.WriteLine('before-timeout-err')
+Start-Sleep -Seconds 30
+'@ \`
+  -TimeoutSeconds 1
+
+$descendant = Invoke-LocalContained \`
+  -Script @'
+$child = Start-Process \`
+  -FilePath (
+    [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+  ) \`
+  -ArgumentList @(
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    'Start-Sleep -Seconds 60'
+  ) \`
+  -PassThru
+[Console]::Out.WriteLine("child_pid=$($child.Id)")
+Start-Sleep -Seconds 60
+'@ \`
+  -TimeoutSeconds 2
+$childMatch = [regex]::Match(
+  $descendant.StdOut,
+  'child_pid=(?<pid>\\d+)'
+)
+$childAlive = $false
+if ($childMatch.Success) {
+  $childAlive = $null -ne (
+    Get-Process \`
+      -Id ([int]$childMatch.Groups['pid'].Value) \`
+      -ErrorAction SilentlyContinue
+  )
+}
+
+$bounded = Invoke-LocalContained \`
+  -Script @'
+[Console]::Out.Write(('o' * 300000))
+[Console]::Error.Write(('e' * 300000))
+'@ \`
+  -TimeoutSeconds 15
+
+$node = (Get-Command node -ErrorAction Stop).Source
+$lateNodeScript = @'
+const { spawn } = require("child_process");
+const child = spawn(
+  process.execPath,
+  [
+    "-e",
+    "setTimeout(() => {" +
+      "process.stdout.write('late-out');" +
+      "process.stderr.write('late-err')" +
+    "}, 6000)",
+  ],
+  {
+    detached: true,
+    stdio: ["ignore", "inherit", "inherit"],
+  },
+);
+process.stdout.write("early-out|pid=" + child.pid);
+process.stderr.write("early-err");
+child.unref();
+'@
+$lateForwarding = & $module {
+  param(
+    [string]$Executable,
+    [string]$Directory,
+    [string]$TargetScript
+  )
+  Invoke-BinderProcessV1 \`
+    -FilePath $Executable \`
+    -Arguments @('-e', $TargetScript) \`
+    -WorkingDirectory $Directory \`
+    -TimeoutSeconds 20
+} $node $workingDirectory $lateNodeScript
+
+$handleCountBeforeSetupFailures = (
+  [Diagnostics.Process]::GetCurrentProcess().HandleCount
+)
+$setupFailureCount = 0
+foreach ($attempt in 1..12) {
+  try {
+    [void](Invoke-LocalContained \`
+      -Script ('x' * 30000) \`
+      -TimeoutSeconds 10)
+  } catch {
+    $setupFailureCount += 1
+  }
+}
+$handleCountAfterSetupFailures = (
+  [Diagnostics.Process]::GetCurrentProcess().HandleCount
+)
+
+[ordered]@{
+  normal = [ordered]@{
+    exit_code = $normal.ExitCode
+    stdout = $normal.StdOut
+    stderr = $normal.StdErr
+    started = $normal.Started
+    timed_out = $normal.TimedOut
+    root_exited = $normal.RootExited
+    process_tree_empty = $normal.ProcessTreeEmpty
+    termination_confirmed = $normal.TerminationConfirmed
+    output_capture_completed = $normal.OutputCaptureCompleted
+  }
+  timeout = [ordered]@{
+    exit_code = $timeout.ExitCode
+    timed_out = $timeout.TimedOut
+    kill_attempted = $timeout.KillAttempted
+    kill_request_succeeded = $timeout.KillRequestSucceeded
+    root_exited = $timeout.RootExited
+    process_tree_empty = $timeout.ProcessTreeEmpty
+    termination_confirmed = $timeout.TerminationConfirmed
+    output_capture_completed = $timeout.OutputCaptureCompleted
+    stdout = $timeout.StdOut
+    stderr = $timeout.StdErr
+  }
+  descendant = [ordered]@{
+    child_pid_observed = $childMatch.Success
+    child_alive_after_return = $childAlive
+    timed_out = $descendant.TimedOut
+    kill_attempted = $descendant.KillAttempted
+    root_exited = $descendant.RootExited
+    process_tree_empty = $descendant.ProcessTreeEmpty
+    termination_confirmed = $descendant.TerminationConfirmed
+  }
+  bounded = [ordered]@{
+    exit_code = $bounded.ExitCode
+    termination_confirmed = $bounded.TerminationConfirmed
+    output_capture_completed = $bounded.OutputCaptureCompleted
+    stdout_length = $bounded.StdOut.Length
+    stderr_length = $bounded.StdErr.Length
+    stdout_characters_observed = $bounded.StdOutCharactersObserved
+    stderr_characters_observed = $bounded.StdErrCharactersObserved
+    stdout_truncated = $bounded.StdOutTruncated
+    stderr_truncated = $bounded.StdErrTruncated
+  }
+  late_forwarding = [ordered]@{
+    exit_code = $lateForwarding.ExitCode
+    stdout = $lateForwarding.StdOut
+    stderr = $lateForwarding.StdErr
+    process_tree_empty = $lateForwarding.ProcessTreeEmpty
+    termination_confirmed = $lateForwarding.TerminationConfirmed
+    output_capture_completed = $lateForwarding.OutputCaptureCompleted
+  }
+  setup_failure = [ordered]@{
+    attempts = 12
+    failures = $setupFailureCount
+    handle_count_before = $handleCountBeforeSetupFailures
+    handle_count_after = $handleCountAfterSetupFailures
+  }
+} | ConvertTo-Json -Depth 6 -Compress
+`;
+  const execution = spawnSync(
+    "pwsh",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      encodePowerShell(script),
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      maxBuffer: 5 * 1024 * 1024,
+      timeout: 45_000,
+      windowsHide: true,
+    },
+  );
+
+  assert.equal(
+    execution.status,
+    0,
+    `PowerShell containment harness failed:\n${execution.stderr}`,
+  );
+  assert.equal(execution.signal, null);
+  return JSON.parse(execution.stdout.trim());
+}
+
+test(
+  "Collaborative Binders rollout process containment",
+  { skip: process.platform !== "win32" },
+  async (context) => {
+    const report = runContainmentHarness();
+
+    await context.test(
+      "runs the exact child only after release and strips routing overrides",
+      () => {
+        assert.equal(report.normal.exit_code, 7);
+        assert.equal(report.normal.stdout, "contained-ok|");
+        assert.equal(report.normal.stderr, "contained-err");
+        assert.equal(report.normal.started, true);
+        assert.equal(report.normal.timed_out, false);
+        assert.equal(report.normal.root_exited, true);
+        assert.equal(report.normal.process_tree_empty, true);
+        assert.equal(report.normal.termination_confirmed, true);
+        assert.equal(report.normal.output_capture_completed, true);
+      },
+    );
+
+    await context.test(
+      "terminates and confirms an ordinary timeout",
+      () => {
+        assert.equal(report.timeout.timed_out, true);
+        assert.equal(report.timeout.kill_attempted, true);
+        assert.equal(report.timeout.kill_request_succeeded, true);
+        assert.equal(report.timeout.root_exited, true);
+        assert.equal(report.timeout.process_tree_empty, true);
+        assert.equal(report.timeout.termination_confirmed, true);
+        assert.equal(report.timeout.output_capture_completed, true);
+        assert.match(report.timeout.stdout, /before-timeout-out/);
+        assert.match(report.timeout.stderr, /before-timeout-err/);
+        assert.notEqual(report.timeout.exit_code, null);
+      },
+    );
+
+    await context.test(
+      "kills descendants before returning from a timeout",
+      () => {
+        assert.equal(report.descendant.child_pid_observed, true);
+        assert.equal(report.descendant.child_alive_after_return, false);
+        assert.equal(report.descendant.timed_out, true);
+        assert.equal(report.descendant.kill_attempted, true);
+        assert.equal(report.descendant.root_exited, true);
+        assert.equal(report.descendant.process_tree_empty, true);
+        assert.equal(report.descendant.termination_confirmed, true);
+      },
+    );
+
+    await context.test("caps stdout and stderr evidence", () => {
+      assert.equal(report.bounded.exit_code, 0);
+      assert.equal(report.bounded.termination_confirmed, true);
+      assert.equal(report.bounded.output_capture_completed, true);
+      assert.equal(report.bounded.stdout_length, 262_144);
+      assert.equal(report.bounded.stderr_length, 262_144);
+      assert.equal(report.bounded.stdout_characters_observed, 300_000);
+      assert.equal(report.bounded.stderr_characters_observed, 300_000);
+      assert.equal(report.bounded.stdout_truncated, true);
+      assert.equal(report.bounded.stderr_truncated, true);
+    });
+
+    await context.test(
+      "waits for descendant output forwarding before reporting complete",
+      () => {
+        assert.equal(report.late_forwarding.exit_code, 0);
+        assert.match(
+          report.late_forwarding.stdout,
+          /^early-out\|pid=\d+late-out$/,
+        );
+        assert.equal(report.late_forwarding.stderr, "early-errlate-err");
+        assert.equal(report.late_forwarding.process_tree_empty, true);
+        assert.equal(report.late_forwarding.termination_confirmed, true);
+        assert.equal(report.late_forwarding.output_capture_completed, true);
+      },
+    );
+
+    await context.test(
+      "disposes gate and Job Object handles on pre-launch setup failure",
+      () => {
+        assert.equal(report.setup_failure.failures, report.setup_failure.attempts);
+        assert.ok(
+          report.setup_failure.handle_count_after -
+            report.setup_failure.handle_count_before <=
+            2,
+          `unexpected handle growth: ${JSON.stringify(report.setup_failure)}`,
+        );
+      },
+    );
+  },
+);

--- a/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
@@ -18,6 +18,7 @@ const PACKAGE_FINGERPRINT =
 const PRODUCTION_PROJECT_REF = "ycdxbpibncqcchqiihfz";
 const REQUIRED_ANCESTOR_SHA =
   "34caa07324587815040957f9adde1f771ebfc85a";
+const WINDOWS_ONLY = process.platform === "win32";
 
 const MANIFEST_PATH =
   "scripts/ops/collaborative_binders_production_manifest_v1.json";
@@ -629,7 +630,10 @@ test("dry-run parser accepts only the five exact filenames in order", () => {
   );
 });
 
-test("tracked migration inventory rejects an untracked top-level SQL file", () => {
+test(
+  "tracked migration inventory rejects an untracked top-level SQL file",
+  { skip: !WINDOWS_ONLY },
+  () => {
   const script = `
 $osTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\\', '/')
 $fixture = Join-Path $osTemp ('binder-migration-set-fixture-' + [guid]::NewGuid().ToString('N'))
@@ -693,9 +697,13 @@ try {
     result.Failure,
     /does not exactly match the tracked top-level SQL set/i,
   );
-});
+  },
+);
 
-test("staged Supabase source denies migration writes and cleans safely", () => {
+test(
+  "staged Supabase source denies migration writes and cleans safely",
+  { skip: !WINDOWS_ONLY },
+  () => {
   const script = `
 $osTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\\', '/')
 $fixture = Join-Path $osTemp ('binder-stage-fixture-' + [guid]::NewGuid().ToString('N'))
@@ -843,9 +851,13 @@ try {
     JSON.stringify(result.SealedManifest).includes("binder-stage-fixture-"),
     false,
   );
-});
+  },
+);
 
-test("process lifecycle marks started only after a successful process start", () => {
+test(
+  "process lifecycle marks started only after a successful process start",
+  { skip: !WINDOWS_ONLY },
+  () => {
   const body = [
     "$module = Get-Module CollaborativeBindersProductionRolloutV1",
     "$successLifecycle = [pscustomobject]@{ Started = $false; StartedAtUtc = $null }",
@@ -884,7 +896,8 @@ test("process lifecycle marks started only after a successful process start", ()
   assert.equal(result.SuccessExitCode, 0);
   assert.equal(result.FailedStarted, false);
   assert.match(result.StartFailure, /unable to start|cannot find|no such/i);
-});
+  },
+);
 
 test("apply command plan is private, gated, and contains one exact mutating argv", () => {
   const externalCall = runPowerShell(

--- a/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
@@ -1,0 +1,1272 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const PACKAGE_ID = "COLLABORATIVE-BINDERS-DB-V1";
+const PACKAGE_FINGERPRINT =
+  "14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9";
+const PRODUCTION_PROJECT_REF = "ycdxbpibncqcchqiihfz";
+const REQUIRED_ANCESTOR_SHA =
+  "34caa07324587815040957f9adde1f771ebfc85a";
+
+const MANIFEST_PATH =
+  "scripts/ops/collaborative_binders_production_manifest_v1.json";
+const MODULE_PATH =
+  "scripts/ops/CollaborativeBindersProductionRolloutV1.psm1";
+const PREFLIGHT_ENTRYPOINT_PATH =
+  "scripts/ops/collaborative_binders_production_preflight_v1.ps1";
+const APPLY_ENTRYPOINT_PATH =
+  "scripts/ops/collaborative_binders_production_apply_v1.ps1";
+const READBACK_ENTRYPOINT_PATH =
+  "scripts/ops/collaborative_binders_production_readback_v1.ps1";
+const PREFLIGHT_SQL_PATH =
+  "scripts/ops/sql/collaborative_binders_production_preflight_v1.sql";
+const POST_APPLY_SQL_PATH =
+  "scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql";
+const RUNBOOK_PATH =
+  "docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md";
+
+const EXPECTED_MIGRATIONS = [
+  {
+    version: "20260723100000",
+    file: "20260723100000_collaborative_binders_schema_v1.sql",
+    sha256:
+      "7e83ab8bb83e5b938fbec758b21f8cae2b4a71427a6600c54c5f773c974bae33",
+    cumulative_tables: 19,
+    cumulative_functions: 17,
+    cumulative_indexes: 61,
+    cumulative_rls_policies: 19,
+  },
+  {
+    version: "20260723101000",
+    file: "20260723101000_collaborative_binders_core_rpcs_v1.sql",
+    sha256:
+      "eb9ca9898bca12b127f4b79aff9df81259efe74fa1029487ea133e94e8a67a7d",
+    cumulative_tables: 19,
+    cumulative_functions: 44,
+    cumulative_indexes: 61,
+    cumulative_rls_policies: 19,
+  },
+  {
+    version: "20260723102000",
+    file: "20260723102000_collaborative_binders_collaboration_rpcs_v1.sql",
+    sha256:
+      "680580044161936c8a382e5209e2cc54369943e13f1a3ae2ed41c299532cf3bf",
+    cumulative_tables: 19,
+    cumulative_functions: 65,
+    cumulative_indexes: 61,
+    cumulative_rls_policies: 19,
+  },
+  {
+    version: "20260723103000",
+    file: "20260723103000_collaborative_binders_read_rpcs_v1.sql",
+    sha256:
+      "73dab7009f059267dcc571fcb6ec79cffdb23b728fc5bf04cd81397a06bcd6fb",
+    cumulative_tables: 19,
+    cumulative_functions: 99,
+    cumulative_indexes: 61,
+    cumulative_rls_policies: 19,
+  },
+  {
+    version: "20260723104000",
+    file: "20260723104000_collaborative_binders_service_rpcs_v1.sql",
+    sha256:
+      "2edbef712d6b228c73b504498a6aa09f5bac440cfef96319d5c75f65e12d2997",
+    cumulative_tables: 21,
+    cumulative_functions: 124,
+    cumulative_indexes: 65,
+    cumulative_rls_policies: 22,
+  },
+];
+
+const EXPECTED_FLAGS = [
+  "schema_internal",
+  "personal",
+  "set_binders",
+  "custom",
+  "shared",
+  "view_links",
+  "public",
+  "community",
+  "templates",
+  "notifications",
+  "pulse_milestones",
+];
+
+const EXCLUDED_FLAGS = [
+  "set_binders",
+  "notifications",
+  "pulse_milestones",
+];
+
+const READBACK_SQL_HASHES = {
+  [PREFLIGHT_SQL_PATH]:
+    "268458ed8a4a16dc513b55b6d0e5b3b03c301320e55a9ab4887a135c7652800d",
+  [POST_APPLY_SQL_PATH]:
+    "5125b0d89f5b3d36c66f98863f0b69b9c6df55561dfb54303437d47d8731f1a1",
+};
+
+const EXPECTED_READBACK_SQL = [
+  {
+    phase: "pre_apply",
+    file: PREFLIGHT_SQL_PATH,
+    sha256: READBACK_SQL_HASHES[PREFLIGHT_SQL_PATH],
+  },
+  {
+    phase: "post_apply",
+    file: POST_APPLY_SQL_PATH,
+    sha256: READBACK_SQL_HASHES[POST_APPLY_SQL_PATH],
+  },
+];
+
+function absolute(relativePath) {
+  return path.join(REPO_ROOT, ...relativePath.split("/"));
+}
+
+function source(relativePath) {
+  return readFileSync(absolute(relativePath), "utf8");
+}
+
+function bytes(relativePath) {
+  return readFileSync(absolute(relativePath));
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function packageFingerprint(manifest) {
+  const lines = [
+    `schema_version=${manifest.schema_version}`,
+    `package_id=${manifest.package_id}`,
+    `required_ancestor_sha=${manifest.required_ancestor_sha}`,
+    `production_project_ref=${manifest.production_project_ref}`,
+    `canonical_git_repository=${manifest.canonical_git_repository}`,
+  ];
+
+  for (const migration of manifest.migrations) {
+    lines.push(
+      [
+        "migration=" + migration.version,
+        migration.file,
+        migration.sha256,
+        migration.cumulative_tables,
+        migration.cumulative_functions,
+        migration.cumulative_indexes,
+        migration.cumulative_rls_policies,
+      ].join("|"),
+    );
+  }
+
+  for (const readback of manifest.readback_sql) {
+    lines.push(
+      `readback=${readback.phase}|${readback.file}|${readback.sha256}`,
+    );
+  }
+
+  for (const [key, value] of Object.entries(manifest.final_expected_shape)) {
+    lines.push(`shape.${key}=${Array.isArray(value) ? value.join(",") : value}`);
+  }
+  for (const flag of manifest.feature_flags_must_remain_disabled) {
+    lines.push(`disabled_flag=${flag}`);
+  }
+  for (const flag of manifest.excluded_from_rollout) {
+    lines.push(`excluded_flag=${flag}`);
+  }
+
+  return sha256(lines.join("\n"));
+}
+
+function psLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function base64(value) {
+  return Buffer.from(value, "utf8").toString("base64");
+}
+
+function powerShellTextFromBase64(value) {
+  return (
+    "[System.Text.Encoding]::UTF8.GetString(" +
+    `[Convert]::FromBase64String(${psLiteral(base64(value))}))`
+  );
+}
+
+function runPowerShell(body, { env = {} } = {}) {
+  const childEnv = { ...process.env, ...env };
+  delete childEnv.GROOKAI_BINDER_PROD_APPLY_ACK;
+  delete childEnv.GROOKAI_BINDER_PROD_BACKUP_ACK;
+  Object.assign(childEnv, env);
+
+  const command = [
+    "$ErrorActionPreference = 'Stop'",
+    `Import-Module ${psLiteral(absolute(MODULE_PATH))} -Force`,
+    body,
+  ].join("; ");
+
+  return spawnSync(
+    "pwsh",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      command,
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: childEnv,
+      windowsHide: true,
+    },
+  );
+}
+
+function assertPowerShellSuccess(result, label) {
+  assert.equal(
+    result.error,
+    undefined,
+    `${label}: could not launch pwsh: ${result.error?.message ?? ""}`,
+  );
+  assert.equal(
+    result.status,
+    0,
+    `${label}: ${result.stderr || result.stdout}`,
+  );
+}
+
+function parsePowerShellJson(result, label) {
+  assertPowerShellSuccess(result, label);
+  return JSON.parse(result.stdout.trim());
+}
+
+function stripSqlCommentsAndStrings(sql) {
+  return sql
+    .replace(/--[^\r\n]*/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/'(?:''|[^'])*'/g, "''");
+}
+
+test("Binder rollout manifest is the exact reviewed content-addressed package", () => {
+  const manifest = JSON.parse(source(MANIFEST_PATH));
+
+  assert.equal(manifest.schema_version, 1);
+  assert.equal(manifest.package_id, PACKAGE_ID);
+  assert.equal(manifest.package_fingerprint_sha256, PACKAGE_FINGERPRINT);
+  assert.equal(manifest.required_ancestor_sha, REQUIRED_ANCESTOR_SHA);
+  assert.equal(manifest.production_project_ref, PRODUCTION_PROJECT_REF);
+  assert.equal(
+    manifest.canonical_git_repository,
+    "OriginalSoseji/grookai_vault",
+  );
+  assert.deepEqual(manifest.migrations, EXPECTED_MIGRATIONS);
+  assert.deepEqual(manifest.readback_sql, EXPECTED_READBACK_SQL);
+  assert.deepEqual(manifest.final_expected_shape, {
+    tables: 21,
+    functions: 124,
+    indexes: 65,
+    rls_policies: 22,
+    feature_flags: 11,
+    enabled_feature_flags: 0,
+    public_execute_functions: 0,
+    anonymous_raw_privileges: 0,
+    anonymous_raw_sequence_privileges: 0,
+    authenticated_raw_mutations: 0,
+    authenticated_raw_sequence_privileges: 0,
+    authenticated_raw_select_tables: ["binder_refresh_signals"],
+    realtime_tables: ["binder_refresh_signals"],
+  });
+  assert.deepEqual(manifest.feature_flags_must_remain_disabled, EXPECTED_FLAGS);
+  assert.deepEqual(manifest.excluded_from_rollout, EXCLUDED_FLAGS);
+  assert.equal(packageFingerprint(manifest), PACKAGE_FINGERPRINT);
+
+  for (const migration of EXPECTED_MIGRATIONS) {
+    const relativePath = `supabase/migrations/${migration.file}`;
+    assert.equal(
+      sha256(bytes(relativePath)),
+      migration.sha256,
+      `${migration.file} byte hash`,
+    );
+  }
+
+  const schemaMigration = source(
+    `supabase/migrations/${EXPECTED_MIGRATIONS[0].file}`,
+  );
+  assert.match(
+    schemaMigration,
+    /revoke all on sequence public\.binder_rate_limit_events_id_seq\s+from public, anon, authenticated;/i,
+  );
+  assert.match(
+    schemaMigration,
+    /grant all on sequence public\.binder_rate_limit_events_id_seq\s+to service_role;/i,
+  );
+});
+
+test("PowerShell policy agrees exactly with the immutable manifest", () => {
+  const policy = parsePowerShellJson(
+    runPowerShell(
+      "Get-BinderRolloutPolicyV1 | ConvertTo-Json -Depth 12 -Compress",
+    ),
+    "policy",
+  );
+
+  assert.equal(policy.PackageId, PACKAGE_ID);
+  assert.equal(policy.PackageFingerprintSha256, PACKAGE_FINGERPRINT);
+  assert.equal(policy.ProjectRef, PRODUCTION_PROJECT_REF);
+  assert.equal(policy.RequiredAncestorSha, REQUIRED_ANCESTOR_SHA);
+  assert.equal(policy.SupportedSupabaseCliVersion, "2.90.0");
+  assert.equal(
+    policy.SupabaseCliLauncherSha256,
+    "140e3801d8adeda639a21b14e62b93a4c7d26b7a758421f43c82be59753be49b",
+  );
+  assert.equal(
+    policy.SupabaseCliBinarySha256,
+    "31c2a25bd590a36ad803a7c669cf76a62eac3cd5aa7112eeb2e1c5f308c8b39c",
+  );
+  assert.equal(
+    policy.SupabaseCliShimDescriptorSha256,
+    "0c68f69a367b2b76e61f3e71fb98c9a867143628a361a2e715dd30f33c4b2c3f",
+  );
+  assert.equal(
+    policy.PreflightSqlSha256,
+    READBACK_SQL_HASHES[PREFLIGHT_SQL_PATH],
+  );
+  assert.equal(
+    policy.PostApplySqlSha256,
+    READBACK_SQL_HASHES[POST_APPLY_SQL_PATH],
+  );
+  assert.deepEqual(
+    policy.MigrationVersions,
+    EXPECTED_MIGRATIONS.map((migration) => migration.version),
+  );
+  assert.deepEqual(
+    policy.MigrationFiles,
+    EXPECTED_MIGRATIONS.map((migration) => migration.file),
+  );
+  assert.deepEqual(
+    policy.MigrationSha256,
+    EXPECTED_MIGRATIONS.map((migration) => migration.sha256),
+  );
+  assert.deepEqual(policy.FeatureFlags, EXPECTED_FLAGS);
+  assert.deepEqual(policy.ExcludedFlags, EXCLUDED_FLAGS);
+  assert.deepEqual(policy.ApplyArguments, [
+    "db",
+    "push",
+    "--linked",
+    "--yes",
+  ]);
+});
+
+test("both catalog readbacks are immutable single-statement read-only SQL", () => {
+  const forbiddenKeywords =
+    /\b(insert|update|delete|merge|create|alter|drop|truncate|grant|revoke|copy|call|do|vacuum|analyze|refresh|lock|set|reset|listen|notify|unlisten|discard|prepare|execute|deallocate|cluster|reindex|checkpoint|into)\b/i;
+  const sideEffectFunctions =
+    /\b(pg_notify|set_config|nextval|setval|dblink(?:_exec)?|lo_(?:import|export|unlink)|pg_(?:advisory|try_advisory|terminate_backend|cancel_backend|reload_conf))\s*\(/i;
+
+  for (const [relativePath, expectedHash] of Object.entries(
+    READBACK_SQL_HASHES,
+  )) {
+    const sql = source(relativePath);
+    const executable = stripSqlCommentsAndStrings(sql);
+
+    assert.equal(sha256(bytes(relativePath)), expectedHash, relativePath);
+    assert.match(executable.trimStart(), /^with\b/i, relativePath);
+    assert.equal(executable.includes(";"), false, relativePath);
+    assert.doesNotMatch(executable, forbiddenKeywords, relativePath);
+    assert.doesNotMatch(executable, sideEffectFunctions, relativePath);
+    assert.doesNotMatch(executable, /\bfor\s+(?:update|share)\b/i, relativePath);
+    assert.match(sql, /'read_only',\s*true/i, relativePath);
+    assert.match(sql, /as rollout_readback\s+from snapshot\s*$/i, relativePath);
+  }
+});
+
+test("catalog readbacks cover prerequisites and exact post-apply security shape", () => {
+  const preflight = source(PREFLIGHT_SQL_PATH);
+  const postApply = source(POST_APPLY_SQL_PATH);
+
+  for (const marker of [
+    "required_columns(schema_name, table_name, column_name, data_type)",
+    "required_function_bodies(function_signature, body_sha256)",
+    "missing_columns as (",
+    "drifted_functions as (",
+    "stable_catalog_fingerprint as (",
+    "'stable_catalog_fingerprint_sha256'",
+    "c.relkind in ('r', 'p')",
+    "external_trigger_name_collisions as (",
+    "reviewed_public_default_acl_fingerprint as (",
+    "unexpected_schema_create_privileges as (",
+    "realtime_publication_config_fingerprint as (",
+    "server_major_version_ok",
+  ]) {
+    assert.ok(preflight.includes(marker), `preflight missing ${marker}`);
+  }
+
+  for (const marker of [
+    "function_arguments",
+    "function_owner",
+    "function_acl_fingerprint as (",
+    "index_fingerprint as (",
+    "policy_fingerprint as (",
+    "trigger_fingerprint as (",
+    "table_acl_fingerprint as (",
+    "binder_identity_sequence_shape_fingerprint as (",
+    "binder_identity_sequence_acl_fingerprint as (",
+    "realtime_binder_projection_fingerprint as (",
+    "unexpected_schema_create_privileges as (",
+    "stable_catalog_fingerprint as (",
+    "external_trigger_map",
+    "binder_function_acl_fingerprint_sha256",
+    "binder_index_fingerprint_sha256",
+    "binder_policy_fingerprint_sha256",
+    "binder_trigger_fingerprint_sha256",
+    "binder_table_acl_fingerprint_sha256",
+    "enabled_flag_count = 0",
+    "server_major_version_ok",
+  ]) {
+    assert.ok(postApply.includes(marker), `post-apply missing ${marker}`);
+  }
+  for (const [label, sql] of [
+    ["preflight", preflight],
+    ["post-apply", postApply],
+  ]) {
+    assert.match(
+      sql,
+      /current_setting\('server_version_num'\)::integer\s*\/\s*10000\s*=\s*17/i,
+      `${label} must require PostgreSQL major 17`,
+    );
+    assert.match(
+      sql,
+      /execution_role\s*=\s*'postgres'\s+and\s+server_major_version_ok/i,
+      `${label} must require execution as postgres`,
+    );
+  }
+
+  assert.match(
+    postApply,
+    /replace\(pg_get_function_identity_arguments\(p\.oid\), 'public\.', ''\)/,
+  );
+  assert.match(
+    postApply,
+    /has_function_privilege\('authenticated', oid, 'EXECUTE'\)/,
+  );
+  assert.match(
+    postApply,
+    /has_table_privilege\([\s\S]*?'authenticated'[\s\S]*?'SELECT'/,
+  );
+});
+
+test("migration-list parser accepts ANSI/CRLF and the exact pending set", () => {
+  const ledgerText = [
+    "\u001b[32m Local          | Remote         | Time (UTC)\u001b[0m",
+    "----------------|----------------|---------------------",
+    "20260715120000  | 20260715120000 | 2026-07-15 12:00:00",
+    ...EXPECTED_MIGRATIONS.map(
+      (migration) =>
+        `${migration.version}  |                | 2026-07-23 10:00:00`,
+    ),
+    "",
+  ].join("\r\n");
+
+  const body = [
+    `$text = ${powerShellTextFromBase64(ledgerText)}`,
+    "$ledger = ConvertFrom-SupabaseMigrationListV1 -Text $text",
+    "Assert-ExactBinderPendingSetV1 -Ledger $ledger",
+    "ConvertTo-Json -InputObject $ledger -Depth 12 -Compress",
+  ].join("; ");
+  const ledger = parsePowerShellJson(
+    runPowerShell(body),
+    "exact migration ledger",
+  );
+
+  assert.equal(ledger.Rows.length, 6);
+  assert.equal(ledger.Shared.length, 1);
+  assert.equal(ledger.LocalOnly.length, 5);
+  assert.equal(ledger.RemoteOnly.length, 0);
+  assert.deepEqual(
+    ledger.LocalOnly.map((row) => row.Local),
+    EXPECTED_MIGRATIONS.map((migration) => migration.version),
+  );
+});
+
+test("migration-list guard rejects extra and remote-only migration rows", () => {
+  const exactRows = [
+    "20260715120000 | 20260715120000 | baseline",
+    ...EXPECTED_MIGRATIONS.map(
+      (migration) => `${migration.version} | | pending`,
+    ),
+  ];
+  const cases = [
+    {
+      label: "extra pending",
+      text: [...exactRows, "20260723105000 | | unexpected"].join("\n"),
+      expected: /Pending migration count is not exactly five/i,
+    },
+    {
+      label: "remote only",
+      text: [...exactRows, "| 20260723105000 | remote-only"].join("\n"),
+      expected: /Remote-only migrations detected/i,
+    },
+  ];
+
+  for (const fixture of cases) {
+    const body = [
+      `$text = ${powerShellTextFromBase64(fixture.text)}`,
+      "$ledger = ConvertFrom-SupabaseMigrationListV1 -Text $text",
+      "Assert-ExactBinderPendingSetV1 -Ledger $ledger",
+    ].join("; ");
+    const result = runPowerShell(body);
+
+    assert.notEqual(result.status, 0, fixture.label);
+    assert.match(
+      `${result.stderr}\n${result.stdout}`,
+      fixture.expected,
+      fixture.label,
+    );
+  }
+});
+
+test("post-apply ledger delta is exactly the five Binder versions", () => {
+  const baseline = "20260715120000 | 20260715120000 | baseline";
+  const beforeText = [
+    baseline,
+    ...EXPECTED_MIGRATIONS.map(
+      (migration) => `${migration.version} | | pending`,
+    ),
+  ].join("\n");
+  const exactAfterText = [
+    baseline,
+    ...EXPECTED_MIGRATIONS.map(
+      (migration) =>
+        `${migration.version} | ${migration.version} | applied`,
+    ),
+  ].join("\n");
+  const exactBody = [
+    `$beforeText = ${powerShellTextFromBase64(beforeText)}`,
+    `$afterText = ${powerShellTextFromBase64(exactAfterText)}`,
+    "$before = ConvertFrom-SupabaseMigrationListV1 -Text $beforeText",
+    "$after = ConvertFrom-SupabaseMigrationListV1 -Text $afterText",
+    "$module = Get-Module CollaborativeBindersProductionRolloutV1",
+    "& $module { param($beforeLedger, $afterLedger) " +
+      "Assert-ExactBinderLedgerDeltaV1 " +
+      "-Before $beforeLedger -After $afterLedger } $before $after",
+    "'pass' | ConvertTo-Json -Compress",
+  ].join("; ");
+  assert.equal(
+    parsePowerShellJson(runPowerShell(exactBody), "exact ledger delta"),
+    "pass",
+  );
+
+  const injectedAfterText = [
+    exactAfterText,
+    "20260723105000 | 20260723105000 | injected",
+  ].join("\n");
+  const injectedBody = [
+    `$beforeText = ${powerShellTextFromBase64(beforeText)}`,
+    `$afterText = ${powerShellTextFromBase64(injectedAfterText)}`,
+    "$before = ConvertFrom-SupabaseMigrationListV1 -Text $beforeText",
+    "$after = ConvertFrom-SupabaseMigrationListV1 -Text $afterText",
+    "$module = Get-Module CollaborativeBindersProductionRolloutV1",
+    "& $module { param($beforeLedger, $afterLedger) " +
+      "Assert-ExactBinderLedgerDeltaV1 " +
+      "-Before $beforeLedger -After $afterLedger } $before $after",
+  ].join("; ");
+  const injected = runPowerShell(injectedBody);
+  assert.notEqual(injected.status, 0);
+  assert.match(
+    `${injected.stderr}\n${injected.stdout}`,
+    /Remote migration delta is not exactly five/i,
+  );
+});
+
+test("dry-run parser accepts only the five exact filenames in order", () => {
+  const exactText = [
+    "\u001b[36mDRY RUN\u001b[0m",
+    ...EXPECTED_MIGRATIONS.map(
+      (migration) => `Would apply migration ${migration.file}`,
+    ),
+  ].join("\n");
+  const successBody = [
+    `$text = ${powerShellTextFromBase64(exactText)}`,
+    "$parsed = ConvertFrom-SupabaseDryRunV1 -Text $text",
+    "ConvertTo-Json -InputObject $parsed -Depth 8 -Compress",
+  ].join("; ");
+  const parsed = parsePowerShellJson(
+    runPowerShell(successBody),
+    "exact dry run",
+  );
+  assert.deepEqual(
+    parsed.MigrationFiles,
+    EXPECTED_MIGRATIONS.map((migration) => migration.file),
+  );
+
+  const wrongOrder = [
+    "DRY RUN",
+    `Would apply migration ${EXPECTED_MIGRATIONS[1].file}`,
+    `Would apply migration ${EXPECTED_MIGRATIONS[0].file}`,
+    ...EXPECTED_MIGRATIONS.slice(2).map(
+      (migration) => `Would apply migration ${migration.file}`,
+    ),
+  ].join("\n");
+  const failureBody = [
+    `$text = ${powerShellTextFromBase64(wrongOrder)}`,
+    "ConvertFrom-SupabaseDryRunV1 -Text $text",
+  ].join("; ");
+  const failure = runPowerShell(failureBody);
+  assert.notEqual(failure.status, 0);
+  assert.match(
+    `${failure.stderr}\n${failure.stdout}`,
+    /Dry-run migration order mismatch/i,
+  );
+});
+
+test("tracked migration inventory rejects an untracked top-level SQL file", () => {
+  const script = `
+$osTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\\', '/')
+$fixture = Join-Path $osTemp ('binder-migration-set-fixture-' + [guid]::NewGuid().ToString('N'))
+if ((Split-Path -Parent $fixture) -cne $osTemp) { throw 'unsafe fixture path' }
+try {
+  [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/migrations'))
+  $migration = Join-Path $fixture 'supabase/migrations/20260723100000_fixture.sql'
+  [IO.File]::WriteAllText($migration, 'select 1;')
+  $null = & git -C $fixture init --quiet 2>&1
+  if ($LASTEXITCODE -ne 0) { throw 'fixture git init failed' }
+  $null = & git -C $fixture add -- 'supabase/migrations/20260723100000_fixture.sql' 2>&1
+  if ($LASTEXITCODE -ne 0) { throw 'fixture git add failed' }
+  $module = Get-Module CollaborativeBindersProductionRolloutV1
+  $exact = & $module {
+    param($root)
+    Get-BinderTrackedMigrationSetV1 -RepoRoot $root
+  } $fixture
+  [IO.File]::WriteAllText(
+    (Join-Path $fixture 'supabase/migrations/20260723100001_injected.sql'),
+    'select 2;'
+  )
+  $failure = ''
+  try {
+    [void](& $module {
+      param($root)
+      Get-BinderTrackedMigrationSetV1 -RepoRoot $root
+    } $fixture)
+  } catch {
+    $failure = $_.Exception.Message
+  }
+  [pscustomobject]@{
+    ExactCount = $exact.Count
+    ExactFingerprint = $exact.Sha256
+    Failure = $failure
+  } | ConvertTo-Json -Compress
+} finally {
+  if (
+    (Test-Path -LiteralPath $fixture) -and
+    (Split-Path -Parent ([IO.Path]::GetFullPath($fixture))) -ceq $osTemp
+  ) {
+    foreach ($file in [IO.Directory]::EnumerateFiles(
+      $fixture,
+      '*',
+      [IO.SearchOption]::AllDirectories
+    )) {
+      [IO.File]::SetAttributes($file, [IO.FileAttributes]::Normal)
+    }
+    [IO.Directory]::Delete($fixture, $true)
+  }
+}
+`;
+  const body =
+    `& ([scriptblock]::Create(${powerShellTextFromBase64(script)}))`;
+  const result = parsePowerShellJson(
+    runPowerShell(body),
+    "tracked migration inventory",
+  );
+  assert.equal(result.ExactCount, 1);
+  assert.match(result.ExactFingerprint, /^[0-9a-f]{64}$/);
+  assert.match(
+    result.Failure,
+    /does not exactly match the tracked top-level SQL set/i,
+  );
+});
+
+test("staged Supabase source denies migration writes and cleans safely", () => {
+  const script = `
+$osTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\\', '/')
+$fixture = Join-Path $osTemp ('binder-stage-fixture-' + [guid]::NewGuid().ToString('N'))
+if ((Split-Path -Parent $fixture) -cne $osTemp) { throw 'unsafe fixture path' }
+$stage = $null
+try {
+  [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/migrations'))
+  [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/.temp'))
+  [IO.File]::WriteAllText(
+    (Join-Path $fixture 'supabase/config.toml'),
+    'project_id = "${PRODUCTION_PROJECT_REF}"'
+  )
+  [IO.File]::WriteAllText(
+    (Join-Path $fixture 'supabase/.temp/project-ref'),
+    '${PRODUCTION_PROJECT_REF}'
+  )
+  $migration = Join-Path $fixture 'supabase/migrations/20260723100000_fixture.sql'
+  [IO.File]::WriteAllText($migration, 'select 1;')
+  $hash = (Get-FileHash -LiteralPath $migration -Algorithm SHA256).Hash.ToLowerInvariant()
+  $module = Get-Module CollaborativeBindersProductionRolloutV1
+  $setHash = & $module {
+    param($line)
+    Get-BinderSha256StringV1 -Value $line
+  } ("supabase/migrations/20260723100000_fixture.sql|" + $hash)
+  $set = [pscustomobject]@{
+    Count = 1
+    Sha256 = $setHash
+    Entries = @([pscustomobject]@{
+      RelativePath = 'supabase/migrations/20260723100000_fixture.sql'
+      FullPath = $migration
+      Sha256 = $hash
+    })
+  }
+  $stage = & $module {
+    param($root, $migrationSet)
+    New-BinderSupabaseStageV1 -RepoRoot $root -TrackedMigrationSet $migrationSet
+  } $fixture $set
+
+  $createDenied = $false
+  try {
+    [IO.File]::WriteAllText(
+      (Join-Path $stage.MigrationDirectory '20260723100001_injected.sql'),
+      'select 2;'
+    )
+  } catch {
+    $exception = $_.Exception
+    $createDenied = (
+      $exception -is [UnauthorizedAccessException] -or
+      $exception.InnerException -is [UnauthorizedAccessException]
+    )
+  }
+  $writeDenied = $false
+  try {
+    [IO.File]::WriteAllText(
+      (Join-Path $stage.MigrationDirectory '20260723100000_fixture.sql'),
+      'changed'
+    )
+  } catch {
+    $writeDenied = $true
+  }
+  $sealedManifest = $stage.SealedManifest
+  $cleanup = & $module {
+    param($value)
+    Close-BinderSupabaseStageV1 -Stage $value
+  } $stage
+  $stage = $null
+  $failedLifecycle = [pscustomobject]@{
+    CreatedRoot = $null
+    CleanupAttempted = $false
+    CleanupSucceeded = $null
+    CleanupMessage = ''
+  }
+  $badSet = [pscustomobject]@{
+    Count = 1
+    Sha256 = ('0' * 64)
+    Entries = $set.Entries
+  }
+  $constructionFailure = ''
+  try {
+    [void](& $module {
+      param($root, $migrationSet, $lifecycle)
+      New-BinderSupabaseStageV1 -RepoRoot $root -TrackedMigrationSet $migrationSet -StageLifecycle $lifecycle
+    } $fixture $badSet $failedLifecycle)
+  } catch {
+    $constructionFailure = $_.Exception.Message
+  }
+  [pscustomobject]@{
+    CreateDenied = $createDenied
+    WriteDenied = $writeDenied
+    CleanupSucceeded = $cleanup.Succeeded
+    StageExistsAfterCleanup = Test-Path -LiteralPath $cleanup.Root
+    SealedManifest = $sealedManifest
+    ConstructionFailure = $constructionFailure
+    InternalCleanupAttempted = $failedLifecycle.CleanupAttempted
+    InternalCleanupSucceeded = $failedLifecycle.CleanupSucceeded
+    InternalStageExists = if ($null -ne $failedLifecycle.CreatedRoot) {
+      Test-Path -LiteralPath $failedLifecycle.CreatedRoot
+    } else {
+      $false
+    }
+  } | ConvertTo-Json -Depth 8 -Compress
+} finally {
+  if ($null -ne $stage) {
+    [void](& (Get-Module CollaborativeBindersProductionRolloutV1) {
+      param($value)
+      Close-BinderSupabaseStageV1 -Stage $value
+    } $stage)
+  }
+  if (
+    (Test-Path -LiteralPath $fixture) -and
+    (Split-Path -Parent ([IO.Path]::GetFullPath($fixture))) -ceq $osTemp
+  ) {
+    [IO.Directory]::Delete($fixture, $true)
+  }
+}
+`;
+  const body =
+    `& ([scriptblock]::Create(${powerShellTextFromBase64(script)}))`;
+  const result = parsePowerShellJson(
+    runPowerShell(body),
+    "immutable staged Supabase source",
+  );
+  assert.equal(result.CreateDenied, true);
+  assert.equal(result.WriteDenied, true);
+  assert.equal(result.CleanupSucceeded, true);
+  assert.equal(result.StageExistsAfterCleanup, false);
+  assert.match(
+    result.ConstructionFailure,
+    /Staged migration-set fingerprint mismatch/i,
+  );
+  assert.equal(result.InternalCleanupAttempted, true);
+  assert.equal(result.InternalCleanupSucceeded, true);
+  assert.equal(result.InternalStageExists, false);
+  assert.equal(result.SealedManifest.migration_count, 1);
+  assert.equal(result.SealedManifest.migration_set_sha256.length, 64);
+  assert.equal(result.SealedManifest.config_sha256.length, 64);
+  assert.equal(result.SealedManifest.project_ref, PRODUCTION_PROJECT_REF);
+  assert.deepEqual(result.SealedManifest.migrations, [
+    {
+      file: "20260723100000_fixture.sql",
+      sha256: result.SealedManifest.migrations[0].sha256,
+    },
+  ]);
+  assert.equal(
+    JSON.stringify(result.SealedManifest).includes("binder-stage-fixture-"),
+    false,
+  );
+});
+
+test("process lifecycle marks started only after a successful process start", () => {
+  const body = [
+    "$module = Get-Module CollaborativeBindersProductionRolloutV1",
+    "$successLifecycle = [pscustomobject]@{ Started = $false; StartedAtUtc = $null }",
+    "$pwshPath = (Get-Command pwsh).Source",
+    "$success = & $module { param($file, $root, $lifecycle) " +
+      "Invoke-BinderProcessV1 -FilePath $file " +
+      "-Arguments @('-NoProfile','-NonInteractive','-Command','exit 0') " +
+      "-WorkingDirectory $root -TimeoutSeconds 10 " +
+      "-ProcessLifecycle $lifecycle } " +
+      "$pwshPath " +
+      `${psLiteral(REPO_ROOT)} ` +
+      "$successLifecycle",
+    "$failedLifecycle = [pscustomobject]@{ Started = $false; StartedAtUtc = $null }",
+    "$startFailure = ''",
+    "try { & $module { param($root, $lifecycle) " +
+      "Invoke-BinderProcessV1 " +
+      "-FilePath (Join-Path $root 'definitely-missing-binder-tool.exe') " +
+      "-Arguments @('--version') -WorkingDirectory $root -TimeoutSeconds 10 " +
+      "-ProcessLifecycle $lifecycle } " +
+      `${psLiteral(REPO_ROOT)} $failedLifecycle } ` +
+      "catch { $startFailure = $_.Exception.Message }",
+    "[pscustomobject]@{ " +
+      "SuccessStarted = $successLifecycle.Started; " +
+      "SuccessTimestamp = $successLifecycle.StartedAtUtc; " +
+      "SuccessExitCode = $success.ExitCode; " +
+      "FailedStarted = $failedLifecycle.Started; " +
+      "StartFailure = $startFailure " +
+      "} | ConvertTo-Json -Compress",
+  ].join("; ");
+  const result = parsePowerShellJson(
+    runPowerShell(body),
+    "process lifecycle",
+  );
+  assert.equal(result.SuccessStarted, true);
+  assert.match(result.SuccessTimestamp, /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(result.SuccessExitCode, 0);
+  assert.equal(result.FailedStarted, false);
+  assert.match(result.StartFailure, /unable to start|cannot find|no such/i);
+});
+
+test("apply command plan is private, gated, and contains one exact mutating argv", () => {
+  const externalCall = runPowerShell(
+    "New-BinderApplyCommandPlanV1 -AuthorizationValidated $true",
+  );
+  assert.notEqual(externalCall.status, 0);
+  assert.match(
+    `${externalCall.stderr}\n${externalCall.stdout}`,
+    /New-BinderApplyCommandPlanV1.*not recognized/is,
+  );
+
+  const blocked = runPowerShell(
+    "$module = Get-Module CollaborativeBindersProductionRolloutV1; " +
+      "& $module { New-BinderApplyCommandPlanV1 -AuthorizationValidated $false }",
+  );
+  assert.notEqual(blocked.status, 0);
+  assert.match(
+    `${blocked.stderr}\n${blocked.stdout}`,
+    /cannot be constructed before authorization validation/i,
+  );
+
+  const plan = parsePowerShellJson(
+    runPowerShell(
+      "$module = Get-Module CollaborativeBindersProductionRolloutV1; " +
+        "$plan = @(& $module { " +
+        "New-BinderApplyCommandPlanV1 -AuthorizationValidated $true }); " +
+        "ConvertTo-Json -InputObject $plan -Depth 8 -Compress",
+    ),
+    "apply plan",
+  );
+  assert.deepEqual(plan, [
+    {
+      Tool: "supabase",
+      Arguments: ["db", "push", "--linked", "--yes"],
+      MutatesRemote: true,
+    },
+  ]);
+});
+
+test("production apply requires both exact acknowledgements and confirmation", () => {
+  const fakeManifest = {
+    head_sha: "0123456789abcdef0123456789abcdef01234567",
+    manifest_fingerprint_sha256: "a".repeat(64),
+    backup_evidence_sha256: "b".repeat(64),
+  };
+  const manifestExpression =
+    `ConvertFrom-Json ${psLiteral(JSON.stringify(fakeManifest))}`;
+  const expectedApply =
+    `APPLY-COLLABORATIVE-BINDERS-V1::${PRODUCTION_PROJECT_REF}::` +
+    `${fakeManifest.head_sha}::${fakeManifest.manifest_fingerprint_sha256}`;
+  const expectedBackup =
+    `BACKUP-VERIFIED::${PRODUCTION_PROJECT_REF}::` +
+    fakeManifest.backup_evidence_sha256;
+
+  const exact = runPowerShell(
+    `$manifest = ${manifestExpression}; ` +
+      "Assert-BinderApplyAuthorizationV1 " +
+      "-PreflightManifest $manifest -ConfirmProduction $true | " +
+      "ConvertTo-Json -Compress",
+    {
+      env: {
+        GROOKAI_BINDER_PROD_APPLY_ACK: expectedApply,
+        GROOKAI_BINDER_PROD_BACKUP_ACK: expectedBackup,
+      },
+    },
+  );
+  assert.equal(parsePowerShellJson(exact, "exact authorization"), true);
+
+  const noConfirmation = runPowerShell(
+    `$manifest = ${manifestExpression}; ` +
+      "Assert-BinderApplyAuthorizationV1 " +
+      "-PreflightManifest $manifest -ConfirmProduction $false",
+    {
+      env: {
+        GROOKAI_BINDER_PROD_APPLY_ACK: expectedApply,
+        GROOKAI_BINDER_PROD_BACKUP_ACK: expectedBackup,
+      },
+    },
+  );
+  assert.notEqual(noConfirmation.status, 0);
+  assert.match(
+    `${noConfirmation.stderr}\n${noConfirmation.stdout}`,
+    /requires -ConfirmProduction/i,
+  );
+
+  const nearMiss = runPowerShell(
+    `$manifest = ${manifestExpression}; ` +
+      "Assert-BinderApplyAuthorizationV1 " +
+      "-PreflightManifest $manifest -ConfirmProduction $true",
+    {
+      env: {
+        GROOKAI_BINDER_PROD_APPLY_ACK: `${expectedApply} `,
+        GROOKAI_BINDER_PROD_BACKUP_ACK: expectedBackup,
+      },
+    },
+  );
+  assert.notEqual(nearMiss.status, 0);
+  assert.match(
+    `${nearMiss.stderr}\n${nearMiss.stdout}`,
+    /acknowledgement is missing or not exact/i,
+  );
+});
+
+test("apply implementation revalidates every source guard before its sole push", () => {
+  const moduleSource = source(MODULE_PATH);
+  const applyStart = moduleSource.indexOf(
+    "function Invoke-BinderProductionApplyV1",
+  );
+  const applyEnd = moduleSource.indexOf(
+    "\nExport-ModuleMember",
+    applyStart,
+  );
+  assert.ok(applyStart >= 0 && applyEnd > applyStart);
+  const applySource = moduleSource.slice(applyStart, applyEnd);
+
+  const orderedMarkers = [
+    "Test-PreflightManifestV1 -Path $ManifestPath",
+    "Test-BinderSourceV1 -RepoRoot $RepoRoot",
+    "Assert-BinderRepositoryStateV1",
+    "Assert-ProjectBindingV1",
+    "Test-BackupEvidenceV1",
+    "Get-BinderLedgerV1 -RepoRoot $RepoRoot -ExpectedState PreApply",
+    "Invoke-BinderReadbackV1 -RepoRoot $RepoRoot -ExpectedState PreApply",
+    "Get-BinderDryRunV1 -RepoRoot $RepoRoot",
+    "Assert-BinderApplyAuthorizationV1",
+    "Get-BinderTrackedMigrationSetV1 -RepoRoot $RepoRoot",
+    "Open-BinderApplySealV1",
+    "Assert-BinderFinalLocalSealV1",
+    "New-BinderApplyCommandPlanV1",
+    "New-BinderSupabaseStageV1",
+    "-Arguments @($plan[0].Arguments)",
+    "-RepoRoot $stage.Root",
+  ];
+  let previous = -1;
+  for (const marker of orderedMarkers) {
+    const index = applySource.indexOf(marker);
+    assert.ok(index > previous, `missing or out-of-order apply guard: ${marker}`);
+    previous = index;
+  }
+
+  assert.equal(
+    (
+      applySource.match(
+        /-Arguments\s+@\(\$plan\[0\]\.Arguments\)/g,
+      ) ?? []
+    ).length,
+    1,
+  );
+  assert.match(
+    applySource,
+    /Get-BinderLedgerV1[\s\S]*?-RepoRoot \$RepoRoot[\s\S]*?-ExpectedState PostApply/,
+  );
+  assert.match(
+    applySource,
+    /Invoke-BinderReadbackV1[\s\S]*?-RepoRoot \$RepoRoot[\s\S]*?-ExpectedState PostApply/,
+  );
+  assert.match(
+    applySource,
+    /Assert-ExactBinderLedgerDeltaV1[\s\S]*?-Before \$ledgerBefore\.Ledger[\s\S]*?-After \$ledgerAfter\.Ledger/,
+  );
+  assert.match(
+    applySource,
+    /Get-BinderLedgerV1 -RepoRoot \$RepoRoot -ExpectedState PreApply[\s\S]*?ledger\.before\.txt[\s\S]*?ledger\.before\.json[\s\S]*?\$pushAttempted = \$true/,
+  );
+  assert.match(
+    applySource,
+    /New-BinderSupabaseStageV1[\s\S]*?sealed-source-manifest\.json[\s\S]*?\$pushAttempted = \$true/,
+  );
+  assert.match(
+    applySource,
+    /if \(\s*\$pushLifecycle\.Started -and\s*\$pushLifecycle\.TerminationConfirmed\s*\)\s*\{[\s\S]*diagnosticLedger = Invoke-BinderSupabaseV1/,
+  );
+  assert.match(applySource, /push_attempted = \$pushAttempted/);
+  assert.match(
+    applySource,
+    /push_started = \[bool\]\$pushLifecycle\.Started/,
+  );
+  assert.match(applySource, /push_succeeded = if \(\$null -ne \$push\)/);
+  assert.match(
+    applySource,
+    /push_timed_out = \[bool\]\$pushLifecycle\.TimedOut/,
+  );
+  assert.match(
+    applySource,
+    /mutation_possible = \[bool\]\$pushLifecycle\.Started/,
+  );
+});
+
+test("apply keeps one immutable execution identity through verification and diagnostics", () => {
+  const moduleSource = source(MODULE_PATH);
+  const applyStart = moduleSource.indexOf(
+    "function Invoke-BinderProductionApplyV1",
+  );
+  const applyEnd = moduleSource.indexOf(
+    "\nExport-ModuleMember",
+    applyStart,
+  );
+  const applySource = moduleSource.slice(applyStart, applyEnd);
+  const positions = [
+    applySource.indexOf("Open-BinderApplySealV1"),
+    applySource.indexOf("-Arguments @($plan[0].Arguments)"),
+    applySource.indexOf("-ExpectedState PostApply"),
+    applySource.indexOf("diagnosticLedger = Invoke-BinderSupabaseV1"),
+    applySource.indexOf("diagnosticReadback = Invoke-BinderSupabaseV1"),
+    applySource.indexOf("Close-BinderApplySealV1"),
+  ];
+  assert.ok(
+    positions.every((position) => position >= 0),
+    "all sealed apply phases must be present",
+  );
+  assert.deepEqual(
+    [...positions].sort((left, right) => left - right),
+    positions,
+    "the apply seal must close only after verification and diagnostics",
+  );
+  assert.equal(
+    (applySource.match(/Close-BinderApplySealV1/g) ?? []).length,
+    1,
+    "the apply seal must close exactly once",
+  );
+  assert.match(
+    applySource,
+    /finally\s*\{[\s\S]*?\$pushLifecycle\.TerminationConfirmed[\s\S]*?\[Environment\]::FailFast\([\s\S]*?Close-BinderApplySealV1 -Streams \$sealStreams\s*\}/,
+  );
+  assert.match(
+    applySource,
+    /Open-BinderApplySealV1[\s\S]*?-SupabaseExecutable \$supabaseExecutable/,
+  );
+  assert.match(
+    applySource,
+    /-Arguments @\(\$plan\[0\]\.Arguments\)[\s\S]*?-ExecutablePath \$supabaseExecutable\.BinaryPath/,
+  );
+  assert.match(
+    applySource,
+    /-ExpectedState PostApply[\s\S]*?-ExecutablePath \$supabaseExecutable\.BinaryPath/,
+  );
+  assert.match(
+    applySource,
+    /diagnosticLedger = Invoke-BinderSupabaseV1[\s\S]*?-ExecutablePath \$supabaseExecutable\.BinaryPath/,
+  );
+  assert.match(
+    applySource,
+    /diagnosticReadback = Invoke-BinderSupabaseV1[\s\S]*?-ExecutablePath \$supabaseExecutable\.BinaryPath/,
+  );
+  assert.match(
+    applySource,
+    /\$push = Invoke-BinderSupabaseV1[\s\S]*?\$pushSucceeded = \([\s\S]*?\)\s*\}\s*finally/,
+    "push outcome must be captured before fallible cleanup",
+  );
+
+  const readbackStart = moduleSource.indexOf("function Invoke-BinderReadbackV1");
+  const readbackEnd = moduleSource.indexOf(
+    "\nfunction Get-BinderDryRunV1",
+    readbackStart,
+  );
+  const readbackSource = moduleSource.slice(readbackStart, readbackEnd);
+  const hashCheck = readbackSource.indexOf("Get-BinderSha256FileV1 -Path $sqlPath");
+  const invocation = readbackSource.indexOf("Invoke-BinderSupabaseV1");
+  assert.ok(hashCheck >= 0 && invocation > hashCheck);
+  assert.match(readbackSource, /\$policy\.PreflightSqlSha256/);
+  assert.match(readbackSource, /\$policy\.PostApplySqlSha256/);
+  assert.match(
+    readbackSource,
+    /\$sqlSeal = \[System\.IO\.File\]::Open\([\s\S]*?\$sqlSeal\.Dispose\(\)/,
+  );
+
+  assert.match(
+    moduleSource,
+    /ShimDescriptorPath = \$shimDescriptorPath/,
+  );
+  assert.match(
+    moduleSource,
+    /\$SupabaseExecutable\.ShimDescriptorPath[\s\S]*?\$paths\.Add/,
+  );
+  assert.match(
+    applySource,
+    /\[CmdletBinding\(SupportsShouldProcess = \$true, ConfirmImpact = 'High'\)\]/,
+  );
+  assert.match(applySource, /\$PSCmdlet\.ShouldProcess\(/);
+});
+
+test("rollout executables expose no repair, force, routing, or flag-enable path", () => {
+  const executableSource = [
+    MODULE_PATH,
+    PREFLIGHT_ENTRYPOINT_PATH,
+    APPLY_ENTRYPOINT_PATH,
+    READBACK_ENTRYPOINT_PATH,
+  ]
+    .map(source)
+    .join("\n");
+
+  assert.doesNotMatch(executableSource, /migration\s+repair/i);
+  assert.doesNotMatch(executableSource, /--include-all\b/i);
+  assert.doesNotMatch(executableSource, /--include-seed\b/i);
+  assert.doesNotMatch(executableSource, /--include-roles\b/i);
+  assert.doesNotMatch(executableSource, /--db-url\b/i);
+  assert.doesNotMatch(executableSource, /--password\b/i);
+  assert.doesNotMatch(
+    executableSource,
+    /Arguments\s+@\(\s*['"](?:link|db\s+pull|db\s+reset)/i,
+  );
+  assert.doesNotMatch(
+    executableSource,
+    /\b(?:insert\s+into|update|delete\s+from)\s+(?:public\.)?binder_feature_flags\b/i,
+  );
+  assert.doesNotMatch(
+    executableSource,
+    /(?:setx|\$env:)\s*(?:GROOKAI_)?BINDERS?_[A-Z0-9_]*(?:ENABLED|V1)\s*=\s*['"]?(?:true|1)/i,
+  );
+  assert.doesNotMatch(executableSource, /ValueFromRemainingArguments/i);
+
+  const applyEntrypoint = source(APPLY_ENTRYPOINT_PATH);
+  assert.match(applyEntrypoint, /SupportsShouldProcess\s*=\s*\$true/i);
+  assert.match(applyEntrypoint, /\[switch\]\$ConfirmProduction/);
+  assert.match(
+    applyEntrypoint,
+    /leave every feature flag disabled/i,
+  );
+
+  const moduleSource = source(MODULE_PATH);
+  assert.match(
+    moduleSource,
+    /\$env:GROOKAI_BINDER_PROD_APPLY_ACK\s+-ceq\s+\$expectedApply/,
+  );
+  assert.match(
+    moduleSource,
+    /\$env:GROOKAI_BINDER_PROD_BACKUP_ACK\s+-ceq\s+\$expectedBackup/,
+  );
+  assert.match(
+    moduleSource,
+    /Invoke-BinderSupabaseV1[\s\S]*?-SanitizeDatabaseEnvironment/,
+  );
+  assert.match(moduleSource, /'PG\.\*\|'/);
+  assert.match(moduleSource, /'POSTGRES\(\?:QL\)\?_URL\.\*\|'/);
+  assert.match(moduleSource, /SUPABASE_CA_SKIP_VERIFY/);
+  assert.match(moduleSource, /SUPABASE_INTERNAL_\.\*/);
+  assert.match(moduleSource, /REDACTED_SUPABASE_ACCESS_TOKEN/);
+  assert.match(moduleSource, /SupabaseCliLauncherSha256/);
+  assert.match(moduleSource, /SupabaseCliBinarySha256/);
+  assert.match(moduleSource, /SupabaseCliShimDescriptorSha256/);
+  assert.match(moduleSource, /FileShare\]::Read/);
+  assert.match(moduleSource, /Get-BinderTrackedMigrationSetV1/);
+  assert.match(moduleSource, /GetTempPath\(\)/);
+  assert.match(
+    moduleSource,
+    /FileSystemAccessRule\]::new\([\s\S]*?AccessControlType\]::Deny/,
+  );
+  assert.match(moduleSource, /FileSystemRights\]::WriteData/);
+  assert.match(moduleSource, /FileSystemRights\]::AppendData/);
+  assert.match(moduleSource, /FileSystemRights\]::WriteAttributes/);
+  assert.match(moduleSource, /FileSystemRights\]::WriteExtendedAttributes/);
+  assert.match(moduleSource, /InheritanceFlags\]::ContainerInherit/);
+  assert.match(moduleSource, /InheritanceFlags\]::ObjectInherit/);
+  assert.match(moduleSource, /Staged migration directory still permits file creation/);
+  assert.match(
+    moduleSource,
+    /\$stage\.Streams = @\(\$streams\)[\s\S]*?Get-BinderSealedStageManifestV1 -Stage \$stage/,
+  );
+  assert.match(moduleSource, /Close-BinderSupabaseStageV1/);
+  assert.match(moduleSource, /Write-BinderAtomicTextV1/);
+  assert.match(moduleSource, /Write-BinderChecksumsV1/);
+});
+
+test("runbook keeps installation, activation, Set Binders, and P8 separate", () => {
+  const runbook = source(RUNBOOK_PATH);
+
+  assert.match(runbook, /Status: prepared, not applied/);
+  assert.match(
+    runbook,
+    /does not activate Binders[\s\S]*enable any feature flag/i,
+  );
+  assert.match(runbook, /P8 is excluded/i);
+  assert.match(runbook, /All 11 Binder flags must remain disabled/i);
+  for (const flag of EXCLUDED_FLAGS) {
+    assert.match(runbook, new RegExp(`\\\`${flag}\\\``));
+  }
+  assert.match(
+    runbook,
+    /There is exactly one permitted remote mutation command:[\s\S]*supabase db push --linked --yes/i,
+  );
+  assert.match(
+    runbook,
+    /never links, pulls, resets,\s*changes migration history, or writes feature flags/i,
+  );
+});


### PR DESCRIPTION
## What changed

- adds a content-addressed production rollout manifest and guarded PowerShell preflight/apply/readback tooling
- pins the exact five Collaborative Binders migrations and exact production project reference
- adds immutable pre/post catalog readbacks, ledger-delta verification, source sealing, and Windows process-tree containment
- tightens the Binder rate-limit sequence ACL to service-role-only access
- adds rollout and containment contract coverage plus an operator runbook
- runs Windows-only ACL/process tests in a dedicated Windows CI job while keeping Linux CI portable

## Why

Collaborative Binders needs a fail-closed production installation path that cannot silently apply extra migrations, target the wrong project, enable features, or leave a mutating process tree running after failure.

## Safety boundaries

- no new migration was added
- all Binder flags remain disabled after installation
- P8, Set Binders, notifications, Pulse milestones, and public discovery remain excluded
- production was not contacted or changed while preparing this PR

## Validation

- full repository contract suite: 843/843 passed on Windows
- focused rollout and process-containment suite: 24/24 passed on Windows
- disposable zero-state migration replay: 294/294 migrations
- Binder pgTAP: 128/128 passed
- concurrency gates: 5/5 passed
- boundary race gates: 10/10 passed
- independent adversarial audit: zero blockers
- source-only package validation passed with fingerprint `14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9`

The initial Linux CI run exposed three Windows-only integration cases. They now skip only on non-Windows runners, and a dedicated Windows job preserves their real ACL/process-containment coverage.

The local commit/push hook could not run its production-dependent runtime preflight because this isolated worktree intentionally has no `SUPABASE_DB_URL`; the relevant source, contract, replay, and containment validations above were run independently.