### PR TITLE
Harden Binder production rollout supervisor

### DIFF
--- a/.github/workflows/contracts-runtime-protection.yml
+++ b/.github/workflows/contracts-runtime-protection.yml
@@ -76,3 +76,4 @@ jobs:
           node --test
           tests/contracts/collaborative_binders_process_containment_v1.test.mjs
           tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
+          tests/contracts/collaborative_binders_unattended_supervisor_v1.test.mjs

--- a/docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md
+++ b/docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md
@@ -112,6 +112,60 @@ does not create or claim a backup.
 `verified_logical_backup`. Verification must be no more than 24 hours old, and
 the recoverable horizon must be within 15 minutes of the preflight.
 
+## Reviewed one-shot unattended path
+
+The manual preflight and apply path remains the default. A one-shot unattended
+path may be used only when its supervisor source has merged to `main` and a
+separate compact authorization envelope has been reviewed. The envelope must
+be outside every Git worktree, use the closed V1 schema, and match a
+caller-supplied SHA-256 over its exact UTF-8 bytes.
+
+That authorization binds all of the following:
+
+- the exact `origin/main` commit and canonical repository/remote
+- the production project ref and URL
+- package, manifest, tracked-migration-set, migration-file, readback, rollout,
+  supervisor, entrypoint, restore-procedure, and pinned CLI hashes
+- the old completed-backup floor and a short polling/mutation deadline
+- the fixed protected state and artifact roots under Windows Local AppData
+- exact pre-apply absence/fingerprint assertions
+- all 11 Binder flags disabled, the three excluded flags, P8 excluded, and no
+  activation, deployment, repair, rollback, arbitrary command, or retry
+- named operator and reviewer confirmation that the hash-bound restore
+  procedure was reviewed
+
+The supervisor may only poll the fixed Supabase physical-backup-list command.
+It requires exactly one completed physical backup strictly newer than the
+approved floor and no more than five minutes old, then confirms the same
+candidate in a second poll. Ambiguous, malformed, stale, future, or changed
+backup evidence stops the run.
+
+After selecting a backup, the supervisor durably creates
+`UNATTENDED_ATTEMPT_CLAIMED`; that package/project can never be relaunched
+automatically. It runs the linked preflight exactly once, independently seals
+and reviews every artifact and acknowledgement, and requires at least five
+minutes of recovery-horizon reserve. Immediately before mutation it rechecks
+the source bundle, live `origin/main`, project binding, preflight, backup, and
+authorization. The backup recheck is a final contained live listing that must
+return the same completed backup key, full response fingerprint, region, and
+reviewed PITR/WAL-G mode. It then durably creates
+`MUTATION_LAUNCH_COMMITTED` and invokes the existing guarded apply exactly
+once. Any failure after the mutation claim is classified as mutation possible.
+The supervisor never retries, repairs, restores, deploys, or enables a flag.
+
+Only the two-parameter entrypoint is allowed:
+
+```powershell
+pwsh -NoProfile -File scripts/ops/collaborative_binders_unattended_supervisor_v1.ps1 `
+  -AuthorizationPath "<absolute-reviewed-envelope-path>" `
+  -ExpectedAuthorizationSha256 "<independently-reviewed-envelope-sha256>"
+```
+
+Do not launch from a broad approval or a draft envelope. The exact post-merge
+envelope bytes, their SHA-256, and the bound restore procedure must be reviewed
+before the one-shot process starts. If a claim or artifact root already exists
+or its state is uncertain, do not delete it and do not relaunch.
+
 ## Source-only validation
 
 This mode is local-only. It verifies the package fingerprint, exact migration
@@ -202,13 +256,15 @@ diagnostic reads. It never claims that flags or migration state are unchanged
 after a timed-out or failed push.
 
 After process-tree termination is confirmed, the sealed temporary source is
-deleted. It contains no copied pooler URL or database password. A sanitized
-manifest of staged filenames and hashes is retained in the external apply
-evidence directory. If ordinary cleanup cannot safely unseal and remove the
-temporary source, the guard stops. In the exceptional fail-fast containment
-path, ordinary cleanup deliberately does not run; treat any matching sealed
-temporary directory as incident evidence until the process tree is confirmed
-absent and recovery is directed.
+deleted. It may contain the exact hash-pinned, passwordless Supabase pooler
+route and linked-project identity files so final read-only gates and the sole
+push consume the same sealed route. It never copies a database password or
+other credential. A sanitized manifest of staged filenames and hashes is
+retained in the external apply evidence directory. If ordinary cleanup cannot
+safely unseal and remove the temporary source, the guard stops. In the
+exceptional fail-fast containment path, ordinary cleanup deliberately does not
+run; treat any matching sealed temporary directory as incident evidence until
+the process tree is confirmed absent and recovery is directed.
 
 ## Mandatory post-apply readback
 

--- a/docs/runbooks/SUPABASE_PLATFORM_BACKUP_RESTORE_PROCEDURE_V1.md
+++ b/docs/runbooks/SUPABASE_PLATFORM_BACKUP_RESTORE_PROCEDURE_V1.md
@@ -1,0 +1,111 @@
+# Supabase Platform Backup Restore Procedure V1
+
+Status: review-required, human-operated disaster-recovery procedure
+
+Production project: `ycdxbpibncqcchqiihfz`
+
+Official reference reviewed on 2026-07-24:
+<https://supabase.com/docs/guides/platform/backups>
+
+This is the only restore procedure accepted by the Collaborative Binders V1
+unattended-supervisor authorization contract. The authorization envelope binds
+the exact bytes of this file by SHA-256 and by this fixed URI:
+
+`repo:///docs/runbooks/SUPABASE_PLATFORM_BACKUP_RESTORE_PROCEDURE_V1.md`
+
+For this one-shot V1 contract, `inserted_at` from the pinned Supabase CLI
+physical-backup row is the only machine-verifiable backup timestamp and is
+therefore recorded as `recoverable_through_utc`. It is a selection and
+guard-horizon marker, not an independent guarantee about transaction-level
+coverage. Before any restore, the human operator must compare it with the
+Dashboard's displayed backup/recovery point. If Supabase displays a different
+time or does not make the coverage clear, stop and obtain Supabase Support
+confirmation; calculate potential data loss from the earlier defensible point.
+
+## Hard boundary
+
+The unattended supervisor never starts, schedules, or approves a restore. A
+restore replaces database state and can discard every database write after the
+selected recovery point. It is a separate destructive control-plane action
+requiring an awake owner, current incident evidence, and a new explicit
+authorization after the rollout process has stopped.
+
+Do not improvise a rollback with migration-history repair, manual SQL, a second
+database push, an internal API, or an automatic retry.
+
+## Required access and evidence
+
+Before proposing a restore:
+
+1. Stop the rollout and prevent any automated restart. Preserve the supervisor
+   state directory, authorization envelope, immutable attempt and mutation
+   claims, rollout artifact directory, `STOP-incident.json`, process output,
+   migration ledger, and catalog readbacks.
+2. Treat a started, timed-out, interrupted, or indeterminate database push as
+   `mutation_possible`.
+3. Sign in to the Supabase Dashboard with an account authorized to restore the
+   production project. Independently verify the organization, project name,
+   project ref `ycdxbpibncqcchqiihfz`, and current incident.
+4. In **Database > Backups**, verify that the exact physical backup recorded by
+   the supervisor still appears as completed and restorable. Its UTC
+   `inserted_at` value is the recovery horizon used by this contract.
+5. Calculate and document the data-loss window from that recovery horizon to
+   the proposed restore start. Identify user writes, purchases, messages,
+   collection changes, authentication changes, and operational updates that
+   could be lost or need reconciliation.
+6. Plan for the project to be inaccessible during restoration. Pause or drain
+   application writes and integrations only under a separately approved
+   incident plan.
+7. If the project has non-Realtime replication slots or subscriptions, make a
+   reviewed plan to drop them before restoration and recreate them afterward.
+   Supabase handles its own Realtime slot.
+8. Record that database backups do not restore Storage objects deleted after
+   the recovery point; they restore database metadata, not the missing object
+   bytes. Plan a separate Storage reconciliation if needed.
+9. Record every custom login role whose password must be reset after a daily
+   backup restore; Supabase daily backups do not retain custom-role passwords.
+10. Obtain explicit owner approval naming the exact project, exact backup UTC
+    recovery horizon, estimated downtime, and accepted data-loss window.
+
+If the backup, project, access level, or data-loss window is uncertain, stop
+and contact Supabase Support. Do not guess.
+
+## Human restore execution
+
+1. Keep the application in the separately approved incident state and confirm
+   no rollout or remediation process is running.
+2. Open the verified production project in the Supabase Dashboard.
+3. Open **Database > Backups** and select the exact reviewed completed physical
+   backup. Do not select a merely nearby backup or a different timestamp.
+4. Recheck the displayed project and recovery point against the written owner
+   authorization.
+5. Use the Dashboard restore action and review its confirmation prompt. If the
+   Dashboard flow, project, recovery point, or warnings differ from this
+   procedure or the owner authorization, cancel and escalate.
+6. Confirm the restore only after the final human comparison. Record the
+   operator, UTC start time, selected recovery point, Dashboard notification or
+   operation identifier, screenshots, and incident identifier.
+7. Wait for the Dashboard to report completion. Do not run migrations, repair
+   history, enable feature flags, or resume writes while the restore is in
+   progress.
+
+## Verification before reopening traffic
+
+1. Confirm the project and database report healthy and record the UTC
+   completion time.
+2. Reset and test any affected custom-role passwords without recording secrets
+   in rollout artifacts.
+3. Recreate and validate any separately managed replication slots or
+   subscriptions.
+4. Compare the migration ledger, database catalog, Trust/Pulse/card-event
+   fingerprints, and key row counts with the preserved pre-apply evidence and
+   the approved recovery point.
+5. Verify authentication, Vault, Wall, Pulse, Discover, messaging, Trust,
+   hosted image delivery, Storage object availability, and Realtime behavior.
+6. Confirm all 11 Binder feature flags remain disabled. P8 remains excluded.
+7. Reconcile or deliberately discard post-recovery-point writes according to
+   the incident plan.
+8. Preserve new recovery evidence before any separately reviewed remediation
+   or traffic reopening.
+9. Record the final outcome, unresolved data loss, follow-up owners, and the
+   exact time normal writes resume.

--- a/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
+++ b/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
@@ -606,7 +606,7 @@ function Test-BinderGitForWindowsInjectionEnvironmentNameV1 {
 
   return [regex]::IsMatch(
     $Name,
-    '^(?:MSYS.*|CYGWIN.*|CHERE_INVOKING|BASH_ENV|ENV)$',
+    '^(?:GCM_.*|MSYS.*|CYGWIN.*|CHERE_INVOKING|BASH_ENV|ENV)$',
     [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
   )
 }
@@ -1596,6 +1596,10 @@ function Invoke-BinderProcessV1 {
           $SanitizeDatabaseEnvironment -and
           (
             (Test-BinderRoutingEnvironmentNameV1 -Name $name) -or
+            (
+              Test-BinderGitForWindowsInjectionEnvironmentNameV1 `
+                -Name $name
+            ) -or
             (
               $name.StartsWith(
                 'SUPABASE_',

--- a/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
+++ b/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
@@ -101,6 +101,36 @@ function ConvertTo-BinderUtcDateTimeV1 {
   return $parsed.UtcDateTime
 }
 
+function ConvertTo-BinderStrictUtcDeadlineV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Value,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Assert-BinderConditionV1 (
+    $Value -cmatch
+      '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,7})?Z$'
+  ) "$Label must be an exact UTC Z timestamp."
+  $parsed = [datetimeoffset]::MinValue
+  $valid = [datetimeoffset]::TryParseExact(
+    $Value,
+    [string[]]@(
+      "yyyy-MM-dd'T'HH:mm:ss'Z'",
+      "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'"
+    ),
+    [cultureinfo]::InvariantCulture,
+    (
+      [System.Globalization.DateTimeStyles]::AssumeUniversal -bor
+      [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    ),
+    [ref]$parsed
+  )
+  Assert-BinderConditionV1 $valid "$Label is invalid."
+  return $parsed
+}
+
 function Get-BinderRolloutPolicyV1 {
   [CmdletBinding()]
   param()
@@ -111,7 +141,20 @@ function Get-BinderRolloutPolicyV1 {
     PackageFingerprintSha256 = $script:PackageFingerprintV1
     ProjectRef = 'ycdxbpibncqcchqiihfz'
     CanonicalRepository = 'OriginalSoseji/grookai_vault'
+    CanonicalRemoteUrl =
+      'https://github.com/OriginalSoseji/grookai_vault.git'
     RequiredAncestorSha = '34caa07324587815040957f9adde1f771ebfc85a'
+    GitExecutablePath =
+      'C:\Program Files\Git\mingw64\bin\git.exe'
+    GitExecutableSha256 =
+      '755d4896d35663d0ff08924f84507f35236b83d240635b512c519bf43cc71a87'
+    GitVersion = 'git version 2.51.0.windows.1'
+    GitExecPath =
+      'C:\Program Files\Git\mingw64\libexec\git-core'
+    GitHttpsHelperPath =
+      'C:\Program Files\Git\mingw64\libexec\git-core\git-remote-https.exe'
+    GitHttpsHelperSha256 =
+      '0a5b9d55a338d202f88044c36fe0feb76cb57b68a4176798a80edacc706a34b8'
     SupportedSupabaseCliVersion = '2.90.0'
     SupabaseCliLauncherSha256 = '140e3801d8adeda639a21b14e62b93a4c7d26b7a758421f43c82be59753be49b'
     SupabaseCliBinarySha256 = '31c2a25bd590a36ad803a7c669cf76a62eac3cd5aa7112eeb2e1c5f308c8b39c'
@@ -121,6 +164,19 @@ function Get-BinderRolloutPolicyV1 {
     PostApplySqlRelativePath = 'scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql'
     PreflightSqlSha256 = '268458ed8a4a16dc513b55b6d0e5b3b03c301320e55a9ab4887a135c7652800d'
     PostApplySqlSha256 = '5125b0d89f5b3d36c66f98863f0b69b9c6df55561dfb54303437d47d8731f1a1'
+    SupabaseConfigSha256 =
+      'd7ed1face7c1d1fbc70d35393ae3a42268e27886bd0e15d0b96bc1af439b1567'
+    LinkedProjectRefSha256 =
+      'caf1b086f20f10f60aa27783311afb3466ef31390aba80a00206730ff233d40f'
+    LinkedPoolerUrl =
+      'postgresql://postgres.ycdxbpibncqcchqiihfz@aws-1-us-east-2.pooler.supabase.com:5432/postgres'
+    LinkedPoolerUrlSha256 =
+      'd3609ad1cb525989b2fdbe7f0f25b7fff26fac19c72e2759893de1998a5295c1'
+    LinkedProjectMetadataSha256 =
+      'f86521274b66370ec59227b2a5906f8bcb4499658b54306b50427196ff60e8ed'
+    LinkedProjectName = "OriginalSoseji's Project"
+    LinkedProjectOrganizationId = 'rksadomjkuoxvrbhsmxu'
+    LinkedProjectOrganizationSlug = 'rksadomjkuoxvrbhsmxu'
     MigrationVersions = @(
       '20260723100000',
       '20260723101000',
@@ -300,6 +356,27 @@ function Read-BinderPackageManifestV1 {
     ($actualManifestProperties -join "`n") -ceq
       ($expectedManifestProperties -join "`n")
   ) 'Package manifest fields are missing or unexpected.'
+  Assert-BinderConditionV1 (
+    $manifest.schema_version -is [long] -and
+    $manifest.package_id -is [string] -and
+    $manifest.package_fingerprint_sha256 -is [string] -and
+    $manifest.required_ancestor_sha -is [string] -and
+    $manifest.production_project_ref -is [string] -and
+    $manifest.canonical_git_repository -is [string] -and
+    $manifest.migrations -is [object[]] -and
+    $manifest.readback_sql -is [object[]] -and
+    $manifest.final_expected_shape -is [pscustomobject] -and
+    $manifest.feature_flags_must_remain_disabled -is [object[]] -and
+    $manifest.excluded_from_rollout -is [object[]]
+  ) 'Package manifest primitive types are not exact JSON types.'
+  foreach ($flag in @(
+    @($manifest.feature_flags_must_remain_disabled) +
+    @($manifest.excluded_from_rollout)
+  )) {
+    Assert-BinderConditionV1 (
+      $flag -is [string]
+    ) 'Package manifest flag arrays may contain only strings.'
+  }
 
   Assert-BinderConditionV1 ($manifest.schema_version -eq $policy.SchemaVersion) 'Package manifest schema version mismatch.'
   Assert-BinderConditionV1 ($manifest.package_id -ceq $policy.PackageId) 'Package ID mismatch.'
@@ -334,6 +411,15 @@ function Read-BinderPackageManifestV1 {
       ($actualMigrationProperties -join "`n") -ceq
         ($expectedMigrationProperties -join "`n")
     ) 'Migration manifest fields are missing or unexpected.'
+    Assert-BinderConditionV1 (
+      $migration.version -is [string] -and
+      $migration.file -is [string] -and
+      $migration.sha256 -is [string] -and
+      $migration.cumulative_tables -is [long] -and
+      $migration.cumulative_functions -is [long] -and
+      $migration.cumulative_indexes -is [long] -and
+      $migration.cumulative_rls_policies -is [long]
+    ) 'Migration manifest primitive types are invalid.'
   }
 
   $expectedReadbackProperties = @('phase', 'file', 'sha256') | Sort-Object
@@ -345,6 +431,43 @@ function Read-BinderPackageManifestV1 {
       ($actualReadbackProperties -join "`n") -ceq
         ($expectedReadbackProperties -join "`n")
     ) 'Readback SQL manifest fields are missing or unexpected.'
+    Assert-BinderConditionV1 (
+      $readback.phase -is [string] -and
+      $readback.file -is [string] -and
+      $readback.sha256 -is [string]
+    ) 'Readback SQL manifest primitive types are invalid.'
+  }
+  foreach ($name in @(
+    'tables',
+    'functions',
+    'indexes',
+    'rls_policies',
+    'feature_flags',
+    'enabled_feature_flags',
+    'public_execute_functions',
+    'anonymous_raw_privileges',
+    'anonymous_raw_sequence_privileges',
+    'authenticated_raw_mutations',
+    'authenticated_raw_sequence_privileges'
+  )) {
+    Assert-BinderConditionV1 (
+      $manifest.final_expected_shape.PSObject.Properties[$name].Value -is
+        [long]
+    ) "Package final_expected_shape.$name must be an integer."
+  }
+  foreach ($name in @(
+    'authenticated_raw_select_tables',
+    'realtime_tables'
+  )) {
+    $values = $manifest.final_expected_shape.PSObject.Properties[$name].Value
+    Assert-BinderConditionV1 (
+      $values -is [object[]]
+    ) "Package final_expected_shape.$name must be an array."
+    foreach ($value in @($values)) {
+      Assert-BinderConditionV1 (
+        $value -is [string]
+      ) "Package final_expected_shape.$name may contain only strings."
+    }
   }
 
   return [pscustomobject]@{
@@ -425,6 +548,66 @@ function Test-BinderRoutingEnvironmentNameV1 {
     'SUPABASE_PROJECT_(?:ID|REF)|' +
     'SUPABASE_CA_SKIP_VERIFY' +
     ')$'
+  )
+}
+
+function Test-BinderRuntimeInjectionEnvironmentNameV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return [regex]::IsMatch(
+    $Name,
+    '^(?:DOTNET_|CORECLR_|COR_|COMPLUS_).*$',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  )
+}
+
+function Test-BinderTraceOrRoutingEnvironmentNameV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return [regex]::IsMatch(
+    $Name,
+    (
+      '^(?:' +
+      'HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|' +
+      'SSL_CERT_FILE|SSL_CERT_DIR|SSLKEYLOGFILE|' +
+      'CURL_CA_BUNDLE|REQUESTS_CA_BUNDLE|NODE_EXTRA_CA_CERTS|' +
+      'GODEBUG|GOTRACEBACK|GOCOVERDIR|GRPC_.*' +
+      ')$'
+    ),
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  )
+}
+
+function Test-BinderCredentialEnvironmentNameV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return (
+    $Name -match
+      '(?i)(?:^|_)(?:SECRET|PASSWORD|TOKEN|KEY)(?:_|$)' -or
+    $Name -match
+      '(?i)^(?:GH_|GITHUB_|AWS_|AZURE_|GOOGLE_|GCP_)'
+  )
+}
+
+function Test-BinderGitForWindowsInjectionEnvironmentNameV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return [regex]::IsMatch(
+    $Name,
+    '^(?:MSYS.*|CYGWIN.*|CHERE_INVOKING|BASH_ENV|ENV)$',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
   )
 }
 
@@ -886,6 +1069,7 @@ $ErrorActionPreference = 'Stop'
 $payloadName = 'GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1'
 $gate = $null
 $child = $null
+$payloadDocument = $null
 $exitCode = 250
 try {
   $encodedPayload = [Environment]::GetEnvironmentVariable(
@@ -903,12 +1087,54 @@ try {
   $payloadJson = [Text.Encoding]::UTF8.GetString(
     [Convert]::FromBase64String($encodedPayload)
   )
+  $payloadDocument = [System.Text.Json.JsonDocument]::Parse(
+    $payloadJson
+  )
+  if (
+    $payloadDocument.RootElement.ValueKind -ne
+      [System.Text.Json.JsonValueKind]::Object
+  ) {
+    throw 'Supervisor payload root is invalid.'
+  }
+  $notAfterElement = [System.Text.Json.JsonElement]::new()
+  if (
+    -not $payloadDocument.RootElement.TryGetProperty(
+      'NotAfterUtc',
+      [ref]$notAfterElement
+    ) -or
+    $notAfterElement.ValueKind -ne
+      [System.Text.Json.JsonValueKind]::String
+  ) {
+    throw 'Supervisor payload deadline is not a string.'
+  }
+  $notAfterText = $notAfterElement.GetString()
   $payload = $payloadJson | ConvertFrom-Json
   $gate = [Threading.EventWaitHandle]::OpenExisting(
     [string]$payload.GateName
   )
   if (-not $gate.WaitOne(600000)) {
     throw 'Supervisor gate was not released within ten minutes.'
+  }
+  if (-not [string]::IsNullOrWhiteSpace($notAfterText)) {
+    if ($notAfterText -cnotmatch
+      '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,7})?Z$') {
+      throw 'Contained mutation deadline is invalid.'
+    }
+    $notAfter = [datetimeoffset]::ParseExact(
+      $notAfterText,
+      [string[]]@(
+        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'"
+      ),
+      [cultureinfo]::InvariantCulture,
+      (
+        [Globalization.DateTimeStyles]::AssumeUniversal -bor
+        [Globalization.DateTimeStyles]::AdjustToUniversal
+      )
+    )
+    if ([datetimeoffset]::UtcNow -ge $notAfter) {
+      throw 'Contained mutation authority expired before child start.'
+    }
   }
 
   $start = [Diagnostics.ProcessStartInfo]::new()
@@ -924,6 +1150,12 @@ try {
 
   $child = [Diagnostics.Process]::new()
   $child.StartInfo = $start
+  if (
+    -not [string]::IsNullOrWhiteSpace($notAfterText) -and
+    [datetimeoffset]::UtcNow -ge $notAfter
+  ) {
+    throw 'Contained mutation authority expired at the child-start gate.'
+  }
   if (-not $child.Start()) {
     throw 'Supervisor could not start the reviewed executable.'
   }
@@ -947,6 +1179,9 @@ try {
 } finally {
   if ($null -ne $child) {
     $child.Dispose()
+  }
+  if ($null -ne $payloadDocument) {
+    $payloadDocument.Dispose()
   }
   if ($null -ne $gate) {
     $gate.Dispose()
@@ -1205,12 +1440,35 @@ function Invoke-BinderProcessV1 {
 
     [switch]$SanitizeDatabaseEnvironment,
 
+    [switch]$SanitizeGitEnvironment,
+
+    [string]$TrustedGitExecPath = '',
+
+    [string]$NotAfterUtc = '',
+
     [object]$ProcessLifecycle
   )
 
   Assert-BinderConditionV1 (
     $TimeoutSeconds -gt 0
   ) 'Process timeout must be positive.'
+  if (-not [string]::IsNullOrWhiteSpace($NotAfterUtc)) {
+    $parsedNotAfter = ConvertTo-BinderStrictUtcDeadlineV1 `
+      -Value $NotAfterUtc -Label 'Contained process not-after time'
+    Assert-BinderConditionV1 (
+      [datetimeoffset]::UtcNow -lt $parsedNotAfter
+    ) 'Contained process mutation authority has expired.'
+  }
+  if ($SanitizeGitEnvironment) {
+    Assert-BinderConditionV1 (
+      -not [string]::IsNullOrWhiteSpace($TrustedGitExecPath) -and
+      [System.IO.Path]::IsPathFullyQualified($TrustedGitExecPath)
+    ) 'Contained Git execution path is not fixed.'
+  } else {
+    Assert-BinderConditionV1 (
+      [string]::IsNullOrWhiteSpace($TrustedGitExecPath)
+    ) 'A trusted Git execution path was supplied to a non-Git process.'
+  }
   Initialize-BinderProcessContainmentTypesV1
 
   $maximumOutputCharacters = 262144
@@ -1286,6 +1544,7 @@ function Invoke-BinderProcessV1 {
       FilePath = $resolvedFilePath
       WorkingDirectory = $resolvedWorkingDirectory
       Arguments = @($Arguments)
+      NotAfterUtc = $NotAfterUtc
     }
     $payloadJson = $payload | ConvertTo-Json -Depth 4 -Compress
     $payloadBase64 = [Convert]::ToBase64String(
@@ -1312,12 +1571,76 @@ function Invoke-BinderProcessV1 {
     )) {
       [void]$start.ArgumentList.Add($argument)
     }
-    if ($SanitizeDatabaseEnvironment) {
-      foreach ($name in @($start.Environment.Keys)) {
-        if (Test-BinderRoutingEnvironmentNameV1 -Name $name) {
-          [void]$start.Environment.Remove($name)
-        }
+    foreach ($name in @($start.Environment.Keys)) {
+      $allowSupabaseAccessToken = (
+        $SanitizeDatabaseEnvironment -and
+        $name.Equals(
+          'SUPABASE_ACCESS_TOKEN',
+          [System.StringComparison]::OrdinalIgnoreCase
+        )
+      )
+      if (
+        (Test-BinderRuntimeInjectionEnvironmentNameV1 -Name $name) -or
+        (Test-BinderTraceOrRoutingEnvironmentNameV1 -Name $name) -or
+        (
+          (Test-BinderCredentialEnvironmentNameV1 -Name $name) -and
+          -not $allowSupabaseAccessToken
+        ) -or
+        (
+          $name.StartsWith(
+            'GROOKAI_BINDER_PROD_',
+            [System.StringComparison]::OrdinalIgnoreCase
+          )
+        ) -or
+        (
+          $SanitizeDatabaseEnvironment -and
+          (
+            (Test-BinderRoutingEnvironmentNameV1 -Name $name) -or
+            (
+              $name.StartsWith(
+                'SUPABASE_',
+                [System.StringComparison]::OrdinalIgnoreCase
+              ) -and
+              -not $allowSupabaseAccessToken
+            ) -or
+            $name.StartsWith(
+              'GIT_',
+              [System.StringComparison]::OrdinalIgnoreCase
+            )
+          )
+        ) -or
+        (
+          $SanitizeGitEnvironment -and
+          (
+            $name.StartsWith(
+              'GIT_',
+              [System.StringComparison]::OrdinalIgnoreCase
+            ) -or
+            $name.StartsWith(
+              'SUPABASE_',
+              [System.StringComparison]::OrdinalIgnoreCase
+            ) -or
+            (
+              Test-BinderGitForWindowsInjectionEnvironmentNameV1 `
+                -Name $name
+            ) -or
+            (Test-BinderRoutingEnvironmentNameV1 -Name $name)
+          )
+        )
+      ) {
+        [void]$start.Environment.Remove($name)
       }
+    }
+    if ($SanitizeGitEnvironment) {
+      $start.Environment['GIT_CONFIG_NOSYSTEM'] = '1'
+      $start.Environment['GIT_CONFIG_GLOBAL'] = 'NUL'
+      $start.Environment['GIT_EXEC_PATH'] =
+        [System.IO.Path]::GetFullPath($TrustedGitExecPath)
+      $start.Environment['GIT_TERMINAL_PROMPT'] = '0'
+      $start.Environment['GIT_OPTIONAL_LOCKS'] = '0'
+      $start.Environment['GCM_INTERACTIVE'] = 'Never'
+      $start.Environment['MSYS2_ARG_CONV_EXCL'] = '*'
+      $start.Environment['MSYS_NO_PATHCONV'] = '1'
     }
     $start.Environment[
       'GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1'
@@ -1530,13 +1853,162 @@ function Get-BinderCommandPathV1 {
     [string]$Name
   )
 
-  $command = Get-Command $Name -ErrorAction SilentlyContinue
-  Assert-BinderConditionV1 ($null -ne $command) "Required command is unavailable: $Name"
-  return $command.Source
+  $commands = @(
+    Get-Command $Name -CommandType Application `
+      -ErrorAction SilentlyContinue
+  )
+  Assert-BinderConditionV1 (
+    $commands.Count -gt 0
+  ) "Required application is unavailable: $Name"
+  $source = [string]$commands[0].Source
+  Assert-BinderConditionV1 (
+    -not [string]::IsNullOrWhiteSpace($source) -and
+    [System.IO.Path]::IsPathFullyQualified($source)
+  ) "Resolved application path is not absolute: $Name"
+  return [System.IO.Path]::GetFullPath($source)
+}
+
+function Assert-BinderPinnedProgramFilesFileV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  $programFilesRoot = 'C:\Program Files'
+  Assert-BinderConditionV1 (
+    $fullPath -ceq $ExpectedPath -and
+    $fullPath.StartsWith(
+      "$programFilesRoot\",
+      [System.StringComparison]::OrdinalIgnoreCase
+    ) -and
+    (Test-Path -LiteralPath $fullPath -PathType Leaf)
+  ) "$Label is not the exact fixed Program Files executable."
+  $lowTrustSids = @(
+    'S-1-1-0',
+    'S-1-5-11',
+    'S-1-5-32-545',
+    [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+  )
+  $trustedOwnerSids = @(
+    'S-1-5-18',
+    'S-1-5-32-544',
+    (
+      [System.Security.Principal.NTAccount]::new(
+        'NT SERVICE',
+        'TrustedInstaller'
+      ).Translate(
+        [System.Security.Principal.SecurityIdentifier]
+      ).Value
+    )
+  )
+  $unsafeRights = (
+    [System.Security.AccessControl.FileSystemRights]::WriteData -bor
+    [System.Security.AccessControl.FileSystemRights]::AppendData -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::Delete -bor
+    [System.Security.AccessControl.FileSystemRights]::
+      DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+  $cursor = $fullPath
+  while ($cursor) {
+    $item = Get-Item -LiteralPath $cursor -Force
+    Assert-BinderConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "$Label path contains a reparse point: $cursor"
+    $acl = Get-Acl -LiteralPath $cursor
+    $ownerSid = (
+      [System.Security.Principal.NTAccount]$acl.Owner
+    ).Translate(
+      [System.Security.Principal.SecurityIdentifier]
+    ).Value
+    Assert-BinderConditionV1 (
+      $trustedOwnerSids -ccontains $ownerSid
+    ) "$Label has an untrusted owner: $cursor"
+    foreach ($rule in $acl.GetAccessRules(
+      $true,
+      $true,
+      [System.Security.Principal.SecurityIdentifier]
+    )) {
+      if (
+        $rule.AccessControlType -eq
+          [System.Security.AccessControl.AccessControlType]::Allow -and
+        $lowTrustSids -ccontains $rule.IdentityReference.Value -and
+        (
+          $rule.FileSystemRights -band $unsafeRights
+        ) -ne 0
+      ) {
+        throw "$Label grants write-capable access to a low-trust identity."
+      }
+    }
+    if ($cursor.Equals(
+      $programFilesRoot,
+      [System.StringComparison]::OrdinalIgnoreCase
+    )) {
+      break
+    }
+    $parent = Split-Path -Parent $cursor
+    Assert-BinderConditionV1 (
+      -not [string]::IsNullOrWhiteSpace($parent) -and
+      -not $parent.Equals(
+        $cursor,
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) "$Label escaped its fixed Program Files parent."
+    $cursor = $parent
+  }
+  Assert-BinderConditionV1 (
+    (Get-BinderSha256FileV1 -Path $fullPath) -ceq $ExpectedSha256
+  ) "$Label hash differs from the reviewed identity."
+  return $fullPath
+}
+
+function Get-BinderGitExecutableV1 {
+  $policy = Get-BinderRolloutPolicyV1
+  $gitPath = Assert-BinderPinnedProgramFilesFileV1 `
+    -Path $policy.GitExecutablePath `
+    -ExpectedPath $policy.GitExecutablePath `
+    -ExpectedSha256 $policy.GitExecutableSha256 `
+    -Label 'Git executable'
+  $helperPath = Assert-BinderPinnedProgramFilesFileV1 `
+    -Path $policy.GitHttpsHelperPath `
+    -ExpectedPath $policy.GitHttpsHelperPath `
+    -ExpectedSha256 $policy.GitHttpsHelperSha256 `
+    -Label 'Git HTTPS helper'
+  $execPath = [System.IO.Path]::GetFullPath($policy.GitExecPath)
+  Assert-BinderConditionV1 (
+    $execPath -ceq (Split-Path -Parent $helperPath)
+  ) 'Git HTTPS helper is outside the fixed execution directory.'
+  return [pscustomobject][ordered]@{
+    ExecutablePath = $gitPath
+    ExecutableSha256 = $policy.GitExecutableSha256
+    Version = $policy.GitVersion
+    ExecPath = $execPath
+    HttpsHelperPath = $helperPath
+    HttpsHelperSha256 = $policy.GitHttpsHelperSha256
+  }
 }
 
 function Get-BinderSupabaseExecutableV1 {
+  $policy = Get-BinderRolloutPolicyV1
   $launcherPath = Get-BinderCommandPathV1 -Name 'supabase'
+  $launcherItem = Get-Item -LiteralPath $launcherPath -Force
+  Assert-BinderConditionV1 (
+    -not $launcherItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'Supabase launcher must not be a reparse point.'
   $binaryPath = $launcherPath
   $shimDescriptorPath = $null
   $shimDescriptor = [System.IO.Path]::ChangeExtension(
@@ -1576,6 +2048,27 @@ function Get-BinderSupabaseExecutableV1 {
     Assert-BinderConditionV1 (Test-Path -LiteralPath $candidate -PathType Leaf) 'Resolved Supabase binary does not exist.'
     $binaryPath = $candidate
   }
+  Assert-BinderConditionV1 (
+    -not [string]::IsNullOrWhiteSpace($shimDescriptorPath)
+  ) 'The reviewed Supabase Scoop shim descriptor is missing.'
+  $binaryItem = Get-Item -LiteralPath $binaryPath -Force
+  Assert-BinderConditionV1 (
+    -not $binaryItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'Resolved Supabase binary must not be a reparse point.'
+  Assert-BinderConditionV1 (
+    (Get-BinderSha256FileV1 -Path $launcherPath) -ceq
+      $policy.SupabaseCliLauncherSha256
+  ) 'Supabase CLI launcher is not the reviewed binary.'
+  Assert-BinderConditionV1 (
+    (Get-BinderSha256FileV1 -Path $shimDescriptorPath) -ceq
+      $policy.SupabaseCliShimDescriptorSha256
+  ) 'Supabase CLI shim descriptor is not the reviewed descriptor.'
+  Assert-BinderConditionV1 (
+    (Get-BinderSha256FileV1 -Path $binaryPath) -ceq
+      $policy.SupabaseCliBinarySha256
+  ) 'Supabase CLI binary is not the reviewed binary.'
 
   return [pscustomobject]@{
     LauncherPath = $launcherPath
@@ -1595,11 +2088,449 @@ function Invoke-BinderGitV1 {
     [int]$TimeoutSeconds = 60
   )
 
+  $git = Get-BinderGitExecutableV1
+  $hardenedArguments = @(
+    '-c', 'extensions.worktreeConfig=false',
+    '-c', 'core.fsmonitor=false',
+    '-c', 'core.hooksPath=NUL',
+    '-c', 'core.askPass=',
+    '-c', 'core.sshCommand=',
+    '-c', 'core.gitProxy=',
+    '-c', 'credential.helper=',
+    '-c', 'credential.interactive=false',
+    '-c', 'credential.username=',
+    '-c', 'http.proxy=',
+    '-c', 'http.sslVerify=true',
+    '-c', 'http.sslCAInfo=',
+    '-c', 'http.sslCAPath=',
+    '-c', 'http.sslCert=',
+    '-c', 'http.sslKey=',
+    '-c', 'http.sslCertPasswordProtected=false',
+    '-c', 'http.extraHeader=',
+    '-c', 'remote.origin.proxy='
+  ) + @($Arguments)
   return Invoke-BinderProcessV1 `
-    -FilePath (Get-BinderCommandPathV1 -Name 'git') `
-    -Arguments $Arguments `
+    -FilePath $git.ExecutablePath `
+    -Arguments $hardenedArguments `
     -WorkingDirectory $RepoRoot `
-    -TimeoutSeconds $TimeoutSeconds
+    -TimeoutSeconds $TimeoutSeconds `
+    -SanitizeGitEnvironment `
+    -TrustedGitExecPath $git.ExecPath
+}
+
+function Get-BinderGitTopologyV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $resolvedRepoRoot = [System.IO.Path]::GetFullPath(
+    $RepoRoot
+  ).TrimEnd('\', '/')
+  $result = Invoke-BinderGitV1 `
+    -Arguments @(
+      'rev-parse',
+      '--path-format=absolute',
+      '--show-toplevel',
+      '--absolute-git-dir',
+      '--git-common-dir'
+    ) `
+    -RepoRoot $resolvedRepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $result `
+    -Label 'fixed Git repository topology'
+  $lines = @(
+    $result.StdOut -split "`r?`n" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  Assert-BinderConditionV1 (
+    $lines.Count -eq 3
+  ) 'Git repository topology did not return exactly three paths.'
+  foreach ($line in $lines) {
+    Assert-BinderConditionV1 (
+      $line -cnotmatch '[\x00-\x1f\x7f]'
+    ) 'Git repository topology contains a control character.'
+  }
+
+  $topLevel = [System.IO.Path]::GetFullPath(
+    [string]$lines[0]
+  ).TrimEnd('\', '/')
+  $gitDirectory = [System.IO.Path]::GetFullPath(
+    [string]$lines[1]
+  ).TrimEnd('\', '/')
+  $commonDirectory = [System.IO.Path]::GetFullPath(
+    [string]$lines[2]
+  ).TrimEnd('\', '/')
+  Assert-BinderConditionV1 (
+    $topLevel.Equals(
+      $resolvedRepoRoot,
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  ) 'Git top-level directory is not the exact rollout repository.'
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $gitDirectory -PathType Container
+  ) 'Git directory is missing.'
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $commonDirectory -PathType Container
+  ) 'Git common directory is missing.'
+  $gitIsCommon = $gitDirectory.Equals(
+    $commonDirectory,
+    [System.StringComparison]::OrdinalIgnoreCase
+  )
+  Assert-BinderConditionV1 (
+    $gitIsCommon -or
+    $gitDirectory.StartsWith(
+      "$commonDirectory\worktrees\",
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  ) 'Git directory is outside the reviewed common worktree registry.'
+
+  $dotGitPath = Join-Path $resolvedRepoRoot '.git'
+  Assert-BinderConditionV1 (
+    Test-Path -LiteralPath $dotGitPath
+  ) 'The worktree .git marker is missing.'
+  $dotGitItem = Get-Item -LiteralPath $dotGitPath -Force
+  Assert-BinderConditionV1 (
+    -not $dotGitItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'The worktree .git marker must not be a reparse point.'
+  $dotGitPointerPath = $null
+  if ($dotGitItem.PSIsContainer) {
+    Assert-BinderConditionV1 (
+      $gitIsCommon -and
+      $gitDirectory.Equals(
+        [System.IO.Path]::GetFullPath($dotGitPath),
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) 'A directory .git marker does not match the reported Git directory.'
+  } else {
+    $dotGitPointerPath = [System.IO.Path]::GetFullPath($dotGitPath)
+    $pointerText = Get-Content -LiteralPath $dotGitPointerPath -Raw
+    $pointerMatch = [regex]::Match(
+      $pointerText,
+      '^gitdir: (?<path>[^\r\n\x00-\x1f\x7f]+)\r?\n?$'
+    )
+    Assert-BinderConditionV1 (
+      $pointerMatch.Success
+    ) 'The linked-worktree .git pointer is malformed.'
+    $pointerValue = [string]$pointerMatch.Groups['path'].Value
+    $resolvedPointer = if (
+      [System.IO.Path]::IsPathFullyQualified($pointerValue)
+    ) {
+      [System.IO.Path]::GetFullPath($pointerValue)
+    } else {
+      [System.IO.Path]::GetFullPath(
+        (Join-Path $resolvedRepoRoot $pointerValue)
+      )
+    }
+    Assert-BinderConditionV1 (
+      $resolvedPointer.Equals(
+        $gitDirectory,
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) 'The linked-worktree .git pointer does not match Git topology.'
+  }
+
+  $headPath = Join-Path $gitDirectory 'HEAD'
+  $indexPath = Join-Path $gitDirectory 'index'
+  $commonConfigPath = Join-Path $commonDirectory 'config'
+  foreach ($requiredPath in @(
+    $headPath,
+    $indexPath,
+    $commonConfigPath
+  )) {
+    Assert-BinderConditionV1 (
+      Test-Path -LiteralPath $requiredPath -PathType Leaf
+    ) "Required Git metadata is missing: $requiredPath"
+  }
+
+  $metadata = [System.Collections.Generic.List[object]]::new()
+  function Add-BinderGitMetadataPathLocalV1 {
+    param(
+      [Parameter(Mandatory = $true)]
+      [string]$Label,
+      [Parameter(Mandatory = $true)]
+      [string]$Path,
+      [bool]$Required = $false
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+      Assert-BinderConditionV1 (
+        -not $Required
+      ) "Required Git metadata is missing: $Path"
+      return
+    }
+    $item = Get-Item -LiteralPath $Path -Force
+    Assert-BinderConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "Git metadata must not be a reparse point: $Path"
+    $metadata.Add([pscustomobject][ordered]@{
+      Label = $Label
+      Path = [System.IO.Path]::GetFullPath($Path)
+      Sha256 = Get-BinderSha256FileV1 -Path $Path
+    })
+  }
+
+  Add-BinderGitMetadataPathLocalV1 `
+    -Label 'worktree_head' -Path $headPath -Required $true
+  Add-BinderGitMetadataPathLocalV1 `
+    -Label 'worktree_index' -Path $indexPath -Required $true
+  Add-BinderGitMetadataPathLocalV1 `
+    -Label 'common_config' -Path $commonConfigPath -Required $true
+  if ($null -ne $dotGitPointerPath) {
+    Add-BinderGitMetadataPathLocalV1 `
+      -Label 'worktree_dot_git_pointer' `
+      -Path $dotGitPointerPath `
+      -Required $true
+  }
+
+  $commondirPath = Join-Path $gitDirectory 'commondir'
+  $gitdirPath = Join-Path $gitDirectory 'gitdir'
+  if (-not $gitIsCommon) {
+    foreach ($requiredLinkedPath in @($commondirPath, $gitdirPath)) {
+      Assert-BinderConditionV1 (
+        Test-Path -LiteralPath $requiredLinkedPath -PathType Leaf
+      ) "Linked-worktree metadata is missing: $requiredLinkedPath"
+    }
+    $commondirText = (
+      Get-Content -LiteralPath $commondirPath -Raw
+    ).TrimEnd("`r", "`n")
+    Assert-BinderConditionV1 (
+      $commondirText -cnotmatch '[\x00-\x1f\x7f]' -and
+      -not [string]::IsNullOrWhiteSpace($commondirText)
+    ) 'Linked-worktree commondir metadata is malformed.'
+    $resolvedCommondir = [System.IO.Path]::GetFullPath(
+      (Join-Path $gitDirectory $commondirText)
+    ).TrimEnd('\', '/')
+    Assert-BinderConditionV1 (
+      $resolvedCommondir.Equals(
+        $commonDirectory,
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) 'Linked-worktree commondir does not match Git topology.'
+    $gitdirText = (
+      Get-Content -LiteralPath $gitdirPath -Raw
+    ).TrimEnd("`r", "`n")
+    Assert-BinderConditionV1 (
+      $gitdirText -cnotmatch '[\x00-\x1f\x7f]' -and
+      [System.IO.Path]::IsPathFullyQualified($gitdirText)
+    ) 'Linked-worktree gitdir metadata is malformed.'
+    Assert-BinderConditionV1 (
+      [System.IO.Path]::GetFullPath($gitdirText).Equals(
+        [System.IO.Path]::GetFullPath($dotGitPath),
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) 'Linked-worktree gitdir does not point back to the worktree.'
+    Add-BinderGitMetadataPathLocalV1 `
+      -Label 'worktree_commondir' `
+      -Path $commondirPath `
+      -Required $true
+    Add-BinderGitMetadataPathLocalV1 `
+      -Label 'worktree_gitdir' `
+      -Path $gitdirPath `
+      -Required $true
+  }
+
+  Add-BinderGitMetadataPathLocalV1 `
+    -Label 'common_config_worktree' `
+    -Path (Join-Path $commonDirectory 'config.worktree')
+  if (-not $gitIsCommon) {
+    Add-BinderGitMetadataPathLocalV1 `
+      -Label 'git_config_worktree' `
+      -Path (Join-Path $gitDirectory 'config.worktree')
+  }
+  Add-BinderGitMetadataPathLocalV1 `
+    -Label 'common_packed_refs' `
+    -Path (Join-Path $commonDirectory 'packed-refs')
+
+  $headText = (
+    Get-Content -LiteralPath $headPath -Raw
+  ).TrimEnd("`r", "`n")
+  $headRef = ''
+  if ($headText -cmatch '^ref: (?<ref>refs/heads/[A-Za-z0-9._/-]+)$') {
+    $headRef = [string]$Matches['ref']
+    Assert-BinderConditionV1 (
+      $headRef -cnotmatch '(?:^|/)\.\.(?:/|$)' -and
+      $headRef -cnotmatch '//' -and
+      $headRef -cnotmatch '\.lock$' -and
+      -not $headRef.EndsWith('/')
+    ) 'Git HEAD names an unsafe branch reference.'
+    $headRefPath = Join-Path $commonDirectory (
+      $headRef.Replace('/', '\')
+    )
+    if (Test-Path -LiteralPath $headRefPath -PathType Leaf) {
+      Add-BinderGitMetadataPathLocalV1 `
+        -Label 'current_head_ref' `
+        -Path $headRefPath `
+        -Required $true
+    } else {
+      Assert-BinderConditionV1 (
+        Test-Path -LiteralPath (
+          Join-Path $commonDirectory 'packed-refs'
+        ) -PathType Leaf
+      ) 'Git HEAD reference is neither loose nor packed.'
+    }
+  } else {
+    Assert-BinderConditionV1 (
+      $headText -cmatch '^[0-9a-f]{40}$'
+    ) 'Git HEAD metadata is neither a safe branch ref nor a commit SHA.'
+  }
+
+  $metadataRows = @(
+    $metadata |
+      Sort-Object -Property Label -CaseSensitive
+  )
+  $metadataFingerprint = Get-BinderSha256StringV1 -Value (
+    @(
+      $metadataRows | ForEach-Object {
+        "$($_.Label)|$($_.Sha256)"
+      }
+    ) -join "`n"
+  )
+  return [pscustomobject][ordered]@{
+    TopLevel = $topLevel
+    GitDirectory = $gitDirectory
+    CommonDirectory = $commonDirectory
+    DotGitPath = [System.IO.Path]::GetFullPath($dotGitPath)
+    HeadRef = $headRef
+    CommonConfigPath = $commonConfigPath
+    CommonConfigSha256 =
+      Get-BinderSha256FileV1 -Path $commonConfigPath
+    MetadataCount = $metadataRows.Count
+    MetadataSha256 = $metadataFingerprint
+    Metadata = $metadataRows
+  }
+}
+
+function Assert-BinderGitLocalConfigurationV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $topology = Get-BinderGitTopologyV1 -RepoRoot $RepoRoot
+  $forbiddenPattern = (
+    '^(include\.|includeif\.|' +
+    'alias\.|' +
+    'core\.(askpass|editor|pager|fsmonitor|hookspath|' +
+    'sshcommand|gitproxy|attributesfile|excludesfile)|' +
+    'filter\.|credential\.|http\.|https\.|url\.|' +
+    'diff\.|merge\.|protocol\.|' +
+    'remote\..*\.(proxy|proxyauthmethod|vcs|promisor|' +
+    'partialclonefilter|uploadpack|receivepack)|' +
+    'remote\.origin\.pushurl)'
+  )
+  $forbidden = Invoke-BinderGitV1 `
+    -Arguments @(
+      'config',
+      '--local',
+      '--no-includes',
+      '--get-regexp',
+      $forbiddenPattern
+    ) `
+    -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 (
+    $forbidden.ExitCode -eq 1 -and
+    -not $forbidden.TimedOut -and
+    $forbidden.TerminationConfirmed -eq $true -and
+    $forbidden.OutputCaptureCompleted -eq $true -and
+    $forbidden.OutputTruncated -eq $false -and
+    [string]::IsNullOrWhiteSpace([string]$forbidden.StdOut) -and
+    [string]::IsNullOrWhiteSpace([string]$forbidden.StdErr)
+  ) 'Raw local Git config contains an execution or routing override.'
+
+  $origin = Invoke-BinderGitV1 `
+    -Arguments @(
+      'config',
+      '--local',
+      '--no-includes',
+      '--get-regexp',
+      '^remote\.origin\.'
+    ) `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $origin `
+    -Label 'raw local origin configuration'
+  $originLines = @(
+    $origin.StdOut -split "`r?`n" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  $expectedOriginLines = @(
+    'remote.origin.url https://github.com/OriginalSoseji/grookai_vault.git',
+    'remote.origin.fetch +refs/heads/*:refs/remotes/origin/*'
+  )
+  Assert-BinderConditionV1 (
+    $originLines.Count -eq $expectedOriginLines.Count
+  ) 'Raw local origin configuration contains unexpected keys.'
+  foreach ($expectedLine in $expectedOriginLines) {
+    Assert-BinderConditionV1 (
+      @($originLines | Where-Object { $_ -ceq $expectedLine }).Count -eq 1
+    ) 'Raw local origin URL/fetch configuration is not exact.'
+  }
+
+  $git = Get-BinderGitExecutableV1
+  $version = Invoke-BinderGitV1 `
+    -Arguments @('--version') `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $version `
+    -Label 'fixed Git version'
+  Assert-BinderConditionV1 (
+    $version.StdOut.TrimEnd("`r", "`n") -ceq $git.Version
+  ) 'Git version differs from the reviewed identity.'
+  return [pscustomobject][ordered]@{
+    Topology = $topology
+    ExecutablePath = $git.ExecutablePath
+    ExecutableSha256 = $git.ExecutableSha256
+    Version = $git.Version
+    ExecPath = $git.ExecPath
+    HttpsHelperPath = $git.HttpsHelperPath
+    HttpsHelperSha256 = $git.HttpsHelperSha256
+    CommonConfigSha256 = $topology.CommonConfigSha256
+    MetadataCount = $topology.MetadataCount
+    MetadataSha256 = $topology.MetadataSha256
+  }
+}
+
+function Open-BinderGitMetadataSealV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $guard = Assert-BinderGitLocalConfigurationV1 -RepoRoot $RepoRoot
+  $streams = [System.Collections.Generic.List[System.IO.FileStream]]::new()
+  try {
+    foreach ($entry in @($guard.Topology.Metadata)) {
+      Assert-BinderConditionV1 (
+        (Get-BinderSha256FileV1 -Path $entry.Path) -ceq
+          [string]$entry.Sha256
+      ) "Git metadata changed while opening its retained seal: $($entry.Label)"
+      $streams.Add([System.IO.File]::Open(
+        [string]$entry.Path,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::Read
+      ))
+    }
+    $fresh = Assert-BinderGitLocalConfigurationV1 -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 (
+      $fresh.MetadataCount -eq $guard.MetadataCount -and
+      $fresh.MetadataSha256 -ceq $guard.MetadataSha256
+    ) 'Git metadata changed after retained seals were opened.'
+    return [pscustomobject][ordered]@{
+      Streams = @($streams)
+      Guard = $fresh
+    }
+  } catch {
+    foreach ($stream in $streams) {
+      $stream.Dispose()
+    }
+    throw
+  }
 }
 
 function Invoke-BinderSupabaseV1 {
@@ -1614,7 +2545,9 @@ function Invoke-BinderSupabaseV1 {
 
     [object]$ProcessLifecycle,
 
-    [string]$ExecutablePath
+    [string]$ExecutablePath,
+
+    [string]$NotAfterUtc = ''
   )
 
   $resolvedExecutablePath = if (
@@ -1633,7 +2566,8 @@ function Invoke-BinderSupabaseV1 {
     -WorkingDirectory $RepoRoot `
     -TimeoutSeconds $TimeoutSeconds `
     -SanitizeDatabaseEnvironment `
-    -ProcessLifecycle $ProcessLifecycle
+    -ProcessLifecycle $ProcessLifecycle `
+    -NotAfterUtc $NotAfterUtc
 }
 
 function Assert-BinderCommandSucceededV1 {
@@ -2008,6 +2942,8 @@ function Test-BinderSourceV1 {
   )
 
   $policy = Get-BinderRolloutPolicyV1
+  $gitGuard = Assert-BinderGitLocalConfigurationV1 `
+    -RepoRoot $RepoRoot
   $package = Read-BinderPackageManifestV1 -RepoRoot $RepoRoot
   $trackedMigrationSet = Get-BinderTrackedMigrationSetV1 -RepoRoot $RepoRoot
 
@@ -2049,6 +2985,16 @@ function Test-BinderSourceV1 {
   Assert-BinderSqlReadOnlyV1 -Path $postApplySql
 
   $configPath = Join-Path $RepoRoot 'supabase/config.toml'
+  $configItem = Get-Item -LiteralPath $configPath -Force
+  Assert-BinderConditionV1 (
+    -not $configItem.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'supabase/config.toml must not be a reparse point.'
+  $configSha256 = Get-BinderSha256FileV1 -Path $configPath
+  Assert-BinderConditionV1 (
+    $configSha256 -ceq $policy.SupabaseConfigSha256
+  ) 'supabase/config.toml bytes differ from the reviewed source.'
   $config = Get-Content -LiteralPath $configPath -Raw
   $projectMatch = [regex]::Match(
     $config,
@@ -2060,6 +3006,9 @@ function Test-BinderSourceV1 {
   $originResult = Invoke-BinderGitV1 -Arguments @('remote', 'get-url', 'origin') -RepoRoot $RepoRoot
   Assert-BinderCommandSucceededV1 -Result $originResult -Label 'git remote get-url origin'
   $origin = $originResult.StdOut.Trim()
+  Assert-BinderConditionV1 (
+    $origin -ceq $policy.CanonicalRemoteUrl
+  ) 'Git origin URL is not the exact canonical HTTPS remote.'
   $normalizedOrigin = $origin `
     -replace '^https://github\.com/', '' `
     -replace '^git@github\.com:', '' `
@@ -2106,6 +3055,16 @@ function Test-BinderSourceV1 {
     PackageFingerprintSha256 = $package.FingerprintSha256
     PackageManifestFileSha256 = $package.FileSha256
     ProjectRef = $policy.ProjectRef
+    SupabaseConfigSha256 = $configSha256
+    GitExecutablePath = $gitGuard.ExecutablePath
+    GitExecutableSha256 = $gitGuard.ExecutableSha256
+    GitVersion = $gitGuard.Version
+    GitExecPath = $gitGuard.ExecPath
+    GitHttpsHelperPath = $gitGuard.HttpsHelperPath
+    GitHttpsHelperSha256 = $gitGuard.HttpsHelperSha256
+    GitCommonConfigSha256 = $gitGuard.CommonConfigSha256
+    GitMetadataCount = $gitGuard.MetadataCount
+    GitMetadataSha256 = $gitGuard.MetadataSha256
     SupabaseCliVersion = $version
     SupabaseCliLauncherSha256 = $launcherSha256
     SupabaseCliBinarySha256 = $binarySha256
@@ -2134,6 +3093,8 @@ function Assert-BinderRepositoryStateV1 {
   )
 
   $policy = Get-BinderRolloutPolicyV1
+  $gitGuard = Assert-BinderGitLocalConfigurationV1 `
+    -RepoRoot $RepoRoot
   Assert-BinderConditionV1 ($ExpectedHeadSha -cmatch '^[0-9a-f]{40}$') 'ExpectedHeadSha must be a lowercase 40-character commit SHA.'
 
   $status = Invoke-BinderGitV1 `
@@ -2149,6 +3110,69 @@ function Assert-BinderRepositoryStateV1 {
   $branch = Invoke-BinderGitV1 -Arguments @('branch', '--show-current') -RepoRoot $RepoRoot
   Assert-BinderCommandSucceededV1 -Result $branch -Label 'git branch --show-current'
   Assert-BinderConditionV1 ($branch.StdOut.Trim() -ceq 'main') 'Production rollout must run from the main branch.'
+
+  $rawOrigin = Invoke-BinderGitV1 `
+    -Arguments @('config', '--local', '--get-all', 'remote.origin.url') `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $rawOrigin `
+    -Label 'git raw origin URL'
+  $rawOriginUrls = @(
+    $rawOrigin.StdOut -split "`r?`n" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  Assert-BinderConditionV1 (
+    $rawOriginUrls.Count -eq 1 -and
+    $rawOriginUrls[0] -ceq $policy.CanonicalRemoteUrl
+  ) 'Git origin must contain exactly the canonical raw HTTPS URL.'
+
+  $pushUrl = Invoke-BinderGitV1 `
+    -Arguments @(
+      'config',
+      '--local',
+      '--get-all',
+      'remote.origin.pushurl'
+    ) `
+    -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 (
+    $pushUrl.ExitCode -eq 1 -and
+    -not $pushUrl.TimedOut -and
+    $pushUrl.TerminationConfirmed -and
+    $pushUrl.OutputCaptureCompleted -and
+    -not $pushUrl.OutputTruncated -and
+    [string]::IsNullOrWhiteSpace($pushUrl.StdOut) -and
+    [string]::IsNullOrWhiteSpace($pushUrl.StdErr)
+  ) 'Git origin must not define a distinct or explicit push URL.'
+
+  $effectiveOrigin = Invoke-BinderGitV1 `
+    -Arguments @('remote', 'get-url', '--all', 'origin') `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $effectiveOrigin `
+    -Label 'git effective origin URL'
+  $effectiveOriginUrls = @(
+    $effectiveOrigin.StdOut -split "`r?`n" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  Assert-BinderConditionV1 (
+    $effectiveOriginUrls.Count -eq 1 -and
+    $effectiveOriginUrls[0] -ceq $policy.CanonicalRemoteUrl
+  ) 'Git URL rewrite or multiple-origin ambiguity was detected.'
+
+  $effectivePush = Invoke-BinderGitV1 `
+    -Arguments @('remote', 'get-url', '--push', '--all', 'origin') `
+    -RepoRoot $RepoRoot
+  Assert-BinderCommandSucceededV1 `
+    -Result $effectivePush `
+    -Label 'git effective origin push URL'
+  $effectivePushUrls = @(
+    $effectivePush.StdOut -split "`r?`n" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  Assert-BinderConditionV1 (
+    $effectivePushUrls.Count -eq 1 -and
+    $effectivePushUrls[0] -ceq $policy.CanonicalRemoteUrl
+  ) 'Git push URL rewrite or multiple-push ambiguity was detected.'
 
   $remote = Invoke-BinderGitV1 `
     -Arguments @('ls-remote', 'origin', 'refs/heads/main') `
@@ -2168,6 +3192,9 @@ function Assert-BinderRepositoryStateV1 {
     OriginMainSha = $remoteSha
     Branch = 'main'
     Clean = $true
+    GitCommonConfigSha256 = $gitGuard.CommonConfigSha256
+    GitMetadataCount = $gitGuard.MetadataCount
+    GitMetadataSha256 = $gitGuard.MetadataSha256
   }
 }
 
@@ -2182,6 +3209,112 @@ function Assert-BinderNoRoutingOverridesV1 {
   Assert-BinderConditionV1 ($present.Count -eq 0) "Database routing overrides are forbidden for this rollout: $($present -join ', ')"
 }
 
+function Get-BinderLinkedSupabaseIdentityV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $linkedRefPath = Join-Path $RepoRoot 'supabase/.temp/project-ref'
+  $poolerPath = Join-Path $RepoRoot 'supabase/.temp/pooler-url'
+  $metadataPath = Join-Path (
+    $RepoRoot
+  ) 'supabase/.temp/linked-project.json'
+  foreach ($path in @($linkedRefPath, $poolerPath, $metadataPath)) {
+    Assert-BinderConditionV1 (
+      Test-Path -LiteralPath $path -PathType Leaf
+    ) "Required linked Supabase identity file is missing: $path"
+    $item = Get-Item -LiteralPath $path -Force
+    Assert-BinderConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "Linked Supabase identity must not be a reparse point: $path"
+  }
+
+  $linkedRefSha256 = Get-BinderSha256FileV1 -Path $linkedRefPath
+  $poolerSha256 = Get-BinderSha256FileV1 -Path $poolerPath
+  $metadataSha256 = Get-BinderSha256FileV1 -Path $metadataPath
+  Assert-BinderConditionV1 (
+    $linkedRefSha256 -ceq $policy.LinkedProjectRefSha256
+  ) 'Linked Supabase project-ref bytes differ from the reviewed identity.'
+  Assert-BinderConditionV1 (
+    $poolerSha256 -ceq $policy.LinkedPoolerUrlSha256
+  ) 'Linked Supabase pooler route bytes differ from the reviewed identity.'
+  Assert-BinderConditionV1 (
+    $metadataSha256 -ceq $policy.LinkedProjectMetadataSha256
+  ) 'Linked Supabase project metadata bytes differ from the reviewed identity.'
+
+  $linkedRef = Get-Content -LiteralPath $linkedRefPath -Raw
+  Assert-BinderConditionV1 (
+    $linkedRef -ceq $policy.ProjectRef
+  ) 'Linked Supabase project-ref content is not exact.'
+  $poolerText = Get-Content -LiteralPath $poolerPath -Raw
+  Assert-BinderConditionV1 (
+    $poolerText -ceq $policy.LinkedPoolerUrl -and
+    $poolerText -cnotmatch '[\x00-\x20\x7f]'
+  ) 'Linked Supabase pooler route is not the exact reviewed value.'
+  try {
+    $poolerUri = [uri]$poolerText
+  } catch {
+    throw 'Linked Supabase pooler route is not an absolute URI.'
+  }
+  Assert-BinderConditionV1 (
+    $poolerUri.IsAbsoluteUri -and
+    $poolerUri.Scheme -ceq 'postgresql' -and
+    $poolerUri.Host -ceq 'aws-1-us-east-2.pooler.supabase.com' -and
+    $poolerUri.Port -eq 5432 -and
+    $poolerUri.UserInfo -ceq "postgres.$($policy.ProjectRef)" -and
+    $poolerUri.AbsolutePath -ceq '/postgres' -and
+    [string]::IsNullOrWhiteSpace($poolerUri.Query) -and
+    [string]::IsNullOrWhiteSpace($poolerUri.Fragment)
+  ) 'Linked Supabase pooler route components are not exact.'
+
+  $metadata = ConvertFrom-BinderJsonWithExactStringPropertiesV1 `
+    -Json (Get-Content -LiteralPath $metadataPath -Raw) `
+    -StringProperties @(
+      'ref',
+      'name',
+      'organization_id',
+      'organization_slug'
+    )
+  $metadataProperties = @(
+    $metadata.PSObject.Properties.Name |
+      Sort-Object
+  )
+  $expectedMetadataProperties = @(
+    'name',
+    'organization_id',
+    'organization_slug',
+    'ref'
+  )
+  Assert-BinderConditionV1 (
+    ($metadataProperties -join "`n") -ceq
+      ($expectedMetadataProperties -join "`n")
+  ) 'Linked Supabase project metadata fields are not closed and exact.'
+  Assert-BinderConditionV1 (
+    $metadata.ref -ceq $policy.ProjectRef -and
+    $metadata.name -ceq $policy.LinkedProjectName -and
+    $metadata.organization_id -ceq
+      $policy.LinkedProjectOrganizationId -and
+    $metadata.organization_slug -ceq
+      $policy.LinkedProjectOrganizationSlug
+  ) 'Linked Supabase project metadata does not identify production.'
+
+  return [pscustomobject][ordered]@{
+    ProjectRef = $policy.ProjectRef
+    ProjectRefPath = [System.IO.Path]::GetFullPath($linkedRefPath)
+    ProjectRefSha256 = $linkedRefSha256
+    PoolerPath = [System.IO.Path]::GetFullPath($poolerPath)
+    PoolerSha256 = $poolerSha256
+    ProjectMetadataPath = [System.IO.Path]::GetFullPath($metadataPath)
+    ProjectMetadataSha256 = $metadataSha256
+    PoolerHost = $poolerUri.Host
+    PoolerPort = $poolerUri.Port
+  }
+}
+
 function Assert-ProjectBindingV1 {
   [CmdletBinding()]
   param(
@@ -2192,10 +3325,8 @@ function Assert-ProjectBindingV1 {
   $policy = Get-BinderRolloutPolicyV1
   Assert-BinderNoRoutingOverridesV1
 
-  $linkedRefPath = Join-Path $RepoRoot 'supabase/.temp/project-ref'
-  Assert-BinderConditionV1 (Test-Path -LiteralPath $linkedRefPath -PathType Leaf) 'This worktree is not explicitly linked; refusing to link automatically.'
-  $linkedRef = (Get-Content -LiteralPath $linkedRefPath -Raw).Trim()
-  Assert-BinderConditionV1 ($linkedRef -ceq $policy.ProjectRef) 'Linked Supabase project ref is not production.'
+  $linkedIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+    -RepoRoot $RepoRoot
 
   Assert-BinderConditionV1 (-not [string]::IsNullOrWhiteSpace($env:SUPABASE_URL)) 'SUPABASE_URL is required for independent project binding.'
   try {
@@ -2230,6 +3361,10 @@ function Assert-ProjectBindingV1 {
     ApiHost = $supabaseUri.Host
     DatabaseHost = $databaseHost
     Status = [string]$matches[0].status
+    LinkedProjectRefSha256 = $linkedIdentity.ProjectRefSha256
+    LinkedPoolerUrlSha256 = $linkedIdentity.PoolerSha256
+    LinkedProjectMetadataSha256 =
+      $linkedIdentity.ProjectMetadataSha256
   }
 }
 
@@ -2267,6 +3402,16 @@ function Test-BackupEvidenceV1 {
   $actualProperties = @($evidence.PSObject.Properties.Name | Sort-Object)
   $expectedProperties = @($allowedProperties | Sort-Object)
   Assert-BinderConditionV1 (($actualProperties -join "`n") -ceq ($expectedProperties -join "`n")) 'Backup evidence fields are missing or unexpected.'
+  Assert-BinderConditionV1 (
+    $evidence.schema_version -is [long] -and
+    $evidence.project_ref -is [string] -and
+    $evidence.backup_kind -is [string] -and
+    $evidence.verified_at_utc -is [string] -and
+    $evidence.recoverable_through_utc -is [string] -and
+    $evidence.evidence_reference -is [string] -and
+    $evidence.restore_path_reviewed -is [bool] -and
+    $evidence.operator -is [string]
+  ) 'Backup evidence primitive types are not exact JSON types.'
   Assert-BinderConditionV1 ($evidence.schema_version -eq 1) 'Backup evidence schema version mismatch.'
   Assert-BinderConditionV1 ($evidence.project_ref -ceq $policy.ProjectRef) 'Backup evidence project mismatch.'
   Assert-BinderConditionV1 (@('supabase_pitr', 'supabase_platform_backup', 'verified_logical_backup') -ccontains $evidence.backup_kind) 'Unsupported backup evidence kind.'
@@ -2303,13 +3448,30 @@ function Get-BinderWorktreePathsV1 {
     [string]$RepoRoot
   )
 
-  $result = Invoke-BinderGitV1 -Arguments @('worktree', 'list', '--porcelain') -RepoRoot $RepoRoot
+  [void](Assert-BinderGitLocalConfigurationV1 -RepoRoot $RepoRoot)
+  $result = Invoke-BinderGitV1 `
+    -Arguments @('worktree', 'list', '--porcelain', '-z') `
+    -RepoRoot $RepoRoot
   Assert-BinderCommandSucceededV1 -Result $result -Label 'git worktree list'
   return @(
-    foreach ($line in ($result.StdOut -split "`r?`n")) {
-      if ($line.StartsWith('worktree ')) {
-        [System.IO.Path]::GetFullPath($line.Substring(9).Trim()).TrimEnd('\', '/')
+    foreach ($record in ($result.StdOut -split "`0`0")) {
+      if ([string]::IsNullOrEmpty($record)) {
+        continue
       }
+      $fields = @($record -split "`0")
+      Assert-BinderConditionV1 (
+        $fields.Count -gt 0 -and
+        $fields[0].StartsWith(
+          'worktree ',
+          [System.StringComparison]::Ordinal
+        )
+      ) 'Git worktree porcelain record is malformed.'
+      $path = $fields[0].Substring(9)
+      Assert-BinderConditionV1 (
+        -not [string]::IsNullOrWhiteSpace($path) -and
+        $path -cnotmatch '[\x00-\x1f\x7f]'
+      ) 'Git worktree path contains a control character.'
+      [System.IO.Path]::GetFullPath($path).TrimEnd('\', '/')
     }
   )
 }
@@ -2683,11 +3845,18 @@ function Get-BinderSealedStageManifestV1 {
   ) 'Sealed staged Supabase config hash mismatch.'
   $projectRef = (
     Get-Content -LiteralPath $Stage.ProjectRefPath -Raw
-  ).Trim()
+  )
   $policy = Get-BinderRolloutPolicyV1
   Assert-BinderConditionV1 (
     $projectRef -ceq $policy.ProjectRef
   ) 'Sealed staged project ref changed.'
+  $linkedIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+    -RepoRoot $Stage.Root
+  $preflightSqlSha256 = Get-BinderSha256FileV1 `
+    -Path $Stage.PreflightSqlPath
+  Assert-BinderConditionV1 (
+    $preflightSqlSha256 -ceq $policy.PreflightSqlSha256
+  ) 'Sealed staged preflight SQL changed.'
 
   return [pscustomobject][ordered]@{
     schema_version = 1
@@ -2695,6 +3864,11 @@ function Get-BinderSealedStageManifestV1 {
     migration_set_sha256 = $setFingerprint
     config_sha256 = $configHash
     project_ref = $projectRef
+    project_ref_sha256 = $linkedIdentity.ProjectRefSha256
+    pooler_url_sha256 = $linkedIdentity.PoolerSha256
+    linked_project_metadata_sha256 =
+      $linkedIdentity.ProjectMetadataSha256
+    preflight_sql_sha256 = $preflightSqlSha256
     migrations = $sealedEntries
   }
 }
@@ -2802,6 +3976,9 @@ function New-BinderSupabaseStageV1 {
     MigrationEntries = @()
     ConfigPath = ''
     ProjectRefPath = ''
+    PoolerPath = ''
+    ProjectMetadataPath = ''
+    PreflightSqlPath = ''
     ExpectedConfigSha256 = ''
     SealedManifest = $null
   }
@@ -2815,10 +3992,19 @@ function New-BinderSupabaseStageV1 {
   try {
     [void][System.IO.Directory]::CreateDirectory($migrationDirectory)
     [void][System.IO.Directory]::CreateDirectory($tempDirectory)
+    $stagedSqlDirectory = Join-Path $stageRoot 'scripts/ops/sql'
+    [void][System.IO.Directory]::CreateDirectory($stagedSqlDirectory)
     [void](Assert-BinderSafeStageRootV1 -Path $stageRoot -MustExist $true)
 
     $sourceConfig = Join-Path $RepoRoot 'supabase/config.toml'
-    $sourceProjectRef = Join-Path $RepoRoot 'supabase/.temp/project-ref'
+    $sourceIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+      -RepoRoot $RepoRoot
+    $sourceProjectRef = $sourceIdentity.ProjectRefPath
+    $sourcePooler = $sourceIdentity.PoolerPath
+    $sourceProjectMetadata = $sourceIdentity.ProjectMetadataPath
+    $sourcePreflightSql = Join-Path (
+      $RepoRoot
+    ) $policy.PreflightSqlRelativePath
     Assert-BinderConditionV1 (
       Test-Path -LiteralPath $sourceConfig -PathType Leaf
     ) 'Supabase config is missing while staging.'
@@ -2827,17 +4013,50 @@ function New-BinderSupabaseStageV1 {
     ) 'Linked project ref is missing while staging.'
     $stagedConfig = Join-Path $stageRoot 'supabase/config.toml'
     $stagedProjectRef = Join-Path $tempDirectory 'project-ref'
+    $stagedPooler = Join-Path $tempDirectory 'pooler-url'
+    $stagedProjectMetadata = Join-Path (
+      $tempDirectory
+    ) 'linked-project.json'
+    $stagedPreflightSql = Join-Path (
+      $stageRoot
+    ) $policy.PreflightSqlRelativePath
     [System.IO.File]::Copy($sourceConfig, $stagedConfig, $false)
     [System.IO.File]::Copy($sourceProjectRef, $stagedProjectRef, $false)
+    [System.IO.File]::Copy($sourcePooler, $stagedPooler, $false)
+    [System.IO.File]::Copy(
+      $sourceProjectMetadata,
+      $stagedProjectMetadata,
+      $false
+    )
+    [System.IO.File]::Copy(
+      $sourcePreflightSql,
+      $stagedPreflightSql,
+      $false
+    )
     $sourceConfigHash = Get-BinderSha256FileV1 -Path $sourceConfig
     Assert-BinderConditionV1 (
       (Get-BinderSha256FileV1 -Path $stagedConfig) -ceq
         $sourceConfigHash
     ) 'Staged Supabase config hash mismatch.'
     Assert-BinderConditionV1 (
-      (Get-Content -LiteralPath $stagedProjectRef -Raw).Trim() -ceq
+      (Get-Content -LiteralPath $stagedProjectRef -Raw) -ceq
         $policy.ProjectRef
     ) 'Staged project ref is not production.'
+    $stagedIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+      -RepoRoot $stageRoot
+    Assert-BinderConditionV1 (
+      $stagedIdentity.ProjectRefSha256 -ceq
+        $sourceIdentity.ProjectRefSha256 -and
+      $stagedIdentity.PoolerSha256 -ceq
+        $sourceIdentity.PoolerSha256 -and
+      $stagedIdentity.ProjectMetadataSha256 -ceq
+        $sourceIdentity.ProjectMetadataSha256
+    ) 'Staged linked Supabase identity differs from its sealed source.'
+    Assert-BinderConditionV1 (
+      (Get-BinderSha256FileV1 -Path $stagedPreflightSql) -ceq
+        $policy.PreflightSqlSha256
+    ) 'Staged preflight readback SQL differs from reviewed bytes.'
+    Assert-BinderSqlReadOnlyV1 -Path $stagedPreflightSql
 
     $stagedEntries = [System.Collections.Generic.List[object]]::new()
     foreach ($entry in @($TrackedMigrationSet.Entries)) {
@@ -2897,7 +4116,13 @@ function New-BinderSupabaseStageV1 {
     $stage.Streams = $streams
     foreach ($path in @(
       @($stagedEntries | ForEach-Object FullPath) +
-      @($stagedConfig, $stagedProjectRef)
+      @(
+        $stagedConfig,
+        $stagedProjectRef,
+        $stagedPooler,
+        $stagedProjectMetadata,
+        $stagedPreflightSql
+      )
     )) {
       $item = Get-Item -LiteralPath $path
       Assert-BinderConditionV1 (
@@ -2918,6 +4143,9 @@ function New-BinderSupabaseStageV1 {
     $stage.MigrationEntries = $stagedEntries
     $stage.ConfigPath = $stagedConfig
     $stage.ProjectRefPath = $stagedProjectRef
+    $stage.PoolerPath = $stagedPooler
+    $stage.ProjectMetadataPath = $stagedProjectMetadata
+    $stage.PreflightSqlPath = $stagedPreflightSql
     $stage.ExpectedConfigSha256 = $sourceConfigHash
     $stage.SealedManifest = Get-BinderSealedStageManifestV1 -Stage $stage
     return $stage
@@ -3028,6 +4256,13 @@ function Invoke-BinderReadbackV1 {
     Assert-BinderConditionV1 ($rows.Count -eq 1) "$ExpectedState readback must return exactly one row."
     Assert-BinderConditionV1 ($null -ne $rows[0].rollout_readback) "$ExpectedState readback payload is missing."
     $report = $rows[0].rollout_readback
+    Assert-BinderConditionV1 (
+      $report.package_id -is [string] -and
+      $report.phase -is [string] -and
+      $report.read_only -is [bool] -and
+      $report.ok -is [bool] -and
+      $report.checks -is [pscustomobject]
+    ) "$ExpectedState readback header primitive types are invalid."
     Assert-BinderConditionV1 ($report.read_only -eq $true) "$ExpectedState readback did not identify itself as read-only."
     Assert-BinderConditionV1 ($report.ok -eq $true) "$ExpectedState readback failed its catalog contract."
 
@@ -3044,13 +4279,16 @@ function Invoke-BinderReadbackV1 {
 function Get-BinderDryRunV1 {
   param(
     [Parameter(Mandatory = $true)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [string]$ExecutablePath
   )
 
   $result = Invoke-BinderSupabaseV1 `
     -Arguments @('db', 'push', '--dry-run', '--linked', '--agent', 'no') `
     -RepoRoot $RepoRoot `
-    -TimeoutSeconds 120
+    -TimeoutSeconds 120 `
+    -ExecutablePath $ExecutablePath
   Assert-BinderCommandSucceededV1 -Result $result -Label 'linked migration dry-run'
   $parsed = ConvertFrom-SupabaseDryRunV1 -Text ($result.StdOut + "`n" + $result.StdErr)
   return [pscustomobject]@{
@@ -3107,6 +4345,13 @@ function Invoke-BinderProductionPreflightV1 {
   $policy = Get-BinderRolloutPolicyV1
   $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
   $repository = Assert-BinderRepositoryStateV1 -RepoRoot $RepoRoot -ExpectedHeadSha $ExpectedHeadSha
+  Assert-BinderConditionV1 (
+    $source.GitCommonConfigSha256 -ceq
+      $repository.GitCommonConfigSha256 -and
+    $source.GitMetadataCount -eq $repository.GitMetadataCount -and
+    $source.GitMetadataSha256 -ceq
+      $repository.GitMetadataSha256
+  ) 'Git metadata changed during production preflight.'
   $project = Assert-ProjectBindingV1 -RepoRoot $RepoRoot
   $backup = Test-BackupEvidenceV1 -Path $BackupEvidencePath -RepoRoot $RepoRoot
   $evidenceRoot = New-BinderArtifactRootV1 -Path $ArtifactRoot -RepoRoot $RepoRoot
@@ -3139,6 +4384,23 @@ function Invoke-BinderProductionPreflightV1 {
       package_manifest_file_sha256 = $source.PackageManifestFileSha256
       head_sha = $repository.HeadSha
       origin_main_sha = $repository.OriginMainSha
+      supabase_config_sha256 = $source.SupabaseConfigSha256
+      linked_project_ref_sha256 =
+        $project.LinkedProjectRefSha256
+      linked_pooler_url_sha256 =
+        $project.LinkedPoolerUrlSha256
+      linked_project_metadata_sha256 =
+        $project.LinkedProjectMetadataSha256
+      git_executable_path = $source.GitExecutablePath
+      git_executable_sha256 = $source.GitExecutableSha256
+      git_version = $source.GitVersion
+      git_exec_path = $source.GitExecPath
+      git_https_helper_path = $source.GitHttpsHelperPath
+      git_https_helper_sha256 = $source.GitHttpsHelperSha256
+      git_common_config_sha256 =
+        $repository.GitCommonConfigSha256
+      git_metadata_count = $repository.GitMetadataCount
+      git_metadata_sha256 = $repository.GitMetadataSha256
       supabase_cli_version = $source.SupabaseCliVersion
       supabase_cli_launcher_sha256 = $source.SupabaseCliLauncherSha256
       supabase_cli_binary_sha256 = $source.SupabaseCliBinarySha256
@@ -3243,6 +4505,134 @@ function Test-PreflightManifestV1 {
   $manifest = Read-BinderPreflightManifestV1 -Path $Path
   $data = $manifest.Data
 
+  $expectedProperties = @(
+    'apply_argv',
+    'backup_evidence_path',
+    'backup_evidence_sha256',
+    'created_at_utc',
+    'dry_run_files',
+    'expires_at_utc',
+    'git_common_config_sha256',
+    'git_exec_path',
+    'git_executable_path',
+    'git_executable_sha256',
+    'git_https_helper_path',
+    'git_https_helper_sha256',
+    'git_metadata_count',
+    'git_metadata_sha256',
+    'git_version',
+    'head_sha',
+    'linked_pooler_url_sha256',
+    'linked_project_metadata_sha256',
+    'linked_project_ref_sha256',
+    'manifest_fingerprint_sha256',
+    'migration_files',
+    'origin_main_sha',
+    'package_fingerprint_sha256',
+    'package_id',
+    'package_manifest_file_sha256',
+    'pending_versions',
+    'preapply_readback_sha256',
+    'project_ref',
+    'schema_version',
+    'stable_catalog_fingerprint_sha256',
+    'status',
+    'supabase_cli_binary_sha256',
+    'supabase_cli_launcher_sha256',
+    'supabase_cli_shim_descriptor_sha256',
+    'supabase_cli_version',
+    'supabase_config_sha256',
+    'tracked_migration_count',
+    'tracked_migration_set_sha256'
+  )
+  $actualProperties = @(
+    $data.PSObject.Properties.Name |
+      Sort-Object
+  )
+  Assert-BinderConditionV1 (
+    ($actualProperties -join "`n") -ceq
+      (($expectedProperties | Sort-Object) -join "`n")
+  ) 'Preflight manifest fields are missing or unexpected.'
+  Assert-BinderConditionV1 (
+    $data.schema_version -is [long]
+  ) 'Preflight manifest schema_version must be an integer.'
+  Assert-BinderConditionV1 (
+    $data.tracked_migration_count -is [long]
+  ) 'Preflight tracked_migration_count must be an integer.'
+  Assert-BinderConditionV1 (
+    $data.git_metadata_count -is [long]
+  ) 'Preflight git_metadata_count must be an integer.'
+  foreach ($name in @(
+    'backup_evidence_path',
+    'backup_evidence_sha256',
+    'created_at_utc',
+    'expires_at_utc',
+    'git_common_config_sha256',
+    'git_exec_path',
+    'git_executable_path',
+    'git_executable_sha256',
+    'git_https_helper_path',
+    'git_https_helper_sha256',
+    'git_metadata_sha256',
+    'git_version',
+    'head_sha',
+    'linked_pooler_url_sha256',
+    'linked_project_metadata_sha256',
+    'linked_project_ref_sha256',
+    'manifest_fingerprint_sha256',
+    'origin_main_sha',
+    'package_fingerprint_sha256',
+    'package_id',
+    'package_manifest_file_sha256',
+    'preapply_readback_sha256',
+    'project_ref',
+    'stable_catalog_fingerprint_sha256',
+    'status',
+    'supabase_cli_binary_sha256',
+    'supabase_cli_launcher_sha256',
+    'supabase_cli_shim_descriptor_sha256',
+    'supabase_cli_version',
+    'supabase_config_sha256',
+    'tracked_migration_set_sha256'
+  )) {
+    Assert-BinderConditionV1 (
+      $data.PSObject.Properties[$name].Value -is [string]
+    ) "Preflight manifest property must be a string: $name"
+  }
+  foreach ($name in @(
+    'apply_argv',
+    'dry_run_files',
+    'migration_files',
+    'pending_versions'
+  )) {
+    Assert-BinderConditionV1 (
+      $data.PSObject.Properties[$name].Value -is [object[]]
+    ) "Preflight manifest property must be an array: $name"
+  }
+  foreach ($value in @(
+    @($data.apply_argv) +
+    @($data.dry_run_files) +
+    @($data.pending_versions)
+  )) {
+    Assert-BinderConditionV1 (
+      $value -is [string]
+    ) 'Preflight command/version arrays may contain only strings.'
+  }
+  foreach ($migration in @($data.migration_files)) {
+    Assert-BinderConditionV1 (
+      $migration -is [pscustomobject]
+    ) 'Preflight migration entries must be JSON objects.'
+    Assert-BinderConditionV1 (
+      (
+        @($migration.PSObject.Properties.Name | Sort-Object) -join "`n"
+      ) -ceq "file`nsha256`nversion"
+    ) 'Preflight migration fields are not exact.'
+    foreach ($name in @('file', 'sha256', 'version')) {
+      Assert-BinderConditionV1 (
+        $migration.PSObject.Properties[$name].Value -is [string]
+      ) "Preflight migration property must be a string: $name"
+    }
+  }
   Assert-BinderConditionV1 ($data.schema_version -eq 1) 'Preflight manifest schema mismatch.'
   Assert-BinderConditionV1 ($data.package_id -ceq $policy.PackageId) 'Preflight package mismatch.'
   Assert-BinderConditionV1 ($data.status -ceq 'pass') 'Preflight status is not pass.'
@@ -3254,6 +4644,38 @@ function Test-PreflightManifestV1 {
   Assert-BinderConditionV1 ($data.supabase_cli_launcher_sha256 -ceq $policy.SupabaseCliLauncherSha256) 'Preflight CLI launcher hash mismatch.'
   Assert-BinderConditionV1 ($data.supabase_cli_binary_sha256 -ceq $policy.SupabaseCliBinarySha256) 'Preflight CLI binary hash mismatch.'
   Assert-BinderConditionV1 ($data.supabase_cli_shim_descriptor_sha256 -ceq $policy.SupabaseCliShimDescriptorSha256) 'Preflight CLI shim descriptor hash mismatch.'
+  Assert-BinderConditionV1 (
+    $data.supabase_config_sha256 -ceq
+      $policy.SupabaseConfigSha256
+  ) 'Preflight Supabase config hash mismatch.'
+  Assert-BinderConditionV1 (
+    $data.linked_project_ref_sha256 -ceq
+      $policy.LinkedProjectRefSha256
+  ) 'Preflight linked project-ref hash mismatch.'
+  Assert-BinderConditionV1 (
+    $data.linked_pooler_url_sha256 -ceq
+      $policy.LinkedPoolerUrlSha256
+  ) 'Preflight linked pooler-route hash mismatch.'
+  Assert-BinderConditionV1 (
+    $data.linked_project_metadata_sha256 -ceq
+      $policy.LinkedProjectMetadataSha256
+  ) 'Preflight linked project metadata hash mismatch.'
+  Assert-BinderConditionV1 (
+    $data.git_executable_path -ceq $policy.GitExecutablePath -and
+    $data.git_executable_sha256 -ceq
+      $policy.GitExecutableSha256 -and
+    $data.git_version -ceq $policy.GitVersion -and
+    $data.git_exec_path -ceq $policy.GitExecPath -and
+    $data.git_https_helper_path -ceq
+      $policy.GitHttpsHelperPath -and
+    $data.git_https_helper_sha256 -ceq
+      $policy.GitHttpsHelperSha256
+  ) 'Preflight Git executable identity mismatch.'
+  Assert-BinderConditionV1 (
+    $data.git_common_config_sha256 -cmatch '^[0-9a-f]{64}$' -and
+    $data.git_metadata_count -gt 0 -and
+    $data.git_metadata_sha256 -cmatch '^[0-9a-f]{64}$'
+  ) 'Preflight Git config/metadata identity is invalid.'
   Assert-BinderConditionV1 ((@($data.apply_argv) -join "`n") -ceq ($policy.ApplyArguments -join "`n")) 'Preflight apply argv drifted.'
   Assert-BinderConditionV1 ($data.stable_catalog_fingerprint_sha256 -cmatch '^[0-9a-f]{64}$') 'Stable catalog fingerprint is missing or invalid.'
   Assert-BinderConditionV1 ($data.tracked_migration_count -gt 0) 'Tracked migration count is invalid.'
@@ -3310,6 +4732,32 @@ function Open-BinderApplySealV1 {
   )
 
   $policy = Get-BinderRolloutPolicyV1
+  $gitGuard = Assert-BinderGitLocalConfigurationV1 `
+    -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 (
+    $gitGuard.ExecutableSha256 -ceq
+      [string]$PreflightManifest.git_executable_sha256 -and
+    $gitGuard.Version -ceq
+      [string]$PreflightManifest.git_version -and
+    $gitGuard.HttpsHelperSha256 -ceq
+      [string]$PreflightManifest.git_https_helper_sha256 -and
+    $gitGuard.CommonConfigSha256 -ceq
+      [string]$PreflightManifest.git_common_config_sha256 -and
+    $gitGuard.MetadataCount -eq
+      [long]$PreflightManifest.git_metadata_count -and
+    $gitGuard.MetadataSha256 -ceq
+      [string]$PreflightManifest.git_metadata_sha256
+  ) 'Git identity changed before the apply seal.'
+  $linkedIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+    -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 (
+    $linkedIdentity.ProjectRefSha256 -ceq
+      [string]$PreflightManifest.linked_project_ref_sha256 -and
+    $linkedIdentity.PoolerSha256 -ceq
+      [string]$PreflightManifest.linked_pooler_url_sha256 -and
+    $linkedIdentity.ProjectMetadataSha256 -ceq
+      [string]$PreflightManifest.linked_project_metadata_sha256
+  ) 'Linked Supabase identity changed before the apply seal.'
   $paths = [System.Collections.Generic.List[string]]::new()
   Assert-BinderConditionV1 (
     $TrackedMigrationSet.Count -eq $PreflightManifest.tracked_migration_count
@@ -3321,14 +4769,21 @@ function Open-BinderApplySealV1 {
   foreach ($migration in @($TrackedMigrationSet.Entries)) {
     $paths.Add([string]$migration.FullPath)
   }
+  foreach ($entry in @($gitGuard.Topology.Metadata)) {
+    $paths.Add([string]$entry.Path)
+  }
   foreach ($path in @(
     (Join-Path $RepoRoot 'supabase/config.toml'),
     (Join-Path $RepoRoot 'supabase/.temp/project-ref'),
+    (Join-Path $RepoRoot 'supabase/.temp/pooler-url'),
+    (Join-Path $RepoRoot 'supabase/.temp/linked-project.json'),
     (Join-Path $RepoRoot $policy.ManifestRelativePath),
     (Join-Path $RepoRoot $policy.PreflightSqlRelativePath),
     (Join-Path $RepoRoot $policy.PostApplySqlRelativePath),
     $SupabaseExecutable.LauncherPath,
     $SupabaseExecutable.BinaryPath,
+    $gitGuard.ExecutablePath,
+    $gitGuard.HttpsHelperPath,
     $PreflightManifestEnvelope.Path,
     (Join-Path (
       Split-Path -Parent $PreflightManifestEnvelope.Path
@@ -3365,6 +4820,25 @@ function Open-BinderApplySealV1 {
       )
       $streams.Add($stream)
     }
+    $freshGitGuard = Assert-BinderGitLocalConfigurationV1 `
+      -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 (
+      $freshGitGuard.CommonConfigSha256 -ceq
+        $gitGuard.CommonConfigSha256 -and
+      $freshGitGuard.MetadataCount -eq $gitGuard.MetadataCount -and
+      $freshGitGuard.MetadataSha256 -ceq
+        $gitGuard.MetadataSha256
+    ) 'Git metadata changed after apply seals were retained.'
+    $freshLinkedIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+      -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 (
+      $freshLinkedIdentity.ProjectRefSha256 -ceq
+        $linkedIdentity.ProjectRefSha256 -and
+      $freshLinkedIdentity.PoolerSha256 -ceq
+        $linkedIdentity.PoolerSha256 -and
+      $freshLinkedIdentity.ProjectMetadataSha256 -ceq
+        $linkedIdentity.ProjectMetadataSha256
+    ) 'Linked Supabase identity changed after apply seals were retained.'
     return @($streams)
   } catch {
     foreach ($stream in $streams) {
@@ -3398,6 +4872,13 @@ function Assert-BinderFinalLocalSealV1 {
   $policy = Get-BinderRolloutPolicyV1
   $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
   Assert-BinderConditionV1 ($source.PackageManifestFileSha256 -ceq $PreflightManifest.package_manifest_file_sha256) 'Package manifest changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.SupabaseConfigSha256 -ceq $PreflightManifest.supabase_config_sha256) 'Supabase config changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.GitExecutableSha256 -ceq $PreflightManifest.git_executable_sha256) 'Git executable changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.GitVersion -ceq $PreflightManifest.git_version) 'Git version changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.GitHttpsHelperSha256 -ceq $PreflightManifest.git_https_helper_sha256) 'Git HTTPS helper changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.GitCommonConfigSha256 -ceq $PreflightManifest.git_common_config_sha256) 'Git common config changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.GitMetadataCount -eq $PreflightManifest.git_metadata_count) 'Git metadata count changed at the final apply seal.'
+  Assert-BinderConditionV1 ($source.GitMetadataSha256 -ceq $PreflightManifest.git_metadata_sha256) 'Git metadata fingerprint changed at the final apply seal.'
   Assert-BinderConditionV1 ($source.SupabaseCliLauncherSha256 -ceq $PreflightManifest.supabase_cli_launcher_sha256) 'Supabase launcher changed at the final apply seal.'
   Assert-BinderConditionV1 ($source.SupabaseCliBinarySha256 -ceq $PreflightManifest.supabase_cli_binary_sha256) 'Supabase binary changed at the final apply seal.'
   Assert-BinderConditionV1 ($source.SupabaseCliShimDescriptorSha256 -ceq $PreflightManifest.supabase_cli_shim_descriptor_sha256) 'Supabase shim descriptor changed at the final apply seal.'
@@ -3414,15 +4895,150 @@ function Assert-BinderFinalLocalSealV1 {
   Assert-BinderCommandSucceededV1 -Result $head -Label 'final sealed HEAD'
   Assert-BinderConditionV1 ($head.StdOut.Trim() -ceq $PreflightManifest.head_sha) 'HEAD changed before the production push.'
 
-  $linkedRef = (
-    Get-Content -LiteralPath (
-      Join-Path $RepoRoot 'supabase/.temp/project-ref'
-    ) -Raw
-  ).Trim()
-  Assert-BinderConditionV1 ($linkedRef -ceq $policy.ProjectRef) 'Linked project changed before the production push.'
+  $linkedIdentity = Get-BinderLinkedSupabaseIdentityV1 `
+    -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 (
+    $linkedIdentity.ProjectRefSha256 -ceq
+      [string]$PreflightManifest.linked_project_ref_sha256 -and
+    $linkedIdentity.PoolerSha256 -ceq
+      [string]$PreflightManifest.linked_pooler_url_sha256 -and
+    $linkedIdentity.ProjectMetadataSha256 -ceq
+      [string]$PreflightManifest.linked_project_metadata_sha256
+  ) 'Linked Supabase identity changed before the production push.'
 
   $manifestFileHash = Get-BinderSha256FileV1 -Path $PreflightManifest.backup_evidence_path
   Assert-BinderConditionV1 ($manifestFileHash -ceq $PreflightManifest.backup_evidence_sha256) 'Backup evidence changed before the production push.'
+}
+
+function Assert-BinderFinalRemoteGateV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$FinalRemoteRepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SupabaseExecutablePath,
+
+    [Parameter(Mandatory = $true)]
+    [object]$PreflightManifestEnvelope,
+
+    [Parameter(Mandatory = $true)]
+    [object]$PreflightManifest,
+
+    [Parameter(Mandatory = $true)]
+    [bool]$ConfirmProduction,
+
+    [string]$MutationDeadlineUtc = '',
+
+    [string]$AuthorizationExpiresAtUtc = ''
+  )
+
+  $hasMutationDeadline = -not [string]::IsNullOrWhiteSpace(
+    $MutationDeadlineUtc
+  )
+  $hasAuthorizationExpiry = -not [string]::IsNullOrWhiteSpace(
+    $AuthorizationExpiresAtUtc
+  )
+  Assert-BinderConditionV1 (
+    $hasMutationDeadline -eq $hasAuthorizationExpiry
+  ) 'Mutation deadline and authorization expiry must be supplied together.'
+  $policy = Get-BinderRolloutPolicyV1
+  $freshEnvelope = Test-PreflightManifestV1 `
+    -Path $PreflightManifestEnvelope.Path
+  Assert-BinderConditionV1 (
+    $freshEnvelope.FingerprintSha256 -ceq
+      $PreflightManifestEnvelope.FingerprintSha256
+  ) 'Preflight manifest changed before the final remote gate.'
+  Assert-BinderConditionV1 (
+    [string]$freshEnvelope.Data.manifest_fingerprint_sha256 -ceq
+      [string]$PreflightManifest.manifest_fingerprint_sha256
+  ) 'Preflight authorization changed before the final remote gate.'
+
+  [void](Assert-BinderApplyAuthorizationV1 `
+    -PreflightManifest $freshEnvelope.Data `
+    -ConfirmProduction $ConfirmProduction)
+  [void](Assert-BinderRepositoryStateV1 `
+    -RepoRoot $RepoRoot `
+    -ExpectedHeadSha $freshEnvelope.Data.head_sha)
+  [void](Assert-ProjectBindingV1 -RepoRoot $RepoRoot)
+
+  $freshBackup = Test-BackupEvidenceV1 `
+    -Path $freshEnvelope.Data.backup_evidence_path `
+    -RepoRoot $RepoRoot
+  Assert-BinderConditionV1 (
+    $freshBackup.Sha256 -ceq
+      [string]$freshEnvelope.Data.backup_evidence_sha256
+  ) 'Backup evidence changed before the final remote gate.'
+
+  $freshDryRun = Get-BinderDryRunV1 `
+    -RepoRoot $FinalRemoteRepoRoot `
+    -ExecutablePath $SupabaseExecutablePath
+  Assert-BinderConditionV1 (
+    (
+      @($freshDryRun.Parsed.MigrationFiles) -join "`n"
+    ) -ceq
+      (@($freshEnvelope.Data.dry_run_files) -join "`n")
+  ) 'Final dry-run no longer identifies the exact five migrations.'
+  $freshLedger = Get-BinderLedgerV1 `
+    -RepoRoot $FinalRemoteRepoRoot `
+    -ExpectedState PreApply `
+    -ExecutablePath $SupabaseExecutablePath
+  Assert-BinderConditionV1 (
+    (
+      @($freshLedger.Ledger.LocalOnly | ForEach-Object Local) -join "`n"
+    ) -ceq
+      (@($freshEnvelope.Data.pending_versions) -join "`n")
+  ) 'Final migration ledger no longer has the exact five pending versions.'
+  $freshReadback = Invoke-BinderReadbackV1 `
+    -RepoRoot $FinalRemoteRepoRoot `
+    -ExpectedState PreApply `
+    -ExecutablePath $SupabaseExecutablePath
+  Assert-BinderConditionV1 (
+    $freshReadback.ReportSha256 -ceq
+      [string]$freshEnvelope.Data.preapply_readback_sha256 -and
+    [string]$freshReadback.Report.checks.stable_catalog_fingerprint_sha256 -ceq
+      [string]$freshEnvelope.Data.stable_catalog_fingerprint_sha256
+  ) 'Final pre-apply catalog/readback identity changed.'
+  $backupRecoverableThrough = ConvertTo-BinderUtcDateTimeV1 `
+    -Value $freshBackup.RecoverableThroughUtc `
+    -Label 'Fresh backup recovery horizon'
+  $effectiveNotAfter = [datetimeoffset](
+    $backupRecoverableThrough.AddMinutes(
+      $policy.BackupRecoveryLagMinutes
+    )
+  )
+  if ($hasMutationDeadline) {
+    $parsedMutationDeadline = ConvertTo-BinderStrictUtcDeadlineV1 `
+      -Value $MutationDeadlineUtc `
+      -Label 'Signed mutation deadline'
+    $parsedAuthorizationExpiry = ConvertTo-BinderStrictUtcDeadlineV1 `
+      -Value $AuthorizationExpiresAtUtc `
+      -Label 'Signed authorization expiry'
+    if ($parsedMutationDeadline -lt $effectiveNotAfter) {
+      $effectiveNotAfter = $parsedMutationDeadline
+    }
+    if ($parsedAuthorizationExpiry -lt $effectiveNotAfter) {
+      $effectiveNotAfter = $parsedAuthorizationExpiry
+    }
+  }
+  Assert-BinderConditionV1 (
+    [datetimeoffset]::UtcNow -lt $effectiveNotAfter
+  ) 'Production mutation authority expired at the final remote gate.'
+  $effectiveNotAfterText = $effectiveNotAfter.UtcDateTime.ToString(
+    "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'",
+    [cultureinfo]::InvariantCulture
+  )
+  return [pscustomobject][ordered]@{
+    PreflightManifestFingerprintSha256 =
+      $freshEnvelope.FingerprintSha256
+    BackupEvidenceSha256 = $freshBackup.Sha256
+    PreApplyReadbackSha256 = $freshReadback.ReportSha256
+    DryRunFileCount = @($freshDryRun.Parsed.MigrationFiles).Count
+    NotAfterUtc = $effectiveNotAfterText
+    CheckedAtUtc = [datetime]::UtcNow.ToString('o')
+  }
 }
 
 function Invoke-BinderProductionApplyV1 {
@@ -3434,10 +5050,35 @@ function Invoke-BinderProductionApplyV1 {
     [Parameter(Mandatory = $true)]
     [bool]$ConfirmProduction,
 
+    [string]$MutationDeadlineUtc = '',
+
+    [string]$AuthorizationExpiresAtUtc = '',
+
     [string]$RepoRoot = (Get-BinderRepoRootV1)
   )
 
   $policy = Get-BinderRolloutPolicyV1
+  $hasMutationDeadline = -not [string]::IsNullOrWhiteSpace(
+    $MutationDeadlineUtc
+  )
+  $hasAuthorizationExpiry = -not [string]::IsNullOrWhiteSpace(
+    $AuthorizationExpiresAtUtc
+  )
+  Assert-BinderConditionV1 (
+    $hasMutationDeadline -eq $hasAuthorizationExpiry
+  ) 'Mutation deadline and authorization expiry must be supplied together.'
+  if ($hasMutationDeadline) {
+    $parsedMutationDeadline = ConvertTo-BinderStrictUtcDeadlineV1 `
+      -Value $MutationDeadlineUtc `
+      -Label 'Signed mutation deadline'
+    $parsedAuthorizationExpiry = ConvertTo-BinderStrictUtcDeadlineV1 `
+      -Value $AuthorizationExpiresAtUtc `
+      -Label 'Signed authorization expiry'
+    Assert-BinderConditionV1 (
+      [datetimeoffset]::UtcNow -lt $parsedMutationDeadline -and
+      [datetimeoffset]::UtcNow -lt $parsedAuthorizationExpiry
+    ) 'Signed production mutation authority has expired.'
+  }
   $manifestEnvelope = Test-PreflightManifestV1 -Path $ManifestPath
   $manifest = $manifestEnvelope.Data
   if (-not $PSCmdlet.ShouldProcess(
@@ -3503,13 +5144,28 @@ function Invoke-BinderProductionApplyV1 {
   try {
     $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
     Assert-BinderConditionV1 ($source.PackageManifestFileSha256 -ceq $manifest.package_manifest_file_sha256) 'Package manifest bytes changed after preflight.'
+    Assert-BinderConditionV1 ($source.SupabaseConfigSha256 -ceq $manifest.supabase_config_sha256) 'Supabase config changed after preflight.'
+    Assert-BinderConditionV1 ($source.GitExecutableSha256 -ceq $manifest.git_executable_sha256) 'Git executable changed after preflight.'
+    Assert-BinderConditionV1 ($source.GitVersion -ceq $manifest.git_version) 'Git version changed after preflight.'
+    Assert-BinderConditionV1 ($source.GitHttpsHelperSha256 -ceq $manifest.git_https_helper_sha256) 'Git HTTPS helper changed after preflight.'
+    Assert-BinderConditionV1 ($source.GitCommonConfigSha256 -ceq $manifest.git_common_config_sha256) 'Git common config changed after preflight.'
+    Assert-BinderConditionV1 ($source.GitMetadataCount -eq $manifest.git_metadata_count) 'Git metadata count changed after preflight.'
+    Assert-BinderConditionV1 ($source.GitMetadataSha256 -ceq $manifest.git_metadata_sha256) 'Git metadata changed after preflight.'
     Assert-BinderConditionV1 ($source.SupabaseCliLauncherSha256 -ceq $manifest.supabase_cli_launcher_sha256) 'Supabase CLI launcher changed after preflight.'
     Assert-BinderConditionV1 ($source.SupabaseCliBinarySha256 -ceq $manifest.supabase_cli_binary_sha256) 'Supabase CLI binary changed after preflight.'
     Assert-BinderConditionV1 ($source.SupabaseCliShimDescriptorSha256 -ceq $manifest.supabase_cli_shim_descriptor_sha256) 'Supabase CLI shim descriptor changed after preflight.'
     Assert-BinderConditionV1 ($source.TrackedMigrationCount -eq $manifest.tracked_migration_count) 'Tracked migration count changed after preflight.'
     Assert-BinderConditionV1 ($source.TrackedMigrationSetSha256 -ceq $manifest.tracked_migration_set_sha256) 'Tracked migration-set fingerprint changed after preflight.'
     [void](Assert-BinderRepositoryStateV1 -RepoRoot $RepoRoot -ExpectedHeadSha $manifest.head_sha)
-    [void](Assert-ProjectBindingV1 -RepoRoot $RepoRoot)
+    $projectBinding = Assert-ProjectBindingV1 -RepoRoot $RepoRoot
+    Assert-BinderConditionV1 (
+      $projectBinding.LinkedProjectRefSha256 -ceq
+        [string]$manifest.linked_project_ref_sha256 -and
+      $projectBinding.LinkedPoolerUrlSha256 -ceq
+        [string]$manifest.linked_pooler_url_sha256 -and
+      $projectBinding.LinkedProjectMetadataSha256 -ceq
+        [string]$manifest.linked_project_metadata_sha256
+    ) 'Linked Supabase identity changed after preflight.'
 
     $backup = Test-BackupEvidenceV1 -Path $manifest.backup_evidence_path -RepoRoot $RepoRoot
     Assert-BinderConditionV1 ($backup.Sha256 -ceq $manifest.backup_evidence_sha256) 'Backup evidence changed after preflight.'
@@ -3557,13 +5213,32 @@ function Invoke-BinderProductionApplyV1 {
       Write-BinderJsonV1 `
         -Path (Join-Path $applyRoot 'sealed-source-manifest.json') `
         -Value $stage.SealedManifest
+      $finalRemoteGate = Assert-BinderFinalRemoteGateV1 `
+        -RepoRoot $RepoRoot `
+        -FinalRemoteRepoRoot $stage.Root `
+        -SupabaseExecutablePath $supabaseExecutable.BinaryPath `
+        -PreflightManifestEnvelope $manifestEnvelope `
+        -PreflightManifest $manifest `
+        -ConfirmProduction $ConfirmProduction `
+        -MutationDeadlineUtc $MutationDeadlineUtc `
+        -AuthorizationExpiresAtUtc $AuthorizationExpiresAtUtc
+      Write-BinderJsonV1 `
+        -Path (Join-Path $applyRoot 'final-remote-gate.json') `
+        -Value $finalRemoteGate
+      $pushNotAfter = ConvertTo-BinderStrictUtcDeadlineV1 `
+        -Value ([string]$finalRemoteGate.NotAfterUtc) `
+        -Label 'Final production child-start deadline'
+      Assert-BinderConditionV1 (
+        [datetimeoffset]::UtcNow -lt $pushNotAfter
+      ) 'Production mutation authority expired after final-gate evidence.'
       $pushAttempted = $true
       $push = Invoke-BinderSupabaseV1 `
         -Arguments @($plan[0].Arguments) `
         -RepoRoot $stage.Root `
         -TimeoutSeconds 900 `
         -ProcessLifecycle $pushLifecycle `
-        -ExecutablePath $supabaseExecutable.BinaryPath
+        -ExecutablePath $supabaseExecutable.BinaryPath `
+        -NotAfterUtc ([string]$finalRemoteGate.NotAfterUtc)
       $pushSucceeded = (
         $push.Started -eq $true -and
         $push.TerminationConfirmed -eq $true -and
@@ -3811,6 +5486,43 @@ function Invoke-BinderProductionApplyV1 {
   }
 }
 
+function Invoke-BinderPhysicalBackupListV1 {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Get-BinderRepoRootV1)
+  )
+
+  $policy = Get-BinderRolloutPolicyV1
+  $supabaseExecutable = Get-BinderSupabaseExecutableV1
+  $result = Invoke-BinderSupabaseV1 `
+    -Arguments @(
+      'backups',
+      'list',
+      '--project-ref',
+      $policy.ProjectRef,
+      '--output',
+      'json',
+      '--agent',
+      'no'
+    ) `
+    -RepoRoot $RepoRoot `
+    -TimeoutSeconds 60 `
+    -ExecutablePath $supabaseExecutable.BinaryPath
+  Assert-BinderCommandSucceededV1 `
+    -Result $result `
+    -Label 'Supabase physical-backup listing'
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    ProjectRef = $policy.ProjectRef
+    StdOut = $result.StdOut
+    StdErr = $result.StdErr
+    ExitCode = $result.ExitCode
+    TimedOut = $result.TimedOut
+    ProcessTreeTerminationConfirmed = $result.TerminationConfirmed
+    OutputTruncated = $result.OutputTruncated
+  }
+}
+
 Export-ModuleMember -Function @(
   'Get-BinderRolloutPolicyV1',
   'Get-CanonicalSha256V1',
@@ -3818,12 +5530,16 @@ Export-ModuleMember -Function @(
   'ConvertFrom-SupabaseMigrationListV1',
   'ConvertFrom-SupabaseDryRunV1',
   'Assert-ExactBinderPendingSetV1',
+  'Assert-BinderRepositoryStateV1',
   'Assert-ProjectBindingV1',
   'Test-BackupEvidenceV1',
   'Test-PreflightManifestV1',
   'Assert-BinderApplyAuthorizationV1',
   'Test-BinderSourceV1',
+  'Open-BinderGitMetadataSealV1',
   'Invoke-BinderReadbackV1',
+  'Get-BinderWorktreePathsV1',
+  'Invoke-BinderPhysicalBackupListV1',
   'Invoke-BinderProductionPreflightV1',
   'Invoke-BinderProductionApplyV1'
 )

--- a/scripts/ops/CollaborativeBindersUnattendedSupervisorV1.psm1
+++ b/scripts/ops/CollaborativeBindersUnattendedSupervisorV1.psm1
@@ -1,0 +1,5007 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:BinderSupervisorPackageFingerprintV1 =
+  '14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9'
+$script:BinderSupervisorStableCatalogFingerprintV1 =
+  'c9921f9eb36a7633620f46c495aa48f868f0b1eedbb9dda028cff0bba52f6f38'
+
+function Stop-BinderUnattendedV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet(
+      'safe_stop_pre_mutation',
+      'local_integrity_stop',
+      'mutation_possible_stop'
+    )]
+    [string]$ExitClass,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  $exception = [System.InvalidOperationException]::new($Message)
+  $exception.Data['BinderSupervisorExitClass'] = $ExitClass
+  throw $exception
+}
+
+function Assert-BinderUnattendedConditionV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$Condition,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+
+    [ValidateSet(
+      'safe_stop_pre_mutation',
+      'local_integrity_stop',
+      'mutation_possible_stop'
+    )]
+    [string]$ExitClass = 'local_integrity_stop'
+  )
+
+  if (-not $Condition) {
+    Stop-BinderUnattendedV1 -ExitClass $ExitClass -Message $Message
+  }
+}
+
+function Get-BinderUnattendedPolicyV1 {
+  [CmdletBinding()]
+  param()
+
+  $localAppData = [Environment]::GetFolderPath(
+    [Environment+SpecialFolder]::LocalApplicationData
+  )
+  Assert-BinderUnattendedConditionV1 (
+    -not [string]::IsNullOrWhiteSpace($localAppData)
+  ) 'Windows LocalApplicationData could not be resolved.'
+  $baseNamespace = Join-Path $localAppData 'GrookaiVaultSecureOps'
+  $secureNamespace = Join-Path $baseNamespace 'CollaborativeBindersV1'
+  $stateNamespace = Join-Path $secureNamespace 'state'
+  $stateIdentity = (
+    'ycdxbpibncqcchqiihfz--COLLABORATIVE-BINDERS-DB-V1--' +
+    $script:BinderSupervisorPackageFingerprintV1
+  )
+
+  return [pscustomobject][ordered]@{
+    SchemaVersion = 1
+    PackageId = 'COLLABORATIVE-BINDERS-DB-V1'
+    PackageFingerprintSha256 = $script:BinderSupervisorPackageFingerprintV1
+    PackageManifestSha256 =
+      '2e5458ba2d8161d963f561066f1e745586ebfb9e1296e695f1fbf60c6cc03a90'
+    TrackedMigrationCount = 294
+    TrackedMigrationSetSha256 =
+      '19226d5ea43c8dce5173aa12bb0a2aff8b184b3c9080a181955f9cbc23f5c2f3'
+    ProjectRef = 'ycdxbpibncqcchqiihfz'
+    ProjectUrl = 'https://ycdxbpibncqcchqiihfz.supabase.co'
+    CanonicalRepository = 'OriginalSoseji/grookai_vault'
+    CanonicalRemoteUrl =
+      'https://github.com/OriginalSoseji/grookai_vault.git'
+    GitExecutablePath =
+      'C:\Program Files\Git\mingw64\bin\git.exe'
+    GitExecutableSha256 =
+      '755d4896d35663d0ff08924f84507f35236b83d240635b512c519bf43cc71a87'
+    GitVersion = 'git version 2.51.0.windows.1'
+    GitExecPath =
+      'C:\Program Files\Git\mingw64\libexec\git-core'
+    GitHttpsHelperPath =
+      'C:\Program Files\Git\mingw64\libexec\git-core\git-remote-https.exe'
+    GitHttpsHelperSha256 =
+      '0a5b9d55a338d202f88044c36fe0feb76cb57b68a4176798a80edacc706a34b8'
+    SupabaseConfigSha256 =
+      'd7ed1face7c1d1fbc70d35393ae3a42268e27886bd0e15d0b96bc1af439b1567'
+    LinkedProjectRefSha256 =
+      'caf1b086f20f10f60aa27783311afb3466ef31390aba80a00206730ff233d40f'
+    LinkedPoolerUrlSha256 =
+      'd3609ad1cb525989b2fdbe7f0f25b7fff26fac19c72e2759893de1998a5295c1'
+    LinkedProjectMetadataSha256 =
+      'f86521274b66370ec59227b2a5906f8bcb4499658b54306b50427196ff60e8ed'
+    StableCatalogFingerprintSha256 =
+      $script:BinderSupervisorStableCatalogFingerprintV1
+    SupportedSupabaseCliVersion = '2.90.0'
+    SupabaseCliLauncherSha256 =
+      '140e3801d8adeda639a21b14e62b93a4c7d26b7a758421f43c82be59753be49b'
+    SupabaseCliBinarySha256 =
+      '31c2a25bd590a36ad803a7c669cf76a62eac3cd5aa7112eeb2e1c5f308c8b39c'
+    SupabaseCliShimDescriptorSha256 =
+      '0c68f69a367b2b76e61f3e71fb98c9a867143628a361a2e715dd30f33c4b2c3f'
+    RolloutModuleRelativePath =
+      'scripts/ops/CollaborativeBindersProductionRolloutV1.psm1'
+    SupervisorModuleRelativePath =
+      'scripts/ops/CollaborativeBindersUnattendedSupervisorV1.psm1'
+    SupervisorEntrypointRelativePath =
+      'scripts/ops/collaborative_binders_unattended_supervisor_v1.ps1'
+    PreflightEntrypointRelativePath =
+      'scripts/ops/collaborative_binders_production_preflight_v1.ps1'
+    ApplyEntrypointRelativePath =
+      'scripts/ops/collaborative_binders_production_apply_v1.ps1'
+    PackageManifestRelativePath =
+      'scripts/ops/collaborative_binders_production_manifest_v1.json'
+    PreflightSqlRelativePath =
+      'scripts/ops/sql/collaborative_binders_production_preflight_v1.sql'
+    PostApplySqlRelativePath =
+      'scripts/ops/sql/collaborative_binders_production_post_apply_v1.sql'
+    RestoreProcedureRelativePath =
+      'docs/runbooks/SUPABASE_PLATFORM_BACKUP_RESTORE_PROCEDURE_V1.md'
+    RestoreProcedureUri =
+      'repo:///docs/runbooks/SUPABASE_PLATFORM_BACKUP_RESTORE_PROCEDURE_V1.md'
+    PreflightSqlSha256 =
+      '268458ed8a4a16dc513b55b6d0e5b3b03c301320e55a9ab4887a135c7652800d'
+    PostApplySqlSha256 =
+      '5125b0d89f5b3d36c66f98863f0b69b9c6df55561dfb54303437d47d8731f1a1'
+    BaseNamespaceRoot = $baseNamespace
+    SecureNamespaceRoot = $secureNamespace
+    StateNamespaceRoot = $stateNamespace
+    StateRoot = Join-Path $stateNamespace $stateIdentity
+    ArtifactNamespaceRoot = Join-Path $secureNamespace 'artifacts'
+    MutexName =
+      'Global\GrookaiVault.CollaborativeBinders.DBV1.ycdxbpibncqcchqiihfz'
+    AttemptClaimFileName = 'UNATTENDED_ATTEMPT_CLAIMED'
+    MutationClaimFileName = 'MUTATION_LAUNCH_COMMITTED'
+    BackupListArguments = @(
+      'backups',
+      'list',
+      '--project-ref',
+      'ycdxbpibncqcchqiihfz',
+      '--output',
+      'json',
+      '--agent',
+      'no'
+    )
+    ApplyArguments = @('db', 'push', '--linked', '--yes')
+    BackupPollSeconds = 60
+    BackupConfirmationSeconds = 30
+    BackupMaximumAgeMinutes = 5
+    BackupNotBeforeUtc = '2026-07-24T10:25:37.891Z'
+    BackupExpectedRegion = 'us-east-2'
+    BackupExpectedPitrEnabled = $false
+    BackupExpectedWalgEnabled = $true
+    BackupGuardMaximumAgeMinutes = 15
+    BackupApplyReserveMinutes = 5
+    AuthorizationMaximumHours = 36
+    Migrations = @(
+      [pscustomobject][ordered]@{
+        version = '20260723100000'
+        file = '20260723100000_collaborative_binders_schema_v1.sql'
+        sha256 =
+          '7e83ab8bb83e5b938fbec758b21f8cae2b4a71427a6600c54c5f773c974bae33'
+      },
+      [pscustomobject][ordered]@{
+        version = '20260723101000'
+        file = '20260723101000_collaborative_binders_core_rpcs_v1.sql'
+        sha256 =
+          'eb9ca9898bca12b127f4b79aff9df81259efe74fa1029487ea133e94e8a67a7d'
+      },
+      [pscustomobject][ordered]@{
+        version = '20260723102000'
+        file = '20260723102000_collaborative_binders_collaboration_rpcs_v1.sql'
+        sha256 =
+          '680580044161936c8a382e5209e2cc54369943e13f1a3ae2ed41c299532cf3bf'
+      },
+      [pscustomobject][ordered]@{
+        version = '20260723103000'
+        file = '20260723103000_collaborative_binders_read_rpcs_v1.sql'
+        sha256 =
+          '73dab7009f059267dcc571fcb6ec79cffdb23b728fc5bf04cd81397a06bcd6fb'
+      },
+      [pscustomobject][ordered]@{
+        version = '20260723104000'
+        file = '20260723104000_collaborative_binders_service_rpcs_v1.sql'
+        sha256 =
+          '2edbef712d6b228c73b504498a6aa09f5bac440cfef96319d5c75f65e12d2997'
+      }
+    )
+    FeatureFlags = @(
+      'schema_internal',
+      'personal',
+      'set_binders',
+      'custom',
+      'shared',
+      'view_links',
+      'public',
+      'community',
+      'templates',
+      'notifications',
+      'pulse_milestones'
+    )
+    ExcludedFlags = @(
+      'set_binders',
+      'notifications',
+      'pulse_milestones'
+    )
+    ExpectedPreApply = [pscustomobject][ordered]@{
+      binder_relation_collision_count = 0
+      binder_type_collision_count = 0
+      binder_function_count = 0
+      applied_package_migration_count = 0
+      binder_realtime_object_exists = $false
+      binder_card_event_data_exists = $false
+      binder_trust_report_data_exists = $false
+      wrapped_pulse_function_exists = $false
+    }
+    PreflightArtifacts = @(
+      'approval.txt',
+      'backup-evidence.digest.json',
+      'dry-run.parsed.json',
+      'dry-run.stderr.txt',
+      'dry-run.stdout.txt',
+      'ledger.before.json',
+      'ledger.before.txt',
+      'preflight-manifest.json',
+      'preflight-manifest.sha256',
+      'project-binding.json',
+      'readback.before.json',
+      'repository.json',
+      'source.json'
+    )
+  }
+}
+
+function Get-BinderUnattendedRepoRootV1 {
+  return [System.IO.Path]::GetFullPath(
+    (Join-Path $PSScriptRoot '..\..')
+  )
+}
+
+function Get-BinderUnattendedSha256BytesV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [byte[]]$Bytes
+  )
+
+  return [Convert]::ToHexString(
+    [System.Security.Cryptography.SHA256]::HashData($Bytes)
+  ).ToLowerInvariant()
+}
+
+function Get-BinderUnattendedSha256FileV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $stream = [System.IO.File]::Open(
+    [System.IO.Path]::GetFullPath($Path),
+    [System.IO.FileMode]::Open,
+    [System.IO.FileAccess]::Read,
+    [System.IO.FileShare]::Read
+  )
+  try {
+    return [Convert]::ToHexString(
+      [System.Security.Cryptography.SHA256]::HashData($stream)
+    ).ToLowerInvariant()
+  } finally {
+    $stream.Dispose()
+  }
+}
+
+function ConvertTo-BinderUnattendedUtcV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Value,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $Value -cmatch
+      '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,7})?(?:Z|[+-]\d{2}:\d{2})$'
+  ) "$Label must be an explicit ISO-8601 timestamp with a UTC designator or offset."
+  $parsed = [datetimeoffset]::MinValue
+  $styles = (
+    [System.Globalization.DateTimeStyles]::AllowWhiteSpaces -bor
+    [System.Globalization.DateTimeStyles]::AdjustToUniversal
+  )
+  $valid = [datetimeoffset]::TryParse(
+    $Value,
+    [cultureinfo]::InvariantCulture,
+    $styles,
+    [ref]$parsed
+  )
+  Assert-BinderUnattendedConditionV1 $valid "$Label is not a valid timestamp."
+  return $parsed.ToUniversalTime()
+}
+
+function Get-BinderUnattendedJsonObjectPropertiesV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$ExpectedNames,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Object
+  ) "$Label must be a JSON object."
+  $properties = @($Element.EnumerateObject())
+  $seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  $seenCaseFolded = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  foreach ($property in $properties) {
+    Assert-BinderUnattendedConditionV1 (
+      -not [regex]::IsMatch($property.Name, '[\x00-\x1f\x7f]')
+    ) "$Label contains a control character in a JSON field name."
+    Assert-BinderUnattendedConditionV1 (
+      $seen.Add($property.Name)
+    ) "$Label contains a duplicate JSON field: $($property.Name)"
+    Assert-BinderUnattendedConditionV1 (
+      $seenCaseFolded.Add($property.Name)
+    ) "$Label contains a duplicate or case-colliding JSON field: $($property.Name)"
+  }
+  $actualNames = @($properties | ForEach-Object Name)
+  Assert-BinderUnattendedConditionV1 (
+    $actualNames.Count -eq $ExpectedNames.Count
+  ) "$Label field count does not match the closed V1 schema."
+  for ($index = 0; $index -lt $ExpectedNames.Count; $index += 1) {
+    Assert-BinderUnattendedConditionV1 (
+      $actualNames[$index] -ceq $ExpectedNames[$index]
+    ) "$Label field order does not match the closed V1 schema."
+  }
+  return $properties
+}
+
+function Get-BinderUnattendedJsonStringV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $value = [System.Text.Json.JsonElement]::new()
+  Assert-BinderUnattendedConditionV1 (
+    $Element.TryGetProperty($Name, [ref]$value)
+  ) "$Label is missing $Name."
+  Assert-BinderUnattendedConditionV1 (
+    $value.ValueKind -eq [System.Text.Json.JsonValueKind]::String
+  ) "$Label.$Name must be a string."
+  return $value.GetString()
+}
+
+function Get-BinderUnattendedJsonBooleanV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $value = [System.Text.Json.JsonElement]::new()
+  Assert-BinderUnattendedConditionV1 (
+    $Element.TryGetProperty($Name, [ref]$value)
+  ) "$Label is missing $Name."
+  Assert-BinderUnattendedConditionV1 (
+    $value.ValueKind -eq [System.Text.Json.JsonValueKind]::True -or
+    $value.ValueKind -eq [System.Text.Json.JsonValueKind]::False
+  ) "$Label.$Name must be a boolean."
+  return $value.GetBoolean()
+}
+
+function Get-BinderUnattendedJsonInt32V1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $value = [System.Text.Json.JsonElement]::new()
+  $parsed = 0
+  Assert-BinderUnattendedConditionV1 (
+    $Element.TryGetProperty($Name, [ref]$value) -and
+    $value.ValueKind -eq [System.Text.Json.JsonValueKind]::Number -and
+    $value.TryGetInt32([ref]$parsed)
+  ) "$Label.$Name must be a 32-bit integer."
+  return $parsed
+}
+
+function ConvertFrom-BinderUnattendedJsonStringArrayV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $value = [System.Text.Json.JsonElement]::new()
+  Assert-BinderUnattendedConditionV1 (
+    $Element.TryGetProperty($Name, [ref]$value) -and
+    $value.ValueKind -eq [System.Text.Json.JsonValueKind]::Array
+  ) "$Label.$Name must be an array."
+  return @(
+    foreach ($entry in $value.EnumerateArray()) {
+      Assert-BinderUnattendedConditionV1 (
+        $entry.ValueKind -eq [System.Text.Json.JsonValueKind]::String
+      ) "$Label.$Name must contain only strings."
+      $entry.GetString()
+    }
+  )
+}
+
+function Get-BinderUnattendedAuthorizationPropertyOrderV1 {
+  return @(
+    'schema_version',
+    'authorization_id',
+    'issued_at_utc',
+    'not_before_utc',
+    'backup_poll_deadline_utc',
+    'mutation_deadline_utc',
+    'expires_at_utc',
+    'operator',
+    'reviewer',
+    'restore_path_reviewed',
+    'restore_procedure_uri',
+    'restore_procedure_sha256',
+    'state_root',
+    'artifact_root',
+    'project_ref',
+    'project_url',
+    'canonical_repository',
+    'canonical_remote_url',
+    'supabase_config_sha256',
+    'linked_project_ref_sha256',
+    'linked_pooler_url_sha256',
+    'linked_project_metadata_sha256',
+    'git_executable_path',
+    'git_executable_sha256',
+    'git_version',
+    'git_exec_path',
+    'git_https_helper_path',
+    'git_https_helper_sha256',
+    'git_common_config_sha256',
+    'git_metadata_count',
+    'git_metadata_sha256',
+    'reviewed_main_sha',
+    'package_id',
+    'package_fingerprint_sha256',
+    'package_manifest_sha256',
+    'tracked_migration_count',
+    'tracked_migration_set_sha256',
+    'supervisor_module_sha256',
+    'supervisor_entrypoint_sha256',
+    'rollout_module_sha256',
+    'preflight_entrypoint_sha256',
+    'apply_entrypoint_sha256',
+    'preflight_sql_sha256',
+    'post_apply_sql_sha256',
+    'supabase_cli_version',
+    'supabase_cli_launcher_sha256',
+    'supabase_cli_binary_sha256',
+    'supabase_cli_shim_descriptor_sha256',
+    'backup_source',
+    'backup_not_before_utc',
+    'stable_catalog_fingerprint_sha256',
+    'migrations',
+    'apply_argv',
+    'feature_flags_must_remain_disabled',
+    'excluded_from_rollout',
+    'expected_preapply',
+    'p8_excluded',
+    'activation_allowed',
+    'deployment_allowed',
+    'migration_repair_allowed',
+    'one_attempt_only',
+    'automatic_retry_allowed'
+  )
+}
+
+function Assert-BinderUnattendedScalarStringV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Value,
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+    [int]$MaximumLength = 512
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    -not [string]::IsNullOrWhiteSpace($Value)
+  ) "$Label must not be blank."
+  Assert-BinderUnattendedConditionV1 (
+    $Value.Length -le $MaximumLength
+  ) "$Label exceeds the maximum length."
+  Assert-BinderUnattendedConditionV1 (
+    $Value -ceq $Value.Trim()
+  ) "$Label must not contain leading or trailing whitespace."
+  Assert-BinderUnattendedConditionV1 (
+    -not [regex]::IsMatch($Value, '[\x00-\x1f\x7f]')
+  ) "$Label contains a control character."
+}
+
+function ConvertFrom-BinderUnattendedAuthorizationJsonV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Json
+  )
+
+  $document = $null
+  try {
+    $options = [System.Text.Json.JsonDocumentOptions]::new()
+    $options.AllowTrailingCommas = $false
+    $options.CommentHandling =
+      [System.Text.Json.JsonCommentHandling]::Disallow
+    $options.MaxDepth = 16
+    $document = [System.Text.Json.JsonDocument]::Parse($Json, $options)
+    $root = $document.RootElement
+    [void](Get-BinderUnattendedJsonObjectPropertiesV1 `
+      -Element $root `
+      -ExpectedNames (Get-BinderUnattendedAuthorizationPropertyOrderV1) `
+      -Label 'Authorization envelope')
+
+    $schemaVersion = Get-BinderUnattendedJsonInt32V1 `
+      -Element $root -Name 'schema_version' -Label 'Authorization envelope'
+    $authorizationId = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'authorization_id' -Label 'Authorization envelope'
+    $issuedAt = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'issued_at_utc' -Label 'Authorization envelope'
+    $notBefore = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'not_before_utc' -Label 'Authorization envelope'
+    $backupPollDeadline = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'backup_poll_deadline_utc' `
+      -Label 'Authorization envelope'
+    $mutationDeadline = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'mutation_deadline_utc' `
+      -Label 'Authorization envelope'
+    $expiresAt = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'expires_at_utc' -Label 'Authorization envelope'
+    $operator = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'operator' -Label 'Authorization envelope'
+    $reviewer = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'reviewer' -Label 'Authorization envelope'
+    $restoreProcedureUri = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'restore_procedure_uri' `
+      -Label 'Authorization envelope'
+    $restoreProcedureSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'restore_procedure_sha256' `
+      -Label 'Authorization envelope'
+    $stateRoot = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'state_root' -Label 'Authorization envelope'
+    $artifactRoot = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'artifact_root' -Label 'Authorization envelope'
+    $projectRef = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'project_ref' -Label 'Authorization envelope'
+    $projectUrl = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'project_url' -Label 'Authorization envelope'
+    $canonicalRepository = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'canonical_repository' `
+      -Label 'Authorization envelope'
+    $canonicalRemoteUrl = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'canonical_remote_url' `
+      -Label 'Authorization envelope'
+    $supabaseConfigSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supabase_config_sha256' `
+      -Label 'Authorization envelope'
+    $linkedProjectRefSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'linked_project_ref_sha256' `
+      -Label 'Authorization envelope'
+    $linkedPoolerUrlSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'linked_pooler_url_sha256' `
+      -Label 'Authorization envelope'
+    $linkedProjectMetadataSha256 =
+      Get-BinderUnattendedJsonStringV1 `
+        -Element $root -Name 'linked_project_metadata_sha256' `
+        -Label 'Authorization envelope'
+    $gitExecutablePath = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_executable_path' `
+      -Label 'Authorization envelope'
+    $gitExecutableSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_executable_sha256' `
+      -Label 'Authorization envelope'
+    $gitVersion = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_version' `
+      -Label 'Authorization envelope'
+    $gitExecPath = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_exec_path' `
+      -Label 'Authorization envelope'
+    $gitHttpsHelperPath = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_https_helper_path' `
+      -Label 'Authorization envelope'
+    $gitHttpsHelperSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_https_helper_sha256' `
+      -Label 'Authorization envelope'
+    $gitCommonConfigSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_common_config_sha256' `
+      -Label 'Authorization envelope'
+    $gitMetadataCount = Get-BinderUnattendedJsonInt32V1 `
+      -Element $root -Name 'git_metadata_count' `
+      -Label 'Authorization envelope'
+    $gitMetadataSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'git_metadata_sha256' `
+      -Label 'Authorization envelope'
+    $reviewedMainSha = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'reviewed_main_sha' `
+      -Label 'Authorization envelope'
+    $packageId = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'package_id' -Label 'Authorization envelope'
+    $packageFingerprint = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'package_fingerprint_sha256' `
+      -Label 'Authorization envelope'
+    $packageManifestSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'package_manifest_sha256' `
+      -Label 'Authorization envelope'
+    $trackedMigrationCount = Get-BinderUnattendedJsonInt32V1 `
+      -Element $root -Name 'tracked_migration_count' `
+      -Label 'Authorization envelope'
+    $trackedMigrationSetSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'tracked_migration_set_sha256' `
+      -Label 'Authorization envelope'
+    $supervisorModuleSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supervisor_module_sha256' `
+      -Label 'Authorization envelope'
+    $supervisorEntrypointSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supervisor_entrypoint_sha256' `
+      -Label 'Authorization envelope'
+    $rolloutModuleSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'rollout_module_sha256' `
+      -Label 'Authorization envelope'
+    $preflightEntrypointSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'preflight_entrypoint_sha256' `
+      -Label 'Authorization envelope'
+    $applyEntrypointSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'apply_entrypoint_sha256' `
+      -Label 'Authorization envelope'
+    $preflightSqlSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'preflight_sql_sha256' `
+      -Label 'Authorization envelope'
+    $postApplySqlSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'post_apply_sql_sha256' `
+      -Label 'Authorization envelope'
+    $supabaseCliVersion = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supabase_cli_version' `
+      -Label 'Authorization envelope'
+    $supabaseCliLauncherSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supabase_cli_launcher_sha256' `
+      -Label 'Authorization envelope'
+    $supabaseCliBinarySha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supabase_cli_binary_sha256' `
+      -Label 'Authorization envelope'
+    $supabaseCliShimDescriptorSha256 = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'supabase_cli_shim_descriptor_sha256' `
+      -Label 'Authorization envelope'
+    $backupSource = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'backup_source' -Label 'Authorization envelope'
+    $backupNotBefore = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'backup_not_before_utc' `
+      -Label 'Authorization envelope'
+    $stableCatalogFingerprint = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'stable_catalog_fingerprint_sha256' `
+      -Label 'Authorization envelope'
+
+    foreach ($entry in @(
+      @($authorizationId, 'authorization_id', 64),
+      @($operator, 'operator', 160),
+      @($reviewer, 'reviewer', 160),
+      @($restoreProcedureUri, 'restore_procedure_uri', 256),
+      @($stateRoot, 'state_root', 512),
+      @($artifactRoot, 'artifact_root', 512),
+      @($projectRef, 'project_ref', 64),
+      @($projectUrl, 'project_url', 256),
+      @($canonicalRepository, 'canonical_repository', 160),
+      @($canonicalRemoteUrl, 'canonical_remote_url', 256),
+      @($gitExecutablePath, 'git_executable_path', 512),
+      @($gitVersion, 'git_version', 96),
+      @($gitExecPath, 'git_exec_path', 512),
+      @($gitHttpsHelperPath, 'git_https_helper_path', 512),
+      @($packageId, 'package_id', 96),
+      @($supabaseCliVersion, 'supabase_cli_version', 32),
+      @($backupSource, 'backup_source', 64)
+    )) {
+      Assert-BinderUnattendedScalarStringV1 `
+        -Value ([string]$entry[0]) `
+        -Label "Authorization envelope.$($entry[1])" `
+        -MaximumLength ([int]$entry[2])
+    }
+
+    foreach ($entry in @(
+      @($restoreProcedureSha256, 'restore_procedure_sha256'),
+      @($supabaseConfigSha256, 'supabase_config_sha256'),
+      @($linkedProjectRefSha256, 'linked_project_ref_sha256'),
+      @($linkedPoolerUrlSha256, 'linked_pooler_url_sha256'),
+      @(
+        $linkedProjectMetadataSha256,
+        'linked_project_metadata_sha256'
+      ),
+      @($gitExecutableSha256, 'git_executable_sha256'),
+      @($gitHttpsHelperSha256, 'git_https_helper_sha256'),
+      @($gitCommonConfigSha256, 'git_common_config_sha256'),
+      @($gitMetadataSha256, 'git_metadata_sha256'),
+      @($packageFingerprint, 'package_fingerprint_sha256'),
+      @($packageManifestSha256, 'package_manifest_sha256'),
+      @($trackedMigrationSetSha256, 'tracked_migration_set_sha256'),
+      @($supervisorModuleSha256, 'supervisor_module_sha256'),
+      @($supervisorEntrypointSha256, 'supervisor_entrypoint_sha256'),
+      @($rolloutModuleSha256, 'rollout_module_sha256'),
+      @($preflightEntrypointSha256, 'preflight_entrypoint_sha256'),
+      @($applyEntrypointSha256, 'apply_entrypoint_sha256'),
+      @($preflightSqlSha256, 'preflight_sql_sha256'),
+      @($postApplySqlSha256, 'post_apply_sql_sha256'),
+      @($supabaseCliLauncherSha256, 'supabase_cli_launcher_sha256'),
+      @($supabaseCliBinarySha256, 'supabase_cli_binary_sha256'),
+      @(
+        $supabaseCliShimDescriptorSha256,
+        'supabase_cli_shim_descriptor_sha256'
+      ),
+      @($stableCatalogFingerprint, 'stable_catalog_fingerprint_sha256')
+    )) {
+      Assert-BinderUnattendedConditionV1 (
+        [string]$entry[0] -cmatch '^[0-9a-f]{64}$'
+      ) "Authorization envelope.$($entry[1]) must be lowercase SHA-256."
+    }
+    Assert-BinderUnattendedConditionV1 (
+      $reviewedMainSha -cmatch '^[0-9a-f]{40}$'
+    ) 'Authorization envelope.reviewed_main_sha must be lowercase SHA-1.'
+    Assert-BinderUnattendedConditionV1 (
+      $authorizationId -cmatch '^[0-9a-f]{32}$'
+    ) 'Authorization envelope.authorization_id must be 32 lowercase hex characters.'
+
+    $migrationsElement = [System.Text.Json.JsonElement]::new()
+    Assert-BinderUnattendedConditionV1 (
+      $root.TryGetProperty('migrations', [ref]$migrationsElement) -and
+      $migrationsElement.ValueKind -eq
+        [System.Text.Json.JsonValueKind]::Array
+    ) 'Authorization envelope.migrations must be an array.'
+    $migrations = @(
+      foreach ($migration in $migrationsElement.EnumerateArray()) {
+        [void](Get-BinderUnattendedJsonObjectPropertiesV1 `
+          -Element $migration `
+          -ExpectedNames @('version', 'file', 'sha256') `
+          -Label 'Authorization envelope.migrations entry')
+        [pscustomobject][ordered]@{
+          version = Get-BinderUnattendedJsonStringV1 `
+            -Element $migration -Name 'version' `
+            -Label 'Authorization envelope.migrations entry'
+          file = Get-BinderUnattendedJsonStringV1 `
+            -Element $migration -Name 'file' `
+            -Label 'Authorization envelope.migrations entry'
+          sha256 = Get-BinderUnattendedJsonStringV1 `
+            -Element $migration -Name 'sha256' `
+            -Label 'Authorization envelope.migrations entry'
+        }
+      }
+    )
+
+    $expectedPreApplyElement = [System.Text.Json.JsonElement]::new()
+    Assert-BinderUnattendedConditionV1 (
+      $root.TryGetProperty(
+        'expected_preapply',
+        [ref]$expectedPreApplyElement
+      )
+    ) 'Authorization envelope is missing expected_preapply.'
+    [void](Get-BinderUnattendedJsonObjectPropertiesV1 `
+      -Element $expectedPreApplyElement `
+      -ExpectedNames @(
+        'binder_relation_collision_count',
+        'binder_type_collision_count',
+        'binder_function_count',
+        'applied_package_migration_count',
+        'binder_realtime_object_exists',
+        'binder_card_event_data_exists',
+        'binder_trust_report_data_exists',
+        'wrapped_pulse_function_exists'
+      ) `
+      -Label 'Authorization envelope.expected_preapply')
+    $expectedPreApply = [pscustomobject][ordered]@{
+      binder_relation_collision_count =
+        Get-BinderUnattendedJsonInt32V1 `
+          -Element $expectedPreApplyElement `
+          -Name 'binder_relation_collision_count' `
+          -Label 'Authorization envelope.expected_preapply'
+      binder_type_collision_count =
+        Get-BinderUnattendedJsonInt32V1 `
+          -Element $expectedPreApplyElement `
+          -Name 'binder_type_collision_count' `
+          -Label 'Authorization envelope.expected_preapply'
+      binder_function_count =
+        Get-BinderUnattendedJsonInt32V1 `
+          -Element $expectedPreApplyElement `
+          -Name 'binder_function_count' `
+          -Label 'Authorization envelope.expected_preapply'
+      applied_package_migration_count =
+        Get-BinderUnattendedJsonInt32V1 `
+          -Element $expectedPreApplyElement `
+          -Name 'applied_package_migration_count' `
+          -Label 'Authorization envelope.expected_preapply'
+      binder_realtime_object_exists =
+        Get-BinderUnattendedJsonBooleanV1 `
+          -Element $expectedPreApplyElement `
+          -Name 'binder_realtime_object_exists' `
+          -Label 'Authorization envelope.expected_preapply'
+      binder_card_event_data_exists =
+        Get-BinderUnattendedJsonBooleanV1 `
+          -Element $expectedPreApplyElement `
+          -Name 'binder_card_event_data_exists' `
+          -Label 'Authorization envelope.expected_preapply'
+      binder_trust_report_data_exists =
+        Get-BinderUnattendedJsonBooleanV1 `
+          -Element $expectedPreApplyElement `
+          -Name 'binder_trust_report_data_exists' `
+          -Label 'Authorization envelope.expected_preapply'
+      wrapped_pulse_function_exists =
+        Get-BinderUnattendedJsonBooleanV1 `
+          -Element $expectedPreApplyElement `
+          -Name 'wrapped_pulse_function_exists' `
+          -Label 'Authorization envelope.expected_preapply'
+    }
+
+    return [pscustomobject][ordered]@{
+      schema_version = $schemaVersion
+      authorization_id = $authorizationId
+      issued_at_utc = $issuedAt
+      not_before_utc = $notBefore
+      backup_poll_deadline_utc = $backupPollDeadline
+      mutation_deadline_utc = $mutationDeadline
+      expires_at_utc = $expiresAt
+      operator = $operator
+      reviewer = $reviewer
+      restore_path_reviewed = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'restore_path_reviewed' `
+        -Label 'Authorization envelope'
+      restore_procedure_uri = $restoreProcedureUri
+      restore_procedure_sha256 = $restoreProcedureSha256
+      state_root = $stateRoot
+      artifact_root = $artifactRoot
+      project_ref = $projectRef
+      project_url = $projectUrl
+      canonical_repository = $canonicalRepository
+      canonical_remote_url = $canonicalRemoteUrl
+      supabase_config_sha256 = $supabaseConfigSha256
+      linked_project_ref_sha256 = $linkedProjectRefSha256
+      linked_pooler_url_sha256 = $linkedPoolerUrlSha256
+      linked_project_metadata_sha256 =
+        $linkedProjectMetadataSha256
+      git_executable_path = $gitExecutablePath
+      git_executable_sha256 = $gitExecutableSha256
+      git_version = $gitVersion
+      git_exec_path = $gitExecPath
+      git_https_helper_path = $gitHttpsHelperPath
+      git_https_helper_sha256 = $gitHttpsHelperSha256
+      git_common_config_sha256 = $gitCommonConfigSha256
+      git_metadata_count = $gitMetadataCount
+      git_metadata_sha256 = $gitMetadataSha256
+      reviewed_main_sha = $reviewedMainSha
+      package_id = $packageId
+      package_fingerprint_sha256 = $packageFingerprint
+      package_manifest_sha256 = $packageManifestSha256
+      tracked_migration_count = $trackedMigrationCount
+      tracked_migration_set_sha256 = $trackedMigrationSetSha256
+      supervisor_module_sha256 = $supervisorModuleSha256
+      supervisor_entrypoint_sha256 = $supervisorEntrypointSha256
+      rollout_module_sha256 = $rolloutModuleSha256
+      preflight_entrypoint_sha256 = $preflightEntrypointSha256
+      apply_entrypoint_sha256 = $applyEntrypointSha256
+      preflight_sql_sha256 = $preflightSqlSha256
+      post_apply_sql_sha256 = $postApplySqlSha256
+      supabase_cli_version = $supabaseCliVersion
+      supabase_cli_launcher_sha256 = $supabaseCliLauncherSha256
+      supabase_cli_binary_sha256 = $supabaseCliBinarySha256
+      supabase_cli_shim_descriptor_sha256 =
+        $supabaseCliShimDescriptorSha256
+      backup_source = $backupSource
+      backup_not_before_utc = $backupNotBefore
+      stable_catalog_fingerprint_sha256 = $stableCatalogFingerprint
+      migrations = $migrations
+      apply_argv = ConvertFrom-BinderUnattendedJsonStringArrayV1 `
+        -Element $root -Name 'apply_argv' -Label 'Authorization envelope'
+      feature_flags_must_remain_disabled =
+        ConvertFrom-BinderUnattendedJsonStringArrayV1 `
+          -Element $root `
+          -Name 'feature_flags_must_remain_disabled' `
+          -Label 'Authorization envelope'
+      excluded_from_rollout =
+        ConvertFrom-BinderUnattendedJsonStringArrayV1 `
+          -Element $root -Name 'excluded_from_rollout' `
+          -Label 'Authorization envelope'
+      expected_preapply = $expectedPreApply
+      p8_excluded = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'p8_excluded' -Label 'Authorization envelope'
+      activation_allowed = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'activation_allowed' `
+        -Label 'Authorization envelope'
+      deployment_allowed = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'deployment_allowed' `
+        -Label 'Authorization envelope'
+      migration_repair_allowed = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'migration_repair_allowed' `
+        -Label 'Authorization envelope'
+      one_attempt_only = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'one_attempt_only' `
+        -Label 'Authorization envelope'
+      automatic_retry_allowed = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $root -Name 'automatic_retry_allowed' `
+        -Label 'Authorization envelope'
+    }
+  } catch {
+    if ($_.Exception.Data.Contains('BinderSupervisorExitClass')) {
+      throw
+    }
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'local_integrity_stop' `
+      -Message "Authorization JSON is invalid: $($_.Exception.Message)"
+  } finally {
+    if ($null -ne $document) {
+      $document.Dispose()
+    }
+  }
+}
+
+function ConvertFrom-BinderUnattendedAuthorizationBytesV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [byte[]]$Bytes
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $Bytes.Length -gt 0 -and $Bytes.Length -le 65536
+  ) 'Authorization envelope byte length is invalid.'
+  Assert-BinderUnattendedConditionV1 (
+    -not (
+      $Bytes.Length -ge 3 -and
+      $Bytes[0] -eq 0xef -and
+      $Bytes[1] -eq 0xbb -and
+      $Bytes[2] -eq 0xbf
+    )
+  ) 'Authorization envelope must be UTF-8 without BOM.'
+  foreach ($value in $Bytes) {
+    Assert-BinderUnattendedConditionV1 (
+      $value -ge 0x20 -or $value -eq 0x0a
+    ) 'Authorization envelope contains a forbidden control byte.'
+  }
+  try {
+    $utf8 = [System.Text.UTF8Encoding]::new($false, $true)
+    $json = $utf8.GetString($Bytes)
+  } catch {
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'local_integrity_stop' `
+      -Message 'Authorization envelope is not strict UTF-8.'
+  }
+  $parsed = ConvertFrom-BinderUnattendedAuthorizationJsonV1 -Json $json
+
+  $document = $null
+  $writer = $null
+  $memory = $null
+  try {
+    $document = [System.Text.Json.JsonDocument]::Parse($json)
+    $memory = [System.IO.MemoryStream]::new()
+    $writerOptions = [System.Text.Json.JsonWriterOptions]::new()
+    $writerOptions.Indented = $false
+    $writerOptions.SkipValidation = $false
+    $writer = [System.Text.Json.Utf8JsonWriter]::new(
+      $memory,
+      $writerOptions
+    )
+    $document.RootElement.WriteTo($writer)
+    $writer.Flush()
+    $canonicalBytes = $memory.ToArray()
+    $sameBytes = $Bytes.Length -eq $canonicalBytes.Length
+    if ($sameBytes) {
+      for ($index = 0; $index -lt $Bytes.Length; $index += 1) {
+        if ($Bytes[$index] -ne $canonicalBytes[$index]) {
+          $sameBytes = $false
+          break
+        }
+      }
+    }
+    Assert-BinderUnattendedConditionV1 $sameBytes (
+      'Authorization envelope must be the exact compact canonical UTF-8 ' +
+      'encoding with ordered V1 fields, no BOM, and no trailing newline.'
+    )
+  } finally {
+    if ($null -ne $writer) {
+      $writer.Dispose()
+    }
+    if ($null -ne $memory) {
+      $memory.Dispose()
+    }
+    if ($null -ne $document) {
+      $document.Dispose()
+    }
+  }
+  return $parsed
+}
+
+function Assert-BinderUnattendedLocalPathV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+
+    [ValidateSet('Any', 'Leaf', 'Container')]
+    [string]$RequiredType = 'Any',
+
+    [bool]$MustExist = $true
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    [System.IO.Path]::IsPathFullyQualified($Path)
+  ) "$Label must be an absolute path."
+  Assert-BinderUnattendedConditionV1 (
+    $Path -cmatch '^[A-Z]:\\' -and
+    -not $Path.StartsWith('\\') -and
+    -not $Path.StartsWith('\\?\') -and
+    -not $Path.StartsWith('\\.\')
+  ) "$Label must be a canonical local drive path."
+  $drive = [System.IO.DriveInfo]::new($Path.Substring(0, 3))
+  Assert-BinderUnattendedConditionV1 (
+    $drive.IsReady -and
+    $drive.DriveType -eq [System.IO.DriveType]::Fixed -and
+    $drive.DriveFormat -ceq 'NTFS'
+  ) "$Label must be on a ready fixed local NTFS volume."
+  Initialize-BinderUnattendedNativeV1
+  $deviceTarget = [GrookaiBinderUnattendedNativeV1]::GetDosDeviceTarget(
+    $Path.Substring(0, 2)
+  )
+  Assert-BinderUnattendedConditionV1 (
+    $deviceTarget.StartsWith(
+      '\Device\HarddiskVolume',
+      [System.StringComparison]::Ordinal
+    )
+  ) "$Label must not use a SUBST, mapped, or redirected drive."
+  Assert-BinderUnattendedConditionV1 (
+    $Path.IndexOf(':', 2) -lt 0
+  ) "$Label must not contain an alternate data stream."
+  Assert-BinderUnattendedConditionV1 (
+    $Path -ceq $Path.Trim() -and
+    -not [regex]::IsMatch($Path, '[\x00-\x1f\x7f]')
+  ) "$Label contains forbidden whitespace or control characters."
+  foreach ($segment in @($Path.Substring(3) -split '\\')) {
+    if ([string]::IsNullOrEmpty($segment)) {
+      continue
+    }
+    Assert-BinderUnattendedConditionV1 (
+      -not $segment.EndsWith(
+        '.',
+        [System.StringComparison]::Ordinal
+      ) -and
+      -not $segment.EndsWith(
+        ' ',
+        [System.StringComparison]::Ordinal
+      ) -and
+      -not (
+        [System.IO.Path]::GetFileNameWithoutExtension($segment) -match
+          '^(?i:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$'
+      )
+    ) "$Label contains a Windows alias or reserved path segment."
+  }
+  $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+  Assert-BinderUnattendedConditionV1 (
+    $fullPath -ceq $Path.TrimEnd('\')
+  ) "$Label must already be canonical and must not contain dot segments."
+
+  if ($MustExist) {
+    Assert-BinderUnattendedConditionV1 (
+      Test-Path -LiteralPath $fullPath
+    ) "$Label does not exist."
+    if ($RequiredType -ceq 'Leaf') {
+      Assert-BinderUnattendedConditionV1 (
+        Test-Path -LiteralPath $fullPath -PathType Leaf
+      ) "$Label must be a regular file."
+    } elseif ($RequiredType -ceq 'Container') {
+      Assert-BinderUnattendedConditionV1 (
+        Test-Path -LiteralPath $fullPath -PathType Container
+      ) "$Label must be a directory."
+    }
+  } else {
+    Assert-BinderUnattendedConditionV1 (
+      -not (Test-Path -LiteralPath $fullPath)
+    ) "$Label must not already exist."
+  }
+
+  $cursor = if (Test-Path -LiteralPath $fullPath) {
+    $fullPath
+  } else {
+    Split-Path -Parent $fullPath
+  }
+  while ($cursor -and -not (Test-Path -LiteralPath $cursor)) {
+    $parent = Split-Path -Parent $cursor
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -ceq $cursor) {
+      break
+    }
+    $cursor = $parent
+  }
+  $existingAncestor = $cursor
+  while ($cursor -and (Test-Path -LiteralPath $cursor)) {
+    $item = Get-Item -LiteralPath $cursor -Force
+    Assert-BinderUnattendedConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "$Label path contains a reparse point: $cursor"
+    $parent = Split-Path -Parent $cursor
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -ceq $cursor) {
+      break
+    }
+    $cursor = $parent
+  }
+
+  if ($existingAncestor) {
+    $finalExistingAncestor =
+      Get-BinderUnattendedFinalPathV1 -Path $existingAncestor
+    Assert-BinderUnattendedConditionV1 (
+      $finalExistingAncestor.Equals(
+        [System.IO.Path]::GetFullPath($existingAncestor).TrimEnd('\'),
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) "$Label resolves through a non-canonical path alias."
+  }
+  if ($MustExist) {
+    $finalPath = Get-BinderUnattendedFinalPathV1 -Path $fullPath
+    Assert-BinderUnattendedConditionV1 (
+      $finalPath.Equals(
+        $fullPath,
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) "$Label final path differs from its authorized path."
+  }
+
+  if ($MustExist -and $RequiredType -ceq 'Leaf') {
+    $item = Get-Item -LiteralPath $fullPath -Force
+    Assert-BinderUnattendedConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::Directory
+      )
+    ) "$Label must be a regular file."
+  }
+  return $fullPath
+}
+
+function Assert-BinderUnattendedOutsideRepositoryV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+  $repo = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd('\')
+  Assert-BinderUnattendedConditionV1 (
+    -not (
+      $fullPath.Equals(
+        $repo,
+        [System.StringComparison]::OrdinalIgnoreCase
+      ) -or
+      $fullPath.StartsWith(
+        "$repo\",
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    )
+  ) "$Label must be outside the repository."
+}
+
+function Get-BinderUnattendedFileBytesFromStreamV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.IO.FileStream]$Stream,
+    [int]$MaximumBytes = 65536
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $Stream.Length -gt 0 -and $Stream.Length -le $MaximumBytes
+  ) 'Sealed file length is invalid.'
+  $Stream.Position = 0
+  $bytes = [byte[]]::new([int]$Stream.Length)
+  $offset = 0
+  while ($offset -lt $bytes.Length) {
+    $read = $Stream.Read($bytes, $offset, $bytes.Length - $offset)
+    Assert-BinderUnattendedConditionV1 (
+      $read -gt 0
+    ) 'Sealed file ended before its recorded length.'
+    $offset += $read
+  }
+  $Stream.Position = 0
+  return $bytes
+}
+
+function Open-BinderUnattendedAuthorizationV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorizationPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedAuthorizationSha256,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $ExpectedAuthorizationSha256 -cmatch '^[0-9a-f]{64}$'
+  ) 'ExpectedAuthorizationSha256 must be an independently supplied lowercase SHA-256.'
+  $path = Assert-BinderUnattendedLocalPathV1 `
+    -Path $AuthorizationPath `
+    -Label 'AuthorizationPath' `
+    -RequiredType Leaf
+  [void](Assert-BinderUnattendedOutsideRepositoryV1 `
+    -Path $path -RepoRoot $RepoRoot -Label 'AuthorizationPath')
+  $stream = $null
+  try {
+    $stream = [System.IO.File]::Open(
+      $path,
+      [System.IO.FileMode]::Open,
+      [System.IO.FileAccess]::Read,
+      [System.IO.FileShare]::Read
+    )
+    $bytes = Get-BinderUnattendedFileBytesFromStreamV1 -Stream $stream
+    $actualSha256 = Get-BinderUnattendedSha256BytesV1 -Bytes $bytes
+    Assert-BinderUnattendedConditionV1 (
+      $actualSha256 -ceq $ExpectedAuthorizationSha256
+    ) 'Authorization envelope bytes do not match the caller-supplied SHA-256.'
+    $authorization =
+      ConvertFrom-BinderUnattendedAuthorizationBytesV1 -Bytes $bytes
+    return [pscustomobject][ordered]@{
+      Path = $path
+      Sha256 = $actualSha256
+      Data = $authorization
+      Stream = $stream
+    }
+  } catch {
+    if ($null -ne $stream) {
+      $stream.Dispose()
+    }
+    throw
+  }
+}
+
+function Read-BinderUnattendedAuthorizationV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorizationPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedAuthorizationSha256,
+
+    [string]$RepoRoot = (Get-BinderUnattendedRepoRootV1)
+  )
+
+  $opened = Open-BinderUnattendedAuthorizationV1 `
+    -AuthorizationPath $AuthorizationPath `
+    -ExpectedAuthorizationSha256 $ExpectedAuthorizationSha256 `
+    -RepoRoot $RepoRoot
+  try {
+    return [pscustomobject][ordered]@{
+      Path = $opened.Path
+      Sha256 = $opened.Sha256
+      Data = $opened.Data
+    }
+  } finally {
+    $opened.Stream.Dispose()
+  }
+}
+
+function Assert-BinderUnattendedArrayEqualV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$Actual,
+    [Parameter(Mandatory = $true)]
+    [object[]]$Expected,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    @($Actual).Count -eq @($Expected).Count
+  ) "$Label does not match the reviewed element count."
+  for ($index = 0; $index -lt @($Expected).Count; $index += 1) {
+    $actualRaw = @($Actual)[$index]
+    Assert-BinderUnattendedConditionV1 (
+      $actualRaw -is [string]
+    ) "$Label must contain JSON strings at position $index."
+    $actualValue = [string]$actualRaw
+    Assert-BinderUnattendedConditionV1 (
+      -not [regex]::IsMatch($actualValue, '[\x00-\x1f\x7f]')
+    ) "$Label contains a control character at position $index."
+    Assert-BinderUnattendedConditionV1 (
+      $actualValue -ceq [string]@($Expected)[$index]
+    ) "$Label does not match the reviewed value at position $index."
+  }
+}
+
+function Test-BinderUnattendedAuthorizationV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+
+    [datetimeoffset]$NowUtc = [datetimeoffset]::UtcNow
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.schema_version -eq $policy.SchemaVersion
+  ) 'Authorization schema version mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.project_ref -ceq $policy.ProjectRef
+  ) 'Authorization project ref mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.project_url -ceq $policy.ProjectUrl
+  ) 'Authorization project URL mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.canonical_repository -ceq
+      $policy.CanonicalRepository
+  ) 'Authorization canonical repository mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.canonical_remote_url -ceq
+      $policy.CanonicalRemoteUrl
+  ) 'Authorization canonical remote URL mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.supabase_config_sha256 -ceq
+      $policy.SupabaseConfigSha256 -and
+    $Authorization.linked_project_ref_sha256 -ceq
+      $policy.LinkedProjectRefSha256 -and
+    $Authorization.linked_pooler_url_sha256 -ceq
+      $policy.LinkedPoolerUrlSha256 -and
+    $Authorization.linked_project_metadata_sha256 -ceq
+      $policy.LinkedProjectMetadataSha256
+  ) 'Authorization Supabase source/link identity mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.git_executable_path -ceq
+      $policy.GitExecutablePath -and
+    $Authorization.git_executable_sha256 -ceq
+      $policy.GitExecutableSha256 -and
+    $Authorization.git_version -ceq $policy.GitVersion -and
+    $Authorization.git_exec_path -ceq $policy.GitExecPath -and
+    $Authorization.git_https_helper_path -ceq
+      $policy.GitHttpsHelperPath -and
+    $Authorization.git_https_helper_sha256 -ceq
+      $policy.GitHttpsHelperSha256
+  ) 'Authorization Git executable identity mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.git_common_config_sha256 -cmatch
+      '^[0-9a-f]{64}$' -and
+    $Authorization.git_metadata_count -gt 0 -and
+    $Authorization.git_metadata_sha256 -cmatch '^[0-9a-f]{64}$'
+  ) 'Authorization Git config/metadata identity is invalid.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.package_id -ceq $policy.PackageId
+  ) 'Authorization package ID mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.package_fingerprint_sha256 -ceq
+      $policy.PackageFingerprintSha256
+  ) 'Authorization package fingerprint mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.package_manifest_sha256 -ceq
+      $policy.PackageManifestSha256
+  ) 'Authorization package-manifest hash mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.tracked_migration_count -eq
+      $policy.TrackedMigrationCount -and
+    $Authorization.tracked_migration_set_sha256 -ceq
+      $policy.TrackedMigrationSetSha256
+  ) 'Authorization tracked migration-set identity mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.preflight_sql_sha256 -ceq
+      $policy.PreflightSqlSha256
+  ) 'Authorization preflight SQL hash mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.post_apply_sql_sha256 -ceq
+      $policy.PostApplySqlSha256
+  ) 'Authorization post-apply SQL hash mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.supabase_cli_version -ceq
+      $policy.SupportedSupabaseCliVersion
+  ) 'Authorization Supabase CLI version mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.supabase_cli_launcher_sha256 -ceq
+      $policy.SupabaseCliLauncherSha256
+  ) 'Authorization Supabase CLI launcher hash mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.supabase_cli_binary_sha256 -ceq
+      $policy.SupabaseCliBinarySha256
+  ) 'Authorization Supabase CLI binary hash mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.supabase_cli_shim_descriptor_sha256 -ceq
+      $policy.SupabaseCliShimDescriptorSha256
+  ) 'Authorization Supabase CLI shim hash mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.stable_catalog_fingerprint_sha256 -ceq
+      $policy.StableCatalogFingerprintSha256
+  ) 'Authorization stable catalog fingerprint mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.backup_source -ceq 'supabase_cli_physical_backups_v1'
+  ) 'Authorization permits only the pinned Supabase physical-backup listing.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.backup_not_before_utc -ceq
+      $policy.BackupNotBeforeUtc
+  ) 'Authorization backup floor differs from the reviewed completed backup.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.restore_path_reviewed -eq $true
+  ) 'Authorization does not attest that the restore path was reviewed.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.restore_procedure_uri -ceq
+      $policy.RestoreProcedureUri
+  ) 'Authorization restore procedure URI mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.p8_excluded -eq $true -and
+    $Authorization.activation_allowed -eq $false -and
+    $Authorization.deployment_allowed -eq $false -and
+    $Authorization.migration_repair_allowed -eq $false -and
+    $Authorization.one_attempt_only -eq $true -and
+    $Authorization.automatic_retry_allowed -eq $false
+  ) 'Authorization expands the reviewed no-P8/no-activation/no-retry boundary.'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($Authorization.apply_argv) `
+    -Expected @($policy.ApplyArguments) `
+    -Label 'Authorization apply argv'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($Authorization.feature_flags_must_remain_disabled) `
+    -Expected @($policy.FeatureFlags) `
+    -Label 'Authorization disabled flags'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($Authorization.excluded_from_rollout) `
+    -Expected @($policy.ExcludedFlags) `
+    -Label 'Authorization excluded flags'
+
+  Assert-BinderUnattendedConditionV1 (
+    @($Authorization.migrations).Count -eq @($policy.Migrations).Count
+  ) 'Authorization must contain exactly five migrations.'
+  for ($index = 0; $index -lt @($policy.Migrations).Count; $index += 1) {
+    $actual = @($Authorization.migrations)[$index]
+    $expected = @($policy.Migrations)[$index]
+    Assert-BinderUnattendedConditionV1 (
+      $actual.version -ceq $expected.version -and
+      $actual.file -ceq $expected.file -and
+      $actual.sha256 -ceq $expected.sha256
+    ) "Authorization migration mismatch at position $index."
+  }
+  foreach ($property in $policy.ExpectedPreApply.PSObject.Properties) {
+    Assert-BinderUnattendedConditionV1 (
+      $Authorization.expected_preapply.($property.Name) -eq
+        $property.Value
+    ) "Authorization expected_preapply.$($property.Name) mismatch."
+  }
+
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.state_root -ceq $policy.StateRoot
+  ) 'Authorization state root is not the fixed package/project state root.'
+  $expectedArtifactRoot = Join-Path (
+    $policy.ArtifactNamespaceRoot
+  ) $Authorization.authorization_id
+  Assert-BinderUnattendedConditionV1 (
+    $Authorization.artifact_root -ceq $expectedArtifactRoot
+  ) 'Authorization artifact root is not its exact fixed-namespace run root.'
+
+  $issued = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Authorization.issued_at_utc -Label 'Authorization issued time'
+  $notBefore = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Authorization.not_before_utc `
+    -Label 'Authorization not-before time'
+  $pollDeadline = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Authorization.backup_poll_deadline_utc `
+    -Label 'Authorization backup-poll deadline'
+  foreach ($criticalDeadline in @(
+    [string]$Authorization.mutation_deadline_utc,
+    [string]$Authorization.expires_at_utc
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $criticalDeadline -cmatch
+        '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,7})?Z$'
+    ) 'Mutation deadline and authorization expiry must be exact UTC Z timestamps.'
+  }
+  $mutationDeadline = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Authorization.mutation_deadline_utc `
+    -Label 'Authorization mutation deadline'
+  $expires = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Authorization.expires_at_utc `
+    -Label 'Authorization expiry time'
+  $backupFloor = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Authorization.backup_not_before_utc `
+    -Label 'Authorization backup floor'
+  Assert-BinderUnattendedConditionV1 (
+    $issued -le $notBefore -and
+    $notBefore -lt $pollDeadline -and
+    $pollDeadline -le $mutationDeadline -and
+    $mutationDeadline -le $expires
+  ) 'Authorization time bounds are inconsistent.'
+  Assert-BinderUnattendedConditionV1 (
+    $expires -le $issued.AddHours($policy.AuthorizationMaximumHours)
+  ) 'Authorization validity exceeds the fixed maximum.'
+  Assert-BinderUnattendedConditionV1 (
+    $backupFloor -lt $notBefore -and
+    $backupFloor -lt $pollDeadline
+  ) 'Authorization backup floor is outside the reviewed time window.'
+  Assert-BinderUnattendedConditionV1 (
+    $issued -le $NowUtc.AddMinutes(5) -and
+    $NowUtc -ge $notBefore -and
+    $NowUtc -lt $expires
+  ) 'Authorization is not currently valid.'
+
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    IssuedAtUtc = $issued
+    NotBeforeUtc = $notBefore
+    BackupPollDeadlineUtc = $pollDeadline
+    MutationDeadlineUtc = $mutationDeadline
+    ExpiresAtUtc = $expires
+    BackupNotBeforeUtc = $backupFloor
+  }
+}
+
+function Test-BinderUnattendedBundleV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+
+    [string]$RepoRoot = (Get-BinderUnattendedRepoRootV1)
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $paths = [ordered]@{
+    supervisor_module_sha256 =
+      $policy.SupervisorModuleRelativePath
+    supervisor_entrypoint_sha256 =
+      $policy.SupervisorEntrypointRelativePath
+    rollout_module_sha256 =
+      $policy.RolloutModuleRelativePath
+    preflight_entrypoint_sha256 =
+      $policy.PreflightEntrypointRelativePath
+    apply_entrypoint_sha256 =
+      $policy.ApplyEntrypointRelativePath
+    package_manifest_sha256 =
+      $policy.PackageManifestRelativePath
+    preflight_sql_sha256 =
+      $policy.PreflightSqlRelativePath
+    post_apply_sql_sha256 =
+      $policy.PostApplySqlRelativePath
+    restore_procedure_sha256 =
+      $policy.RestoreProcedureRelativePath
+    supabase_config_sha256 =
+      'supabase/config.toml'
+    linked_project_ref_sha256 =
+      'supabase/.temp/project-ref'
+    linked_pooler_url_sha256 =
+      'supabase/.temp/pooler-url'
+    linked_project_metadata_sha256 =
+      'supabase/.temp/linked-project.json'
+  }
+  $hashes = [ordered]@{}
+  foreach ($entry in $paths.GetEnumerator()) {
+    $path = [System.IO.Path]::GetFullPath(
+      (Join-Path $RepoRoot $entry.Value)
+    )
+    Assert-BinderUnattendedConditionV1 (
+      Test-Path -LiteralPath $path -PathType Leaf
+    ) "Reviewed source file is missing: $($entry.Value)"
+    $item = Get-Item -LiteralPath $path -Force
+    Assert-BinderUnattendedConditionV1 (
+      -not $item.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "Reviewed source file is a reparse point: $($entry.Value)"
+    $actual = Get-BinderUnattendedSha256FileV1 -Path $path
+    Assert-BinderUnattendedConditionV1 (
+      $actual -ceq [string]$Authorization.($entry.Key)
+    ) "Reviewed source hash mismatch: $($entry.Value)"
+    $hashes[$entry.Key] = $actual
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $hashes.package_manifest_sha256 -ceq
+      $policy.PackageManifestSha256
+  ) 'Package manifest bytes do not match the fixed rollout policy.'
+  Assert-BinderUnattendedConditionV1 (
+    $hashes.preflight_sql_sha256 -ceq $policy.PreflightSqlSha256
+  ) 'Preflight SQL bytes do not match the fixed rollout policy.'
+  Assert-BinderUnattendedConditionV1 (
+    $hashes.post_apply_sql_sha256 -ceq $policy.PostApplySqlSha256
+  ) 'Post-apply SQL bytes do not match the fixed rollout policy.'
+  foreach ($entry in @(
+    @(
+      $policy.GitExecutablePath,
+      $Authorization.git_executable_path,
+      $Authorization.git_executable_sha256,
+      'Git executable'
+    ),
+    @(
+      $policy.GitHttpsHelperPath,
+      $Authorization.git_https_helper_path,
+      $Authorization.git_https_helper_sha256,
+      'Git HTTPS helper'
+    )
+  )) {
+    $expectedPath = [string]$entry[0]
+    $authorizedPath = [string]$entry[1]
+    Assert-BinderUnattendedConditionV1 (
+      $authorizedPath -ceq $expectedPath
+    ) "$($entry[3]) authorization path mismatch."
+    [void](Assert-BinderUnattendedLocalPathV1 `
+      -Path $authorizedPath `
+      -Label ([string]$entry[3]) `
+      -RequiredType Leaf)
+    Assert-BinderUnattendedConditionV1 (
+      (Get-BinderUnattendedSha256FileV1 -Path $authorizedPath) -ceq
+        [string]$entry[2]
+    ) "$($entry[3]) hash mismatch."
+  }
+
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    Hashes = [pscustomobject]$hashes
+  }
+}
+
+function Get-BinderUnattendedSha256StringV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string]$Value
+  )
+
+  return Get-BinderUnattendedSha256BytesV1 -Bytes (
+    [System.Text.Encoding]::UTF8.GetBytes($Value)
+  )
+}
+
+function Assert-BinderUnattendedJsonAllowedPropertiesV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
+    [string[]]$RequiredNames,
+    [Parameter(Mandatory = $true)]
+    [string[]]$AllowedNames,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Object
+  ) "$Label must be a JSON object."
+  $seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  $caseFolded = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  foreach ($property in $Element.EnumerateObject()) {
+    Assert-BinderUnattendedConditionV1 (
+      $seen.Add($property.Name) -and
+      $caseFolded.Add($property.Name)
+    ) "$Label contains a duplicate or case-colliding field."
+    Assert-BinderUnattendedConditionV1 (
+      $AllowedNames -ccontains $property.Name
+    ) "$Label contains an unexpected field: $($property.Name)"
+  }
+  foreach ($required in $RequiredNames) {
+    Assert-BinderUnattendedConditionV1 (
+      $seen.Contains($required)
+    ) "$Label is missing $required."
+  }
+}
+
+function Read-BinderBackupConfirmationV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Json,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ProjectRef,
+
+    [Parameter(Mandatory = $true)]
+    [string]$BackupNotBeforeUtc,
+
+    [datetimeoffset]$NowUtc = [datetimeoffset]::UtcNow
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  Assert-BinderUnattendedConditionV1 (
+    $ProjectRef -ceq $policy.ProjectRef
+  ) 'Backup confirmation project mismatch.'
+  $backupFloor = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $BackupNotBeforeUtc -Label 'Backup confirmation floor'
+  $document = $null
+  try {
+    $options = [System.Text.Json.JsonDocumentOptions]::new()
+    $options.AllowTrailingCommas = $false
+    $options.CommentHandling =
+      [System.Text.Json.JsonCommentHandling]::Disallow
+    $options.MaxDepth = 12
+    $document = [System.Text.Json.JsonDocument]::Parse($Json, $options)
+    $root = $document.RootElement
+    Assert-BinderUnattendedJsonAllowedPropertiesV1 `
+      -Element $root `
+      -RequiredNames @(
+        'backups',
+        'physical_backup_data',
+        'pitr_enabled',
+        'region',
+        'walg_enabled'
+      ) `
+      -AllowedNames @(
+        'backups',
+        'physical_backup_data',
+        'pitr_enabled',
+        'region',
+        'walg_enabled'
+      ) `
+      -Label 'Supabase physical-backup response'
+
+    $region = Get-BinderUnattendedJsonStringV1 `
+      -Element $root -Name 'region' `
+      -Label 'Supabase physical-backup response'
+    Assert-BinderUnattendedScalarStringV1 `
+      -Value $region -Label 'Supabase physical-backup response.region' `
+      -MaximumLength 64
+    $pitrEnabled = Get-BinderUnattendedJsonBooleanV1 `
+      -Element $root -Name 'pitr_enabled' `
+      -Label 'Supabase physical-backup response'
+    $walgEnabled = Get-BinderUnattendedJsonBooleanV1 `
+      -Element $root -Name 'walg_enabled' `
+      -Label 'Supabase physical-backup response'
+    Assert-BinderUnattendedConditionV1 (
+      $region -ceq $policy.BackupExpectedRegion -and
+      $pitrEnabled -eq $policy.BackupExpectedPitrEnabled -and
+      $walgEnabled -eq $policy.BackupExpectedWalgEnabled
+    ) 'Supabase backup mode or region changed from the reviewed platform state.'
+
+    $physicalData = [System.Text.Json.JsonElement]::new()
+    Assert-BinderUnattendedConditionV1 (
+      $root.TryGetProperty(
+        'physical_backup_data',
+        [ref]$physicalData
+      )
+    ) 'Supabase physical-backup response is missing physical_backup_data.'
+    Assert-BinderUnattendedJsonAllowedPropertiesV1 `
+      -Element $physicalData `
+      -RequiredNames @() `
+      -AllowedNames @(
+        'earliest_physical_backup_date_unix',
+        'latest_physical_backup_date_unix'
+      ) `
+      -Label 'Supabase physical-backup response.physical_backup_data'
+    Assert-BinderUnattendedConditionV1 (
+      @($physicalData.EnumerateObject()).Count -eq 0
+    ) 'Supabase physical_backup_data changed from the reviewed empty daily-backup mode.'
+    foreach ($name in @(
+      'earliest_physical_backup_date_unix',
+      'latest_physical_backup_date_unix'
+    )) {
+      $value = [System.Text.Json.JsonElement]::new()
+      if ($physicalData.TryGetProperty($name, [ref]$value)) {
+        $parsedUnix = 0L
+        Assert-BinderUnattendedConditionV1 (
+          $value.ValueKind -eq [System.Text.Json.JsonValueKind]::Null -or
+          (
+            $value.ValueKind -eq
+              [System.Text.Json.JsonValueKind]::Number -and
+            $value.TryGetInt64([ref]$parsedUnix)
+          )
+        ) "physical_backup_data.$name has an invalid type."
+      }
+    }
+
+    $backups = [System.Text.Json.JsonElement]::new()
+    Assert-BinderUnattendedConditionV1 (
+      $root.TryGetProperty('backups', [ref]$backups) -and
+      $backups.ValueKind -eq [System.Text.Json.JsonValueKind]::Array
+    ) 'Supabase physical-backup response.backups must be an array.'
+    $allRows = [System.Collections.Generic.List[object]]::new()
+    $eligible = [System.Collections.Generic.List[object]]::new()
+    $staleNewerRows = [System.Collections.Generic.List[object]]::new()
+    foreach ($backup in $backups.EnumerateArray()) {
+      Assert-BinderUnattendedJsonAllowedPropertiesV1 `
+        -Element $backup `
+        -RequiredNames @('inserted_at', 'is_physical_backup', 'status') `
+        -AllowedNames @('inserted_at', 'is_physical_backup', 'status') `
+        -Label 'Supabase physical-backup response.backups entry'
+      $insertedAtText = Get-BinderUnattendedJsonStringV1 `
+        -Element $backup -Name 'inserted_at' `
+        -Label 'Supabase physical-backup response.backups entry'
+      $insertedAt = ConvertTo-BinderUnattendedUtcV1 `
+        -Value $insertedAtText -Label 'Physical backup inserted_at'
+      $isPhysical = Get-BinderUnattendedJsonBooleanV1 `
+        -Element $backup -Name 'is_physical_backup' `
+        -Label 'Supabase physical-backup response.backups entry'
+      $status = Get-BinderUnattendedJsonStringV1 `
+        -Element $backup -Name 'status' `
+        -Label 'Supabase physical-backup response.backups entry'
+      Assert-BinderUnattendedScalarStringV1 `
+        -Value $status -Label 'Physical backup status' -MaximumLength 32
+      $row = [pscustomobject][ordered]@{
+        inserted_at_utc = $insertedAt.ToString('o')
+        is_physical_backup = $isPhysical
+        status = $status
+      }
+      $allRows.Add($row)
+      if (
+        $isPhysical -eq $true -and
+        $status -ceq 'COMPLETED' -and
+        $insertedAt -gt $backupFloor
+      ) {
+        if ($insertedAt -gt $NowUtc) {
+          Stop-BinderUnattendedV1 `
+            -ExitClass 'safe_stop_pre_mutation' `
+            -Message (
+              'A completed physical backup newer than the signed floor ' +
+              'has a future timestamp.'
+            )
+        }
+        if (
+          $insertedAt -lt
+            $NowUtc.AddMinutes(-$policy.BackupMaximumAgeMinutes)
+        ) {
+          $staleNewerRows.Add($row)
+        } else {
+          $eligible.Add($row)
+        }
+      }
+    }
+
+    $fingerprintLines = [System.Collections.Generic.List[string]]::new()
+    $fingerprintLines.Add("project_ref=$ProjectRef")
+    $fingerprintLines.Add("region=$region")
+    $fingerprintLines.Add("pitr_enabled=$($pitrEnabled.ToString().ToLowerInvariant())")
+    $fingerprintLines.Add("walg_enabled=$($walgEnabled.ToString().ToLowerInvariant())")
+    $fingerprintLines.Add(
+      "physical_backup_data=$($physicalData.GetRawText())"
+    )
+    foreach ($row in $allRows) {
+      $fingerprintLines.Add(
+        'backup=' +
+        $row.inserted_at_utc + '|' +
+        $row.is_physical_backup.ToString().ToLowerInvariant() + '|' +
+        $row.status
+      )
+    }
+    $fingerprint = Get-BinderUnattendedSha256StringV1 `
+      -Value ($fingerprintLines -join "`n")
+
+    if ($eligible.Count -gt 1) {
+      Stop-BinderUnattendedV1 `
+        -ExitClass 'safe_stop_pre_mutation' `
+        -Message (
+          'More than one eligible completed physical backup exists; ' +
+          'selection is ambiguous.'
+        )
+    }
+    if ($eligible.Count -eq 0) {
+      if ($staleNewerRows.Count -gt 0) {
+        Stop-BinderUnattendedV1 `
+          -ExitClass 'safe_stop_pre_mutation' `
+          -Message (
+            'A completed physical backup newer than the signed floor ' +
+            'is already outside the five-minute freshness window.'
+          )
+      }
+      return [pscustomobject][ordered]@{
+        Status = 'wait'
+        ProjectRef = $ProjectRef
+        EligibleCount = $eligible.Count
+        ResponseFingerprintSha256 = $fingerprint
+      }
+    }
+    return [pscustomobject][ordered]@{
+      Status = 'candidate'
+      ProjectRef = $ProjectRef
+      EligibleCount = 1
+      InsertedAtUtc = $eligible[0].inserted_at_utc
+      BackupKey = (
+        "$ProjectRef|$($eligible[0].inserted_at_utc)|PHYSICAL|COMPLETED"
+      )
+      ResponseFingerprintSha256 = $fingerprint
+      Region = $region
+    }
+  } catch {
+    if ($_.Exception.Data.Contains('BinderSupervisorExitClass')) {
+      throw
+    }
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'local_integrity_stop' `
+      -Message "Supabase physical-backup JSON is invalid: $($_.Exception.Message)"
+  } finally {
+    if ($null -ne $document) {
+      $document.Dispose()
+    }
+  }
+}
+
+function Test-BinderRoutingEnvironmentNameForSupervisorV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return [regex]::IsMatch(
+    $Name,
+    (
+      '^(?:' +
+      'PG.*|' +
+      'DB_URL|' +
+      'DATABASE_(?:URL|URI)|' +
+      'PRISMA_DATABASE_URL|' +
+      'DIRECT_URL|' +
+      'SHADOW_DATABASE_URL|' +
+      'POSTGRES(?:QL)?_URL.*|' +
+      'SUPABASE_DB_.*|' +
+      'SUPABASE_API_(?:HOST|URL)|' +
+      'SUPABASE_INTERNAL_.*|' +
+      'SUPABASE_PROJECT_(?:ID|REF)|' +
+      'SUPABASE_CA_SKIP_VERIFY|' +
+      'SUPABASE_PROFILE|' +
+      'SUPABASE_WORKDIR|' +
+      'SUPABASE_CONFIG_DIR|' +
+      'SUPABASE_.*|' +
+      'XDG_CONFIG_HOME|' +
+      'GIT_.*|' +
+      'MSYS.*|CYGWIN.*|CHERE_INVOKING|BASH_ENV|ENV|' +
+      'NODE_OPTIONS|' +
+      'PSMODULEPATH|' +
+      'POWERSHELL_DISTRIBUTION_CHANNEL|' +
+      'PSExecutionPolicyPreference|' +
+      'HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|' +
+      'SSL_CERT_FILE|SSL_CERT_DIR|SSLKEYLOGFILE|CURL_CA_BUNDLE|' +
+      'REQUESTS_CA_BUNDLE|NODE_EXTRA_CA_CERTS|' +
+      'GODEBUG|GOTRACEBACK|GOCOVERDIR|GRPC_.*|' +
+      'DOTNET_.*|' +
+      'CORECLR_.*|' +
+      'COR_.*|' +
+      'COMPLUS_.*' +
+      '|GROOKAI_BINDER_PROD_.*|' +
+      '(?:.*_)?(?:SECRET|PASSWORD|TOKEN|KEY)(?:_.*)?|' +
+      'GH_.*|GITHUB_.*|AWS_.*|AZURE_.*|GOOGLE_.*|GCP_.*' +
+      ')$'
+    ),
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  )
+}
+
+function Enter-BinderUnattendedSanitizedEnvironmentV1 {
+  $policy = Get-BinderUnattendedPolicyV1
+  $accessToken = [Environment]::GetEnvironmentVariable(
+    'SUPABASE_ACCESS_TOKEN',
+    [EnvironmentVariableTarget]::Process
+  )
+  $projectUrl = [Environment]::GetEnvironmentVariable(
+    'SUPABASE_URL',
+    [EnvironmentVariableTarget]::Process
+  )
+  Assert-BinderUnattendedConditionV1 (
+    -not [string]::IsNullOrWhiteSpace($accessToken) -and
+    -not [regex]::IsMatch($accessToken, '[\x00-\x1f\x7f]')
+  ) 'SUPABASE_ACCESS_TOKEN is required for the guarded rollout.'
+  Assert-BinderUnattendedConditionV1 (
+    $projectUrl -ceq $policy.ProjectUrl
+  ) 'SUPABASE_URL is not the exact production project origin.'
+  $saved = [ordered]@{}
+  foreach ($entry in Get-ChildItem Env:) {
+    $retained = (
+      $entry.Name.Equals(
+        'SUPABASE_ACCESS_TOKEN',
+        [System.StringComparison]::OrdinalIgnoreCase
+      ) -or
+      $entry.Name.Equals(
+        'SUPABASE_URL',
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    )
+    if ($retained) {
+      continue
+    }
+    if (Test-BinderRoutingEnvironmentNameForSupervisorV1 -Name $entry.Name) {
+      if (
+        -not $entry.Name.StartsWith(
+          'GROOKAI_BINDER_PROD_',
+          [System.StringComparison]::OrdinalIgnoreCase
+        )
+      ) {
+        $saved[$entry.Name] = [string]$entry.Value
+      }
+      Remove-Item -LiteralPath "Env:$($entry.Name)"
+    }
+  }
+  return $saved
+}
+
+function Exit-BinderUnattendedSanitizedEnvironmentV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Collections.IDictionary]$Saved
+  )
+
+  foreach ($entry in $Saved.GetEnumerator()) {
+    [Environment]::SetEnvironmentVariable(
+      [string]$entry.Key,
+      [string]$entry.Value,
+      [EnvironmentVariableTarget]::Process
+    )
+  }
+}
+
+function Protect-BinderUnattendedTextV1 {
+  param(
+    [AllowEmptyString()]
+    [string]$Text = ''
+  )
+
+  $protected = $Text
+  $protected = [regex]::Replace(
+    $protected,
+    '(?i)\bBearer\s+[A-Za-z0-9._~+/\-=]+',
+    'Bearer [REDACTED]'
+  )
+  $protected = [regex]::Replace(
+    $protected,
+    '(?i)(?<key>apikey|api_key|access_token|password|token)=([^&\s]+)',
+    '${key}=[REDACTED]'
+  )
+  $protected = [regex]::Replace(
+    $protected,
+    '(?i)"(?<key>apikey|api_key|access_token|password|token)"\s*:\s*"[^"]*"',
+    '"${key}":"[REDACTED]"'
+  )
+  $protected = [regex]::Replace(
+    $protected,
+    '(?i)\beyJ[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,}\b',
+    '[REDACTED_JWT]'
+  )
+  $protected = [regex]::Replace(
+    $protected,
+    '(?i)(?:postgres(?:ql)?|https?)://[^\s''"]+',
+    '[REDACTED_URL]'
+  )
+  $protected = [regex]::Replace(
+    $protected,
+    '(?i)\b(?:sbp_|sb_secret_|sb_publishable_)[A-Za-z0-9_-]{8,}\b',
+    '[REDACTED_SUPABASE_TOKEN]'
+  )
+  $protected = [regex]::Replace(
+    $protected,
+    '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]',
+    ''
+  )
+  if ($protected.Length -gt 2048) {
+    $protected = $protected.Substring(0, 2048) + '[TRUNCATED]'
+  }
+  return $protected
+}
+
+function Get-BinderUnattendedSupabaseExecutableV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization
+  )
+
+  $commands = @(
+    Get-Command supabase -CommandType Application `
+      -ErrorAction SilentlyContinue
+  )
+  Assert-BinderUnattendedConditionV1 (
+    $commands.Count -gt 0
+  ) 'Pinned Supabase CLI is unavailable.'
+  # Get-Command returns PATH-ordered application candidates. Selecting the
+  # first is exactly the executable bare `supabase` invocation would resolve;
+  # its pinned launcher hash below rejects any precedence hijack.
+  $command = $commands[0]
+  Assert-BinderUnattendedConditionV1 (
+    -not [string]::IsNullOrWhiteSpace([string]$command.Source)
+  ) 'Pinned Supabase CLI resolution returned an empty launcher path.'
+  $launcher = Assert-BinderUnattendedLocalPathV1 `
+    -Path ([System.IO.Path]::GetFullPath([string]$command.Source)) `
+    -Label 'Supabase CLI launcher' `
+    -RequiredType Leaf
+  $descriptor = [System.IO.Path]::ChangeExtension($launcher, '.shim')
+  $descriptor = Assert-BinderUnattendedLocalPathV1 `
+    -Path $descriptor -Label 'Supabase CLI shim descriptor' `
+    -RequiredType Leaf
+  $descriptorText = [System.IO.File]::ReadAllText($descriptor)
+  $pathMatch = [regex]::Match(
+    $descriptorText,
+    '(?m)^\s*path\s*=\s*"(?<path>[^"]+)"\s*$'
+  )
+  Assert-BinderUnattendedConditionV1 (
+    $pathMatch.Success
+  ) 'Supabase CLI shim target could not be resolved.'
+  $binaryCandidate = [System.IO.Path]::GetFullPath(
+    $pathMatch.Groups['path'].Value
+  )
+  $binaryParent = Get-Item -LiteralPath (
+    Split-Path -Parent $binaryCandidate
+  ) -Force
+  if ($binaryParent.Attributes.HasFlag(
+    [System.IO.FileAttributes]::ReparsePoint
+  )) {
+    $resolvedParent = $binaryParent.ResolveLinkTarget($true)
+    Assert-BinderUnattendedConditionV1 (
+      $null -ne $resolvedParent
+    ) 'Supabase CLI binary parent link could not be resolved.'
+    $binaryCandidate = Join-Path $resolvedParent.FullName (
+      Split-Path -Leaf $binaryCandidate
+    )
+  }
+  $binary = Assert-BinderUnattendedLocalPathV1 `
+    -Path $binaryCandidate `
+    -Label 'Supabase CLI binary' `
+    -RequiredType Leaf
+  Assert-BinderUnattendedConditionV1 (
+    (Get-BinderUnattendedSha256FileV1 -Path $launcher) -ceq
+      $Authorization.supabase_cli_launcher_sha256
+  ) 'Supabase CLI launcher hash changed.'
+  Assert-BinderUnattendedConditionV1 (
+    (Get-BinderUnattendedSha256FileV1 -Path $descriptor) -ceq
+      $Authorization.supabase_cli_shim_descriptor_sha256
+  ) 'Supabase CLI shim descriptor hash changed.'
+  Assert-BinderUnattendedConditionV1 (
+    (Get-BinderUnattendedSha256FileV1 -Path $binary) -ceq
+      $Authorization.supabase_cli_binary_sha256
+  ) 'Supabase CLI binary hash changed.'
+  return [pscustomobject][ordered]@{
+    LauncherPath = $launcher
+    ShimDescriptorPath = $descriptor
+    BinaryPath = $binary
+  }
+}
+
+function Initialize-BinderUnattendedNativeV1 {
+  if ('GrookaiBinderUnattendedNativeV1' -as [type]) {
+    return
+  }
+
+  Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+public static class GrookaiBinderUnattendedNativeV1
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SystemPowerStatus
+    {
+        public byte ACLineStatus;
+        public byte BatteryFlag;
+        public byte BatteryLifePercent;
+        public byte SystemStatusFlag;
+        public uint BatteryLifeTime;
+        public uint BatteryFullLifeTime;
+    }
+
+    [Flags]
+    public enum ExecutionState : uint
+    {
+        SystemRequired = 0x00000001,
+        Continuous = 0x80000000
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern ExecutionState SetThreadExecutionState(
+        ExecutionState esFlags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool GetSystemPowerStatus(
+        out SystemPowerStatus status);
+
+    [DllImport(
+        "kernel32.dll",
+        CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    private static extern uint QueryDosDeviceW(
+        string deviceName,
+        StringBuilder targetPath,
+        int max);
+
+    [DllImport(
+        "kernel32.dll",
+        CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport(
+        "kernel32.dll",
+        CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    private static extern uint GetFinalPathNameByHandleW(
+        SafeFileHandle file,
+        StringBuilder path,
+        uint pathLength,
+        uint flags);
+
+    public static string GetFinalPath(string path)
+    {
+        const uint FileReadAttributes = 0x80;
+        const uint ShareRead = 0x1;
+        const uint ShareWrite = 0x2;
+        const uint ShareDelete = 0x4;
+        const uint OpenExisting = 3;
+        const uint BackupSemantics = 0x02000000;
+
+        using (SafeFileHandle handle = CreateFileW(
+            path,
+            FileReadAttributes,
+            ShareRead | ShareWrite | ShareDelete,
+            IntPtr.Zero,
+            OpenExisting,
+            BackupSemantics,
+            IntPtr.Zero))
+        {
+            if (handle.IsInvalid)
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "Could not open path for final-path resolution.");
+            }
+            var buffer = new StringBuilder(32768);
+            uint length = GetFinalPathNameByHandleW(
+                handle,
+                buffer,
+                (uint)buffer.Capacity,
+                0);
+            if (length == 0 || length >= buffer.Capacity)
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "Could not resolve final path.");
+            }
+            string result = buffer.ToString();
+            const string prefix = @"\\?\";
+            if (result.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                result = result.Substring(prefix.Length);
+            }
+            return result;
+        }
+    }
+
+    public static string GetDosDeviceTarget(string drive)
+    {
+        var buffer = new StringBuilder(32768);
+        uint length = QueryDosDeviceW(drive, buffer, buffer.Capacity);
+        if (length == 0)
+        {
+            throw new Win32Exception(
+                Marshal.GetLastWin32Error(),
+                "Could not resolve DOS device target.");
+        }
+        return buffer.ToString();
+    }
+}
+'@
+}
+
+function Get-BinderUnattendedFinalPathV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  Initialize-BinderUnattendedNativeV1
+  return [System.IO.Path]::GetFullPath(
+    [GrookaiBinderUnattendedNativeV1]::GetFinalPath($Path)
+  ).TrimEnd('\')
+}
+
+function Get-BinderUnattendedWorktreePathsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $modulePath = Join-Path $RepoRoot $policy.RolloutModuleRelativePath
+  Import-Module $modulePath -Force
+  return @(Get-BinderWorktreePathsV1 -RepoRoot $RepoRoot)
+}
+
+function Assert-BinderUnattendedOutsideEveryWorktreeV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $finalPath = Get-BinderUnattendedFinalPathV1 -Path $Path
+  foreach ($worktree in (
+    Get-BinderUnattendedWorktreePathsV1 -RepoRoot $RepoRoot
+  )) {
+    $finalWorktree = Get-BinderUnattendedFinalPathV1 -Path $worktree
+    Assert-BinderUnattendedConditionV1 (
+      -not (
+        $finalPath.Equals(
+          $finalWorktree,
+          [System.StringComparison]::OrdinalIgnoreCase
+        ) -or
+        $finalPath.StartsWith(
+          "$finalWorktree\",
+          [System.StringComparison]::OrdinalIgnoreCase
+        )
+      )
+    ) "$Label must be outside every Git worktree."
+  }
+  return $finalPath
+}
+
+function Get-BinderUnattendedAllowedSidsV1 {
+  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+  Assert-BinderUnattendedConditionV1 (
+    $null -ne $identity.User
+  ) 'Current Windows user SID could not be resolved.'
+  return [pscustomobject][ordered]@{
+    CurrentUser = $identity.User
+    System = [System.Security.Principal.SecurityIdentifier]::new(
+      'S-1-5-18'
+    )
+    Administrators =
+      [System.Security.Principal.SecurityIdentifier]::new(
+        'S-1-5-32-544'
+      )
+  }
+}
+
+function Test-BinderUnattendedSidAllowedV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Security.Principal.SecurityIdentifier]$Sid,
+    [Parameter(Mandatory = $true)]
+    [object]$Allowed
+  )
+
+  return (
+    $Sid.Equals($Allowed.CurrentUser) -or
+    $Sid.Equals($Allowed.System) -or
+    $Sid.Equals($Allowed.Administrators)
+  )
+}
+
+function Assert-BinderUnattendedParentDeleteSafetyV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $allowed = Get-BinderUnattendedAllowedSidsV1
+  $dangerous = (
+    [System.Security.AccessControl.FileSystemRights]::Delete -bor
+    [System.Security.AccessControl.FileSystemRights]::
+      DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+  $cursor = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+  while ($cursor -and (Test-Path -LiteralPath $cursor)) {
+    $acl = Get-Acl -LiteralPath $cursor
+    foreach ($rule in $acl.Access) {
+      if (
+        $rule.AccessControlType -eq
+          [System.Security.AccessControl.AccessControlType]::Allow -and
+        -not $rule.PropagationFlags.HasFlag(
+          [System.Security.AccessControl.PropagationFlags]::InheritOnly
+        )
+      ) {
+        try {
+          $sid = $rule.IdentityReference.Translate(
+            [System.Security.Principal.SecurityIdentifier]
+          )
+        } catch {
+          Stop-BinderUnattendedV1 `
+            -ExitClass 'local_integrity_stop' `
+            -Message "ACL identity could not be resolved for $cursor."
+        }
+        if (-not (Test-BinderUnattendedSidAllowedV1 `
+          -Sid $sid -Allowed $allowed)) {
+          Assert-BinderUnattendedConditionV1 (
+            ($rule.FileSystemRights -band $dangerous) -eq 0
+          ) "An untrusted principal can delete or retarget secure state through $cursor."
+        }
+      }
+    }
+    $parent = Split-Path -Parent $cursor
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -ceq $cursor) {
+      break
+    }
+    $cursor = $parent
+  }
+}
+
+function Set-BinderUnattendedPrivateDirectoryAclV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $allowed = Get-BinderUnattendedAllowedSidsV1
+  $security =
+    [System.Security.AccessControl.DirectorySecurity]::new()
+  $security.SetAccessRuleProtection($true, $false)
+  $security.SetOwner($allowed.CurrentUser)
+  $inheritance = (
+    [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+    [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+  )
+  foreach ($sid in @(
+    $allowed.CurrentUser,
+    $allowed.System,
+    $allowed.Administrators
+  )) {
+    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+      $sid,
+      [System.Security.AccessControl.FileSystemRights]::FullControl,
+      $inheritance,
+      [System.Security.AccessControl.PropagationFlags]::None,
+      [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$security.AddAccessRule($rule)
+  }
+  $directory = [System.IO.DirectoryInfo]::new($Path)
+  [System.IO.FileSystemAclExtensions]::SetAccessControl(
+    $directory,
+    $security
+  )
+}
+
+function Assert-BinderUnattendedPrivateDirectoryAclV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $allowed = Get-BinderUnattendedAllowedSidsV1
+  $acl = Get-Acl -LiteralPath $Path
+  Assert-BinderUnattendedConditionV1 (
+    $acl.AreAccessRulesProtected
+  ) "Secure directory inherits ACL entries: $Path"
+  $ownerSid = (
+    [System.Security.Principal.NTAccount]$acl.Owner
+  ).Translate([System.Security.Principal.SecurityIdentifier])
+  Assert-BinderUnattendedConditionV1 (
+    Test-BinderUnattendedSidAllowedV1 -Sid $ownerSid -Allowed $allowed
+  ) "Secure directory owner is not trusted: $Path"
+  $requiredSids = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  foreach ($rule in $acl.Access) {
+    $sid = $rule.IdentityReference.Translate(
+      [System.Security.Principal.SecurityIdentifier]
+    )
+    Assert-BinderUnattendedConditionV1 (
+      $rule.AccessControlType -eq
+        [System.Security.AccessControl.AccessControlType]::Allow -and
+      (Test-BinderUnattendedSidAllowedV1 -Sid $sid -Allowed $allowed) -and
+      -not $rule.IsInherited -and
+      (
+        $rule.FileSystemRights -band
+          [System.Security.AccessControl.FileSystemRights]::FullControl
+      ) -eq [System.Security.AccessControl.FileSystemRights]::FullControl
+    ) "Secure directory ACL contains an unexpected rule: $Path"
+    [void]$requiredSids.Add($sid.Value)
+  }
+  foreach ($sid in @(
+    $allowed.CurrentUser,
+    $allowed.System,
+    $allowed.Administrators
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $requiredSids.Contains($sid.Value)
+    ) "Secure directory ACL is missing a required trustee: $Path"
+  }
+}
+
+function New-BinderUnattendedPrivateDirectoryV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [bool]$AllowExisting = $false
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+  if (Test-Path -LiteralPath $fullPath) {
+    Assert-BinderUnattendedConditionV1 $AllowExisting (
+      "Secure directory already exists unexpectedly: $fullPath"
+    )
+    [void](Assert-BinderUnattendedLocalPathV1 `
+      -Path $fullPath -Label 'Secure directory' `
+      -RequiredType Container)
+    Assert-BinderUnattendedPrivateDirectoryAclV1 -Path $fullPath
+    return $fullPath
+  }
+  $parent = Split-Path -Parent $fullPath
+  Assert-BinderUnattendedConditionV1 (
+    Test-Path -LiteralPath $parent -PathType Container
+  ) "Secure directory parent does not exist: $parent"
+  Assert-BinderUnattendedParentDeleteSafetyV1 -Path $parent
+  [void][System.IO.Directory]::CreateDirectory($fullPath)
+  Set-BinderUnattendedPrivateDirectoryAclV1 -Path $fullPath
+  [void](Assert-BinderUnattendedLocalPathV1 `
+    -Path $fullPath -Label 'Secure directory' `
+    -RequiredType Container)
+  Assert-BinderUnattendedPrivateDirectoryAclV1 -Path $fullPath
+  Assert-BinderUnattendedParentDeleteSafetyV1 -Path $parent
+  return $fullPath
+}
+
+function Initialize-BinderUnattendedSecureRootsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $localAppData = [Environment]::GetFolderPath(
+    [Environment+SpecialFolder]::LocalApplicationData
+  )
+  [void](Assert-BinderUnattendedLocalPathV1 `
+    -Path $localAppData -Label 'LocalApplicationData' `
+    -RequiredType Container)
+  Assert-BinderUnattendedParentDeleteSafetyV1 -Path $localAppData
+  [void](New-BinderUnattendedPrivateDirectoryV1 `
+    -Path $policy.BaseNamespaceRoot -AllowExisting $true)
+  $namespace = New-BinderUnattendedPrivateDirectoryV1 `
+    -Path $policy.SecureNamespaceRoot -AllowExisting $true
+  [void](New-BinderUnattendedPrivateDirectoryV1 `
+    -Path $policy.StateNamespaceRoot -AllowExisting $true)
+  $state = New-BinderUnattendedPrivateDirectoryV1 `
+    -Path $policy.StateRoot -AllowExisting $true
+  $artifacts = New-BinderUnattendedPrivateDirectoryV1 `
+    -Path $policy.ArtifactNamespaceRoot -AllowExisting $true
+  return [pscustomobject][ordered]@{
+    NamespaceRoot = $namespace
+    StateRoot = $state
+    ArtifactNamespaceRoot = $artifacts
+    ArtifactRoot = $Authorization.artifact_root
+  }
+}
+
+function Assert-BinderUnattendedStateAvailableV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$StateRoot
+  )
+
+  Assert-BinderUnattendedPrivateDirectoryAclV1 -Path $StateRoot
+  $entries = @(
+    Get-ChildItem -LiteralPath $StateRoot -Force
+  )
+  $mutationClaimPath = Join-Path (
+    $StateRoot
+  ) (Get-BinderUnattendedPolicyV1).MutationClaimFileName
+  if (Test-Path -LiteralPath $mutationClaimPath) {
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'mutation_possible_stop' `
+      -Message (
+        'Stable state contains the durable mutation-launch marker. ' +
+        'Automation is permanently blocked and database state may have changed.'
+      )
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $entries.Count -eq 0
+  ) (
+    'Stable package/project state is not empty. A prior, corrupt, ' +
+    'unknown, or mutation-possible attempt permanently blocks automation.'
+  )
+}
+
+function New-BinderUnattendedArtifactRunRootV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactRoot
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    -not (Test-Path -LiteralPath $ArtifactRoot)
+  ) 'Authorization artifact run root already exists.'
+  return New-BinderUnattendedPrivateDirectoryV1 -Path $ArtifactRoot
+}
+
+function New-BinderUnattendedMutexV1 {
+  $policy = Get-BinderUnattendedPolicyV1
+  $allowed = Get-BinderUnattendedAllowedSidsV1
+  $security = [System.Security.AccessControl.MutexSecurity]::new()
+  $security.SetAccessRuleProtection($true, $false)
+  foreach ($sid in @(
+    $allowed.CurrentUser,
+    $allowed.System,
+    $allowed.Administrators
+  )) {
+    $rule = [System.Security.AccessControl.MutexAccessRule]::new(
+      $sid,
+      [System.Security.AccessControl.MutexRights]::FullControl,
+      [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$security.AddAccessRule($rule)
+  }
+  $createdNew = $false
+  try {
+    $mutex = [System.Threading.MutexAcl]::Create(
+      $false,
+      $policy.MutexName,
+      [ref]$createdNew,
+      $security
+    )
+  } catch {
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'local_integrity_stop' `
+      -Message 'The fixed global rollout mutex could not be created.'
+  }
+  if (-not $createdNew) {
+    $mutex.Dispose()
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'safe_stop_pre_mutation' `
+      -Message 'The fixed global rollout mutex already exists.'
+  }
+  try {
+    $acquired = $mutex.WaitOne(0)
+  } catch [System.Threading.AbandonedMutexException] {
+    $mutex.Dispose()
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'local_integrity_stop' `
+      -Message 'The fixed global rollout mutex was abandoned.'
+  }
+  if (-not $acquired) {
+    $mutex.Dispose()
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'safe_stop_pre_mutation' `
+      -Message 'Another Binder rollout supervisor owns the global mutex.'
+  }
+  return $mutex
+}
+
+function Enter-BinderUnattendedWakeLockV1 {
+  Initialize-BinderUnattendedNativeV1
+  $flags = (
+    [GrookaiBinderUnattendedNativeV1+ExecutionState]::Continuous -bor
+    [GrookaiBinderUnattendedNativeV1+ExecutionState]::SystemRequired
+  )
+  $previous =
+    [GrookaiBinderUnattendedNativeV1]::SetThreadExecutionState($flags)
+  Assert-BinderUnattendedConditionV1 (
+    [uint32]$previous -ne 0
+  ) 'Windows system-awake lock could not be established.'
+  return $true
+}
+
+function Exit-BinderUnattendedWakeLockV1 {
+  if ('GrookaiBinderUnattendedNativeV1' -as [type]) {
+    [void][GrookaiBinderUnattendedNativeV1]::SetThreadExecutionState(
+      [GrookaiBinderUnattendedNativeV1+ExecutionState]::Continuous
+    )
+  }
+}
+
+function Assert-BinderUnattendedAcPowerV1 {
+  Initialize-BinderUnattendedNativeV1
+  $status =
+    [GrookaiBinderUnattendedNativeV1+SystemPowerStatus]::new()
+  $succeeded =
+    [GrookaiBinderUnattendedNativeV1]::GetSystemPowerStatus(
+      [ref]$status
+    )
+  Assert-BinderUnattendedConditionV1 (
+    $succeeded -and $status.ACLineStatus -eq 1
+  ) 'Unattended production rollout requires confirmed AC power.'
+  return [pscustomobject][ordered]@{
+    ACLineStatus = [int]$status.ACLineStatus
+    BatteryFlag = [int]$status.BatteryFlag
+    BatteryLifePercent = [int]$status.BatteryLifePercent
+  }
+}
+
+function Write-BinderUnattendedCreateNewDurableV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [byte[]]$Bytes
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  $parent = Split-Path -Parent $fullPath
+  Assert-BinderUnattendedPrivateDirectoryAclV1 -Path $parent
+  $stream = $null
+  try {
+    $stream = [System.IO.FileStream]::new(
+      $fullPath,
+      [System.IO.FileMode]::CreateNew,
+      [System.IO.FileAccess]::Write,
+      [System.IO.FileShare]::Read,
+      4096,
+      [System.IO.FileOptions]::WriteThrough
+    )
+    $stream.Write($Bytes, 0, $Bytes.Length)
+    $stream.Flush($true)
+  } catch [System.IO.IOException] {
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'local_integrity_stop' `
+      -Message "Durable at-most-once state already exists or could not be created: $fullPath"
+  } finally {
+    if ($null -ne $stream) {
+      $stream.Dispose()
+    }
+  }
+  $item = Get-Item -LiteralPath $fullPath -Force
+  Assert-BinderUnattendedConditionV1 (
+    -not $item.Attributes.HasFlag(
+      [System.IO.FileAttributes]::ReparsePoint
+    )
+  ) 'Durable state file became a reparse point.'
+  $readback = [System.IO.File]::ReadAllBytes($fullPath)
+  $matches = $readback.Length -eq $Bytes.Length
+  if ($matches) {
+    for ($index = 0; $index -lt $Bytes.Length; $index += 1) {
+      if ($readback[$index] -ne $Bytes[$index]) {
+        $matches = $false
+        break
+      }
+    }
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $matches
+  ) 'Durable state file readback differs from the flushed claim bytes.'
+  return $fullPath
+}
+
+function New-BinderUnattendedClaimV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('attempt', 'mutation')]
+    [string]$Kind,
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorizationSha256,
+    [Parameter(Mandatory = $true)]
+    [string]$StateRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$PreflightManifestSha256,
+    [datetimeoffset]$NowUtc = [datetimeoffset]::UtcNow
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $fileName = if ($Kind -ceq 'attempt') {
+    $policy.AttemptClaimFileName
+  } else {
+    $policy.MutationClaimFileName
+  }
+  $claim = [ordered]@{
+    schema_version = 1
+    claim_kind = $Kind
+    project_ref = $policy.ProjectRef
+    package_id = $policy.PackageId
+    package_fingerprint_sha256 = $policy.PackageFingerprintSha256
+    authorization_id = $Authorization.authorization_id
+    authorization_sha256 = $AuthorizationSha256
+    reviewed_main_sha = $Authorization.reviewed_main_sha
+    preflight_manifest_sha256 = $PreflightManifestSha256
+    committed_at_utc = $NowUtc.ToString('o')
+  }
+  $json = ($claim | ConvertTo-Json -Compress -Depth 8)
+  return Write-BinderUnattendedCreateNewDurableV1 `
+    -Path (Join-Path $StateRoot $fileName) `
+    -Bytes ([System.Text.UTF8Encoding]::new($false).GetBytes($json))
+}
+
+function Get-BinderUnattendedFilesNoReparseV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Root
+  )
+
+  $rootPath = [System.IO.Path]::GetFullPath($Root).TrimEnd('\')
+  $directories =
+    [System.Collections.Generic.Stack[string]]::new()
+  $directories.Push($rootPath)
+  $files = [System.Collections.Generic.List[object]]::new()
+  while ($directories.Count -gt 0) {
+    $directory = $directories.Pop()
+    $directoryItem = Get-Item -LiteralPath $directory -Force
+    Assert-BinderUnattendedConditionV1 (
+      -not $directoryItem.Attributes.HasFlag(
+        [System.IO.FileAttributes]::ReparsePoint
+      )
+    ) "Artifact directory is a reparse point: $directory"
+    foreach ($item in Get-ChildItem -LiteralPath $directory -Force) {
+      Assert-BinderUnattendedConditionV1 (
+        -not $item.Attributes.HasFlag(
+          [System.IO.FileAttributes]::ReparsePoint
+        )
+      ) "Artifact entry is a reparse point: $($item.FullName)"
+      if ($item.PSIsContainer) {
+        $directories.Push($item.FullName)
+      } else {
+        $files.Add($item)
+      }
+    }
+  }
+  return @($files)
+}
+
+function Test-BinderUnattendedChecksumsV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Root,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$ExpectedRelativeFiles
+  )
+
+  $rootPath = Assert-BinderUnattendedLocalPathV1 `
+    -Path $Root -Label 'Preflight artifact root' `
+    -RequiredType Container
+  Assert-BinderUnattendedConditionV1 (
+    @(
+      Get-ChildItem -LiteralPath $rootPath -Directory -Force
+    ).Count -eq 0
+  ) 'Preflight artifact root must not contain subdirectories.'
+  $checksumPath = Join-Path $rootPath 'checksums.sha256'
+  [void](Assert-BinderUnattendedLocalPathV1 `
+    -Path $checksumPath -Label 'Preflight checksum file' `
+    -RequiredType Leaf)
+  $checksumBytes = [System.IO.File]::ReadAllBytes($checksumPath)
+  Assert-BinderUnattendedConditionV1 (
+    -not (
+      $checksumBytes.Length -ge 3 -and
+      $checksumBytes[0] -eq 0xef -and
+      $checksumBytes[1] -eq 0xbb -and
+      $checksumBytes[2] -eq 0xbf
+    )
+  ) 'Preflight checksum file must not contain a BOM.'
+  foreach ($value in $checksumBytes) {
+    Assert-BinderUnattendedConditionV1 (
+      $value -ge 0x20 -or $value -eq 0x0a
+    ) 'Preflight checksum file contains a forbidden control byte.'
+  }
+  $checksumText = [System.Text.UTF8Encoding]::new(
+    $false,
+    $true
+  ).GetString($checksumBytes)
+  Assert-BinderUnattendedConditionV1 (
+    $checksumText.EndsWith("`n", [StringComparison]::Ordinal) -and
+    -not $checksumText.Contains("`r") -and
+    (
+      $checksumText.Length -eq 1 -or
+      $checksumText[$checksumText.Length - 2] -ne "`n"
+    )
+  ) 'Preflight checksum file must use LF and end with one LF.'
+  $lines = @(
+    $checksumText.Substring(0, $checksumText.Length - 1) -split "`n"
+  )
+  $entries = [ordered]@{}
+  $caseFolded = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  foreach ($line in $lines) {
+    $match = [regex]::Match(
+      $line,
+      '^(?<sha>[0-9a-f]{64})  (?<path>[A-Za-z0-9._/-]+)$'
+    )
+    Assert-BinderUnattendedConditionV1 (
+      $match.Success
+    ) 'Preflight checksum line is not canonical.'
+    $relative = $match.Groups['path'].Value
+    $segments = @($relative -split '/')
+    Assert-BinderUnattendedConditionV1 (
+      -not $relative.StartsWith('/') -and
+      -not $relative.Contains('\') -and
+      -not $relative.Contains(':') -and
+      -not ($segments -ccontains '') -and
+      -not ($segments -ccontains '..') -and
+      -not ($segments -ccontains '.')
+    ) 'Preflight checksum path is unsafe.'
+    foreach ($segment in $segments) {
+      Assert-BinderUnattendedConditionV1 (
+        -not $segment.EndsWith(
+          '.',
+          [StringComparison]::Ordinal
+        ) -and
+        -not $segment.EndsWith(
+          ' ',
+          [StringComparison]::Ordinal
+        ) -and
+        -not (
+          [System.IO.Path]::GetFileNameWithoutExtension($segment) -match
+            '^(?i:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$'
+        )
+      ) 'Preflight checksum path contains a Windows alias or reserved name.'
+    }
+    Assert-BinderUnattendedConditionV1 (
+      -not $entries.Contains($relative) -and
+      $caseFolded.Add($relative)
+    ) 'Preflight checksum contains a duplicate or case-colliding path.'
+    $entries[$relative] = $match.Groups['sha'].Value
+  }
+  $expected = @($ExpectedRelativeFiles)
+  $actualEntryNames = @($entries.Keys)
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual $actualEntryNames -Expected $expected `
+    -Label 'Preflight checksum paths'
+
+  $actualFiles = @(
+    Get-BinderUnattendedFilesNoReparseV1 -Root $rootPath |
+      Where-Object {
+        -not $_.FullName.Equals(
+          $checksumPath,
+          [System.StringComparison]::OrdinalIgnoreCase
+        )
+      } |
+      ForEach-Object {
+        [System.IO.Path]::GetRelativePath(
+          $rootPath,
+          $_.FullName
+        ).Replace('\', '/')
+      }
+  )
+  Assert-BinderUnattendedConditionV1 (
+    $actualFiles.Count -eq $expected.Count
+  ) 'Preflight artifact file count is not exact.'
+  $actualFileSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  $actualFileFolded =
+    [System.Collections.Generic.HashSet[string]]::new(
+      [System.StringComparer]::OrdinalIgnoreCase
+    )
+  foreach ($relative in $actualFiles) {
+    Assert-BinderUnattendedConditionV1 (
+      $actualFileSet.Add($relative) -and
+      $actualFileFolded.Add($relative)
+    ) 'Preflight artifacts contain duplicate or case-colliding paths.'
+  }
+  foreach ($relative in $expected) {
+    Assert-BinderUnattendedConditionV1 (
+      $actualFileSet.Contains($relative)
+    ) "Preflight artifact is missing: $relative"
+  }
+  foreach ($relative in $entries.Keys) {
+    $fullPath = [System.IO.Path]::GetFullPath(
+      (Join-Path $rootPath $relative)
+    )
+    Assert-BinderUnattendedConditionV1 (
+      $fullPath.StartsWith(
+        "$rootPath\",
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    ) 'Preflight checksum path escaped the artifact root.'
+    Assert-BinderUnattendedConditionV1 (
+      (Get-BinderUnattendedSha256FileV1 -Path $fullPath) -ceq
+        $entries[$relative]
+    ) "Preflight artifact checksum mismatch: $relative"
+  }
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    FileCount = $entries.Count
+    ChecksumFileSha256 =
+      Get-BinderUnattendedSha256FileV1 -Path $checksumPath
+  }
+}
+
+function Assert-BinderUnattendedNoJsonCollisionsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element,
+    [string]$Label = 'JSON'
+  )
+
+  if ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Object) {
+    $ordinal = [System.Collections.Generic.HashSet[string]]::new(
+      [System.StringComparer]::Ordinal
+    )
+    $folded = [System.Collections.Generic.HashSet[string]]::new(
+      [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($property in $Element.EnumerateObject()) {
+      Assert-BinderUnattendedConditionV1 (
+        $ordinal.Add($property.Name) -and
+        $folded.Add($property.Name) -and
+        -not [regex]::IsMatch($property.Name, '[\x00-\x1f\x7f]')
+      ) "$Label contains duplicate, case-colliding, or unsafe fields."
+      Assert-BinderUnattendedNoJsonCollisionsV1 `
+        -Element $property.Value -Label "$Label.$($property.Name)"
+    }
+  } elseif ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
+    $index = 0
+    foreach ($entry in $Element.EnumerateArray()) {
+      Assert-BinderUnattendedNoJsonCollisionsV1 `
+        -Element $entry -Label "$Label[$index]"
+      $index += 1
+    }
+  }
+}
+
+function ConvertFrom-BinderUnattendedJsonElementV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Text.Json.JsonElement]$Element
+  )
+
+  switch ($Element.ValueKind) {
+    ([System.Text.Json.JsonValueKind]::Object) {
+      $value = [ordered]@{}
+      foreach ($property in $Element.EnumerateObject()) {
+        $value[$property.Name] =
+          ConvertFrom-BinderUnattendedJsonElementV1 `
+            -Element $property.Value
+      }
+      return [pscustomobject]$value
+    }
+    ([System.Text.Json.JsonValueKind]::Array) {
+      $values = [System.Collections.Generic.List[object]]::new()
+      foreach ($entry in $Element.EnumerateArray()) {
+        $values.Add(
+          (ConvertFrom-BinderUnattendedJsonElementV1 -Element $entry)
+        )
+      }
+      return ,$values.ToArray()
+    }
+    ([System.Text.Json.JsonValueKind]::String) {
+      return $Element.GetString()
+    }
+    ([System.Text.Json.JsonValueKind]::Number) {
+      $integer = 0L
+      if ($Element.TryGetInt64([ref]$integer)) {
+        return $integer
+      }
+      $decimal = [decimal]::Zero
+      if ($Element.TryGetDecimal([ref]$decimal)) {
+        return $decimal
+      }
+      return $Element.GetDouble()
+    }
+    ([System.Text.Json.JsonValueKind]::True) {
+      return $true
+    }
+    ([System.Text.Json.JsonValueKind]::False) {
+      return $false
+    }
+    ([System.Text.Json.JsonValueKind]::Null) {
+      return $null
+    }
+    default {
+      Stop-BinderUnattendedV1 `
+        -ExitClass 'local_integrity_stop' `
+        -Message 'Reviewed JSON artifact contains an unsupported value kind.'
+    }
+  }
+}
+
+function Read-BinderUnattendedJsonFileV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [string[]]$RequiredTopLevelNames = @(),
+    [string[]]$AllowedTopLevelNames = @()
+  )
+
+  [void](Assert-BinderUnattendedLocalPathV1 `
+    -Path $Path -Label 'Reviewed JSON artifact' -RequiredType Leaf)
+  $bytes = [System.IO.File]::ReadAllBytes($Path)
+  Assert-BinderUnattendedConditionV1 (
+    -not (
+      $bytes.Length -ge 3 -and
+      $bytes[0] -eq 0xef -and
+      $bytes[1] -eq 0xbb -and
+      $bytes[2] -eq 0xbf
+    )
+  ) 'Reviewed JSON artifact contains a BOM.'
+  $json = [System.Text.UTF8Encoding]::new($false, $true).GetString(
+    $bytes
+  )
+  $document = $null
+  $materialized = $null
+  try {
+    $document = [System.Text.Json.JsonDocument]::Parse($json)
+    Assert-BinderUnattendedNoJsonCollisionsV1 `
+      -Element $document.RootElement -Label 'Reviewed JSON artifact'
+    if ($AllowedTopLevelNames.Count -gt 0) {
+      Assert-BinderUnattendedJsonAllowedPropertiesV1 `
+        -Element $document.RootElement `
+        -RequiredNames $RequiredTopLevelNames `
+        -AllowedNames $AllowedTopLevelNames `
+        -Label 'Reviewed JSON artifact'
+    }
+    $materialized = ConvertFrom-BinderUnattendedJsonElementV1 `
+      -Element $document.RootElement
+  } finally {
+    if ($null -ne $document) {
+      $document.Dispose()
+    }
+  }
+  return $materialized
+}
+
+function Read-BinderUnattendedStrictShaSidecarV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $fullPath = Assert-BinderUnattendedLocalPathV1 `
+    -Path $Path -Label 'SHA-256 sidecar' -RequiredType Leaf
+  $bytes = [System.IO.File]::ReadAllBytes($fullPath)
+  Assert-BinderUnattendedConditionV1 (
+    $bytes.Length -eq 65 -and $bytes[64] -eq 0x0a
+  ) 'SHA-256 sidecar must be exactly 64 lowercase hex bytes plus LF.'
+  $text = [System.Text.Encoding]::ASCII.GetString(
+    $bytes,
+    0,
+    64
+  )
+  Assert-BinderUnattendedConditionV1 (
+    $text -cmatch '^[0-9a-f]{64}$'
+  ) 'SHA-256 sidecar is invalid.'
+  return $text
+}
+
+function Read-BinderUnattendedStrictApprovalV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [object]$Manifest
+  )
+
+  $fullPath = Assert-BinderUnattendedLocalPathV1 `
+    -Path $Path -Label 'Approval artifact' -RequiredType Leaf
+  $bytes = [System.IO.File]::ReadAllBytes($fullPath)
+  Assert-BinderUnattendedConditionV1 (
+    -not (
+      $bytes.Length -ge 3 -and
+      $bytes[0] -eq 0xef -and
+      $bytes[1] -eq 0xbb -and
+      $bytes[2] -eq 0xbf
+    )
+  ) 'Approval artifact must not contain a BOM.'
+  foreach ($value in $bytes) {
+    Assert-BinderUnattendedConditionV1 (
+      $value -ge 0x20 -or $value -eq 0x0a
+    ) 'Approval artifact contains a forbidden control byte.'
+  }
+  $text = [System.Text.UTF8Encoding]::new($false, $true).GetString(
+    $bytes
+  )
+  $expectedApply = (
+    'GROOKAI_BINDER_PROD_APPLY_ACK=' +
+    'APPLY-COLLABORATIVE-BINDERS-V1::' +
+    "$($Manifest.project_ref)::" +
+    "$($Manifest.head_sha)::" +
+    $Manifest.manifest_fingerprint_sha256
+  )
+  $expectedBackup = (
+    'GROOKAI_BINDER_PROD_BACKUP_ACK=' +
+    "BACKUP-VERIFIED::$($Manifest.project_ref)::" +
+    $Manifest.backup_evidence_sha256
+  )
+  $expectedText = "$expectedApply`n$expectedBackup`n"
+  Assert-BinderUnattendedConditionV1 (
+    $text -ceq $expectedText
+  ) 'Approval artifact is not the exact derived two-line acknowledgement.'
+  return [pscustomobject][ordered]@{
+    ApplyAck = $expectedApply.Substring(
+      'GROOKAI_BINDER_PROD_APPLY_ACK='.Length
+    )
+    BackupAck = $expectedBackup.Substring(
+      'GROOKAI_BINDER_PROD_BACKUP_ACK='.Length
+    )
+  }
+}
+
+function Assert-BinderUnattendedObjectPropertySetV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Value,
+    [Parameter(Mandatory = $true)]
+    [string[]]$ExpectedNames,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Assert-BinderUnattendedConditionV1 (
+    $null -ne $Value
+  ) "$Label must be an object."
+  $properties = @($Value.PSObject.Properties)
+  Assert-BinderUnattendedConditionV1 (
+    $properties.Count -eq $ExpectedNames.Count
+  ) "$Label field count is not exact."
+  $actual = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+  )
+  $folded = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  foreach ($property in $properties) {
+    Assert-BinderUnattendedConditionV1 (
+      $actual.Add($property.Name) -and
+      $folded.Add($property.Name)
+    ) "$Label has duplicate or case-colliding fields."
+  }
+  foreach ($name in $ExpectedNames) {
+    Assert-BinderUnattendedConditionV1 (
+      $actual.Contains($name)
+    ) "$Label is missing $name."
+  }
+}
+
+function Test-BinderUnattendedPreflightArtifactsV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PreflightRoot,
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [Parameter(Mandatory = $true)]
+    [string]$BackupEvidencePath,
+    [string]$RepoRoot = (Get-BinderUnattendedRepoRootV1),
+    [datetimeoffset]$NowUtc = [datetimeoffset]::UtcNow
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $checksum = Test-BinderUnattendedChecksumsV1 `
+    -Root $PreflightRoot `
+    -ExpectedRelativeFiles $policy.PreflightArtifacts
+  $manifestPath = Join-Path $PreflightRoot 'preflight-manifest.json'
+  $manifestSidecar = Join-Path (
+    $PreflightRoot
+  ) 'preflight-manifest.sha256'
+  $manifestFileSha256 = Read-BinderUnattendedStrictShaSidecarV1 `
+    -Path $manifestSidecar
+  Assert-BinderUnattendedConditionV1 (
+    (Get-BinderUnattendedSha256FileV1 -Path $manifestPath) -ceq
+      $manifestFileSha256
+  ) 'Preflight manifest sidecar does not match the manifest bytes.'
+
+  $manifestFields = @(
+    'schema_version',
+    'package_id',
+    'status',
+    'created_at_utc',
+    'expires_at_utc',
+    'project_ref',
+    'package_fingerprint_sha256',
+    'package_manifest_file_sha256',
+    'head_sha',
+    'origin_main_sha',
+    'supabase_config_sha256',
+    'linked_project_ref_sha256',
+    'linked_pooler_url_sha256',
+    'linked_project_metadata_sha256',
+    'git_executable_path',
+    'git_executable_sha256',
+    'git_version',
+    'git_exec_path',
+    'git_https_helper_path',
+    'git_https_helper_sha256',
+    'git_common_config_sha256',
+    'git_metadata_count',
+    'git_metadata_sha256',
+    'supabase_cli_version',
+    'supabase_cli_launcher_sha256',
+    'supabase_cli_binary_sha256',
+    'supabase_cli_shim_descriptor_sha256',
+    'tracked_migration_count',
+    'tracked_migration_set_sha256',
+    'migration_files',
+    'pending_versions',
+    'dry_run_files',
+    'preapply_readback_sha256',
+    'stable_catalog_fingerprint_sha256',
+    'backup_evidence_path',
+    'backup_evidence_sha256',
+    'apply_argv',
+    'manifest_fingerprint_sha256'
+  )
+  $manifest = Read-BinderUnattendedJsonFileV1 `
+    -Path $manifestPath `
+    -RequiredTopLevelNames $manifestFields `
+    -AllowedTopLevelNames $manifestFields
+
+  $rolloutModulePath = Join-Path (
+    $RepoRoot
+  ) $policy.RolloutModuleRelativePath
+  Import-Module $rolloutModulePath -Force
+  $guardManifest = Test-PreflightManifestV1 `
+    -Path $manifestPath `
+    -NowUtc $NowUtc.UtcDateTime
+  Assert-BinderUnattendedConditionV1 (
+    $guardManifest.FingerprintSha256 -ceq
+      $manifest.manifest_fingerprint_sha256
+  ) 'Independent preflight manifest fingerprint mismatch.'
+  Assert-BinderUnattendedConditionV1 (
+    $manifest.schema_version -is [long] -and
+    $manifest.tracked_migration_count -is [long] -and
+    $manifest.git_metadata_count -is [long] -and
+    $manifest.migration_files -is [object[]] -and
+    $manifest.pending_versions -is [object[]] -and
+    $manifest.dry_run_files -is [object[]] -and
+    $manifest.apply_argv -is [object[]]
+  ) 'Preflight manifest primitive types are not exact JSON types.'
+  foreach ($name in @(
+    $manifestFields |
+      Where-Object {
+        $_ -notin @(
+          'schema_version',
+          'tracked_migration_count',
+          'git_metadata_count',
+          'migration_files',
+          'pending_versions',
+          'dry_run_files',
+          'apply_argv'
+        )
+      }
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $manifest.PSObject.Properties[$name].Value -is [string]
+    ) "Preflight manifest $name must be a JSON string."
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $manifest.schema_version -eq 1 -and
+    $manifest.package_id -ceq $Authorization.package_id -and
+    $manifest.status -ceq 'pass' -and
+    $manifest.project_ref -ceq $Authorization.project_ref -and
+    $manifest.package_fingerprint_sha256 -ceq
+      $Authorization.package_fingerprint_sha256 -and
+    $manifest.package_manifest_file_sha256 -ceq
+      $Authorization.package_manifest_sha256 -and
+    $manifest.head_sha -ceq $Authorization.reviewed_main_sha -and
+    $manifest.origin_main_sha -ceq $Authorization.reviewed_main_sha
+  ) 'Preflight manifest identity differs from the authorization envelope.'
+  Assert-BinderUnattendedConditionV1 (
+    $manifest.supabase_config_sha256 -ceq
+      $Authorization.supabase_config_sha256 -and
+    $manifest.linked_project_ref_sha256 -ceq
+      $Authorization.linked_project_ref_sha256 -and
+    $manifest.linked_pooler_url_sha256 -ceq
+      $Authorization.linked_pooler_url_sha256 -and
+    $manifest.linked_project_metadata_sha256 -ceq
+      $Authorization.linked_project_metadata_sha256 -and
+    $manifest.git_executable_path -ceq
+      $Authorization.git_executable_path -and
+    $manifest.git_executable_sha256 -ceq
+      $Authorization.git_executable_sha256 -and
+    $manifest.git_version -ceq $Authorization.git_version -and
+    $manifest.git_exec_path -ceq $Authorization.git_exec_path -and
+    $manifest.git_https_helper_path -ceq
+      $Authorization.git_https_helper_path -and
+    $manifest.git_https_helper_sha256 -ceq
+      $Authorization.git_https_helper_sha256 -and
+    $manifest.git_common_config_sha256 -ceq
+      $Authorization.git_common_config_sha256 -and
+    $manifest.git_metadata_count -eq
+      $Authorization.git_metadata_count -and
+    $manifest.git_metadata_sha256 -ceq
+      $Authorization.git_metadata_sha256 -and
+    $manifest.supabase_cli_version -ceq
+      $Authorization.supabase_cli_version -and
+    $manifest.supabase_cli_launcher_sha256 -ceq
+      $Authorization.supabase_cli_launcher_sha256 -and
+    $manifest.supabase_cli_binary_sha256 -ceq
+      $Authorization.supabase_cli_binary_sha256 -and
+    $manifest.supabase_cli_shim_descriptor_sha256 -ceq
+      $Authorization.supabase_cli_shim_descriptor_sha256 -and
+    $manifest.tracked_migration_count -eq
+      $Authorization.tracked_migration_count -and
+    $manifest.tracked_migration_set_sha256 -ceq
+      $Authorization.tracked_migration_set_sha256
+  ) 'Preflight manifest source or CLI identity differs from authorization.'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($manifest.pending_versions) `
+    -Expected @($policy.Migrations | ForEach-Object version) `
+    -Label 'Preflight pending migration versions'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($manifest.dry_run_files) `
+    -Expected @($policy.Migrations | ForEach-Object file) `
+    -Label 'Preflight dry-run files'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($manifest.apply_argv) `
+    -Expected @($policy.ApplyArguments) `
+    -Label 'Preflight apply argv'
+  Assert-BinderUnattendedConditionV1 (
+    @($manifest.migration_files).Count -eq @($policy.Migrations).Count
+  ) 'Preflight manifest migration count mismatch.'
+  for ($index = 0; $index -lt @($policy.Migrations).Count; $index += 1) {
+    $actual = @($manifest.migration_files)[$index]
+    $expected = @($policy.Migrations)[$index]
+    Assert-BinderUnattendedObjectPropertySetV1 `
+      -Value $actual `
+      -ExpectedNames @('version', 'file', 'sha256') `
+      -Label "Preflight manifest migration_files[$index]"
+    Assert-BinderUnattendedConditionV1 (
+      $actual.version -is [string] -and
+      $actual.file -is [string] -and
+      $actual.sha256 -is [string] -and
+      $actual.version -ceq $expected.version -and
+      $actual.file -ceq $expected.file -and
+      $actual.sha256 -ceq $expected.sha256
+    ) "Preflight manifest migration mismatch at position $index."
+  }
+
+  $actualBackupHash = Get-BinderUnattendedSha256FileV1 `
+    -Path $BackupEvidencePath
+  $backupEvidenceFields = @(
+    'schema_version',
+    'project_ref',
+    'backup_kind',
+    'verified_at_utc',
+    'recoverable_through_utc',
+    'evidence_reference',
+    'restore_path_reviewed',
+    'operator'
+  )
+  $backupEvidence = Read-BinderUnattendedJsonFileV1 `
+    -Path $BackupEvidencePath `
+    -RequiredTopLevelNames $backupEvidenceFields `
+    -AllowedTopLevelNames $backupEvidenceFields
+  Assert-BinderUnattendedConditionV1 (
+    $manifest.backup_evidence_path -ceq $BackupEvidencePath -and
+    $manifest.backup_evidence_sha256 -ceq $actualBackupHash
+  ) 'Preflight manifest does not bind the fresh supervisor backup evidence.'
+
+  $sourceFields = @(
+    'Status',
+    'PackageId',
+    'PackageFingerprintSha256',
+    'PackageManifestFileSha256',
+    'ProjectRef',
+    'SupabaseConfigSha256',
+    'GitExecutablePath',
+    'GitExecutableSha256',
+    'GitVersion',
+    'GitExecPath',
+    'GitHttpsHelperPath',
+    'GitHttpsHelperSha256',
+    'GitCommonConfigSha256',
+    'GitMetadataCount',
+    'GitMetadataSha256',
+    'SupabaseCliVersion',
+    'SupabaseCliLauncherSha256',
+    'SupabaseCliBinarySha256',
+    'SupabaseCliShimDescriptorSha256',
+    'TrackedMigrationCount',
+    'TrackedMigrationSetSha256',
+    'MigrationFiles'
+  )
+  $source = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'source.json') `
+    -RequiredTopLevelNames $sourceFields `
+    -AllowedTopLevelNames $sourceFields
+  Assert-BinderUnattendedConditionV1 (
+    $source.TrackedMigrationCount -is [long] -and
+    $source.GitMetadataCount -is [long] -and
+    $source.MigrationFiles -is [object[]]
+  ) 'Preflight source count/array primitive types are not exact.'
+  foreach ($name in @(
+    $sourceFields |
+      Where-Object {
+        $_ -notin @(
+          'TrackedMigrationCount',
+          'GitMetadataCount',
+          'MigrationFiles'
+        )
+      }
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $source.PSObject.Properties[$name].Value -is [string]
+    ) "Preflight source $name must be a JSON string."
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $source.Status -ceq 'pass' -and
+    $source.PackageId -ceq $Authorization.package_id -and
+    $source.PackageFingerprintSha256 -ceq
+      $Authorization.package_fingerprint_sha256 -and
+    $source.PackageManifestFileSha256 -ceq
+      $Authorization.package_manifest_sha256 -and
+    $source.ProjectRef -ceq $Authorization.project_ref -and
+    $source.SupabaseConfigSha256 -ceq
+      $Authorization.supabase_config_sha256 -and
+    $source.GitExecutablePath -ceq
+      $Authorization.git_executable_path -and
+    $source.GitExecutableSha256 -ceq
+      $Authorization.git_executable_sha256 -and
+    $source.GitVersion -ceq $Authorization.git_version -and
+    $source.GitExecPath -ceq $Authorization.git_exec_path -and
+    $source.GitHttpsHelperPath -ceq
+      $Authorization.git_https_helper_path -and
+    $source.GitHttpsHelperSha256 -ceq
+      $Authorization.git_https_helper_sha256 -and
+    $source.GitCommonConfigSha256 -ceq
+      $Authorization.git_common_config_sha256 -and
+    $source.GitMetadataCount -eq
+      $Authorization.git_metadata_count -and
+    $source.GitMetadataSha256 -ceq
+      $Authorization.git_metadata_sha256 -and
+    $source.SupabaseCliVersion -ceq
+      $Authorization.supabase_cli_version -and
+    $source.SupabaseCliLauncherSha256 -ceq
+      $Authorization.supabase_cli_launcher_sha256 -and
+    $source.SupabaseCliBinarySha256 -ceq
+      $Authorization.supabase_cli_binary_sha256 -and
+    $source.SupabaseCliShimDescriptorSha256 -ceq
+      $Authorization.supabase_cli_shim_descriptor_sha256 -and
+    $source.TrackedMigrationCount -eq
+      $Authorization.tracked_migration_count -and
+    $source.TrackedMigrationSetSha256 -ceq
+      $Authorization.tracked_migration_set_sha256
+  ) 'Preflight source artifact differs from authorization.'
+  Assert-BinderUnattendedConditionV1 (
+    @($source.MigrationFiles).Count -eq @($policy.Migrations).Count
+  ) 'Preflight source artifact migration count mismatch.'
+  for ($index = 0; $index -lt @($policy.Migrations).Count; $index += 1) {
+    $actual = @($source.MigrationFiles)[$index]
+    $expected = @($policy.Migrations)[$index]
+    Assert-BinderUnattendedObjectPropertySetV1 `
+      -Value $actual `
+      -ExpectedNames @('version', 'file', 'sha256') `
+      -Label "Preflight source MigrationFiles[$index]"
+    Assert-BinderUnattendedConditionV1 (
+      $actual.version -is [string] -and
+      $actual.file -is [string] -and
+      $actual.sha256 -is [string] -and
+      $actual.version -ceq $expected.version -and
+      $actual.file -ceq $expected.file -and
+      $actual.sha256 -ceq $expected.sha256
+    ) "Preflight source migration mismatch at position $index."
+  }
+
+  $repository = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'repository.json') `
+    -RequiredTopLevelNames @(
+      'HeadSha',
+      'OriginMainSha',
+      'Branch',
+      'Clean',
+      'GitCommonConfigSha256',
+      'GitMetadataCount',
+      'GitMetadataSha256'
+    ) `
+    -AllowedTopLevelNames @(
+      'HeadSha',
+      'OriginMainSha',
+      'Branch',
+      'Clean',
+      'GitCommonConfigSha256',
+      'GitMetadataCount',
+      'GitMetadataSha256'
+    )
+  Assert-BinderUnattendedConditionV1 (
+    $repository.HeadSha -is [string] -and
+    $repository.OriginMainSha -is [string] -and
+    $repository.Branch -is [string] -and
+    $repository.Clean -is [bool] -and
+    $repository.GitCommonConfigSha256 -is [string] -and
+    $repository.GitMetadataCount -is [long] -and
+    $repository.GitMetadataSha256 -is [string] -and
+    $repository.HeadSha -ceq $Authorization.reviewed_main_sha -and
+    $repository.OriginMainSha -ceq
+      $Authorization.reviewed_main_sha -and
+    $repository.Branch -ceq 'main' -and
+    $repository.Clean -eq $true -and
+    $repository.GitCommonConfigSha256 -ceq
+      $Authorization.git_common_config_sha256 -and
+    $repository.GitMetadataCount -eq
+      $Authorization.git_metadata_count -and
+    $repository.GitMetadataSha256 -ceq
+      $Authorization.git_metadata_sha256
+  ) 'Preflight repository artifact differs from authorization.'
+
+  $project = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'project-binding.json') `
+    -RequiredTopLevelNames @(
+      'ProjectRef',
+      'ApiHost',
+      'DatabaseHost',
+      'Status',
+      'LinkedProjectRefSha256',
+      'LinkedPoolerUrlSha256',
+      'LinkedProjectMetadataSha256'
+    ) `
+    -AllowedTopLevelNames @(
+      'ProjectRef',
+      'ApiHost',
+      'DatabaseHost',
+      'Status',
+      'LinkedProjectRefSha256',
+      'LinkedPoolerUrlSha256',
+      'LinkedProjectMetadataSha256'
+    )
+  Assert-BinderUnattendedConditionV1 (
+    $project.ProjectRef -is [string] -and
+    $project.ApiHost -is [string] -and
+    $project.DatabaseHost -is [string] -and
+    $project.Status -is [string] -and
+    $project.LinkedProjectRefSha256 -is [string] -and
+    $project.LinkedPoolerUrlSha256 -is [string] -and
+    $project.LinkedProjectMetadataSha256 -is [string] -and
+    $project.ProjectRef -ceq $Authorization.project_ref -and
+    $project.ApiHost -ceq "$($Authorization.project_ref).supabase.co" -and
+    $project.DatabaseHost -ceq
+      "db.$($Authorization.project_ref).supabase.co" -and
+    $project.Status -ceq 'ACTIVE_HEALTHY' -and
+    $project.LinkedProjectRefSha256 -ceq
+      $Authorization.linked_project_ref_sha256 -and
+    $project.LinkedPoolerUrlSha256 -ceq
+      $Authorization.linked_pooler_url_sha256 -and
+    $project.LinkedProjectMetadataSha256 -ceq
+      $Authorization.linked_project_metadata_sha256
+  ) 'Preflight project binding artifact is not exact production.'
+
+  $ledger = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'ledger.before.json') `
+    -RequiredTopLevelNames @('Rows', 'Shared', 'LocalOnly', 'RemoteOnly') `
+    -AllowedTopLevelNames @('Rows', 'Shared', 'LocalOnly', 'RemoteOnly')
+  foreach ($collectionName in @(
+    'Rows',
+    'Shared',
+    'LocalOnly',
+    'RemoteOnly'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $ledger.($collectionName) -is [object[]]
+    ) "Preflight ledger.$collectionName must be a JSON array."
+    foreach ($row in @($ledger.($collectionName))) {
+      Assert-BinderUnattendedObjectPropertySetV1 `
+        -Value $row -ExpectedNames @('Local', 'Remote', 'Time') `
+        -Label "Preflight ledger.$collectionName row"
+      foreach ($name in @('Local', 'Remote', 'Time')) {
+        $value = $row.PSObject.Properties[$name].Value
+        Assert-BinderUnattendedConditionV1 (
+          $null -eq $value -or $value -is [string]
+        ) "Preflight ledger.$collectionName.$name must be null or a string."
+      }
+    }
+  }
+  Assert-ExactBinderPendingSetV1 -Ledger $ledger
+  $dryRun = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'dry-run.parsed.json') `
+    -RequiredTopLevelNames @('MigrationFiles') `
+    -AllowedTopLevelNames @('MigrationFiles')
+  Assert-BinderUnattendedConditionV1 (
+    $dryRun.MigrationFiles -is [object[]]
+  ) 'Parsed preflight dry-run MigrationFiles must be a JSON array.'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($dryRun.MigrationFiles) `
+    -Expected @($policy.Migrations | ForEach-Object file) `
+    -Label 'Parsed preflight dry-run'
+
+  $readback = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'readback.before.json') `
+    -RequiredTopLevelNames @(
+      'package_id',
+      'phase',
+      'read_only',
+      'ok',
+      'checks'
+    ) `
+    -AllowedTopLevelNames @(
+      'package_id',
+      'phase',
+      'read_only',
+      'ok',
+      'checks'
+    )
+  Assert-BinderUnattendedConditionV1 (
+    $readback.package_id -is [string] -and
+    $readback.phase -is [string] -and
+    $readback.read_only -is [bool] -and
+    $readback.ok -is [bool] -and
+    $readback.checks -is [pscustomobject] -and
+    $readback.package_id -ceq $Authorization.package_id -and
+    $readback.phase -ceq 'preflight' -and
+    $readback.read_only -eq $true -and
+    $readback.ok -eq $true
+  ) 'Preflight readback status is not exact pass/read-only.'
+  $readbackCheckNames = @(
+    'applied_package_migration_count',
+    'binder_card_event_data_exists',
+    'binder_function_count',
+    'binder_realtime_object_exists',
+    'binder_relation_collision_count',
+    'binder_trust_report_data_exists',
+    'binder_type_collision_count',
+    'card_event_failure_baseline_ok',
+    'card_events_feed_body_sha256',
+    'card_events_insert_policy',
+    'card_events_select_policy',
+    'changed_external_function_acl_fingerprint_sha256',
+    'changed_external_function_count',
+    'changed_external_function_fingerprint_sha256',
+    'changed_external_policy_count',
+    'changed_external_policy_fingerprint_sha256',
+    'changed_external_table_acl_fingerprint_sha256',
+    'drifted_functions',
+    'execution_role',
+    'external_trigger_name_collisions',
+    'migration_head',
+    'missing_columns',
+    'missing_functions',
+    'missing_relations',
+    'missing_roles',
+    'pulse_body_sha256',
+    'realtime_publication_config_count',
+    'realtime_publication_config_fingerprint_sha256',
+    'realtime_publication_exists',
+    'required_server_major_version',
+    'reviewed_public_default_acl_fingerprint_sha256',
+    'reviewed_public_default_acl_row_count',
+    'server_major_version',
+    'server_major_version_ok',
+    'server_version_num',
+    'stable_catalog_fingerprint_sha256',
+    'trust_insert_policy',
+    'trust_surface_constraint',
+    'trust_surface_constraint_count',
+    'trust_surface_constraint_fingerprint_sha256',
+    'unexpected_public_default_acl_grantees',
+    'unexpected_schema_create_privileges',
+    'wrapped_pulse_function_exists'
+  )
+  Assert-BinderUnattendedObjectPropertySetV1 `
+    -Value $readback.checks `
+    -ExpectedNames $readbackCheckNames `
+    -Label 'Preflight readback.checks'
+  foreach ($name in @(
+    'applied_package_migration_count',
+    'binder_function_count',
+    'binder_relation_collision_count',
+    'binder_type_collision_count',
+    'changed_external_function_count',
+    'changed_external_policy_count',
+    'realtime_publication_config_count',
+    'required_server_major_version',
+    'reviewed_public_default_acl_row_count',
+    'server_major_version',
+    'server_version_num',
+    'trust_surface_constraint_count'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $readback.checks.($name) -is [long]
+    ) "Preflight readback $name must be a JSON integer."
+  }
+  foreach ($name in @(
+    'binder_card_event_data_exists',
+    'binder_realtime_object_exists',
+    'binder_trust_report_data_exists',
+    'card_event_failure_baseline_ok',
+    'realtime_publication_exists',
+    'server_major_version_ok',
+    'wrapped_pulse_function_exists'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $readback.checks.($name) -is [bool]
+    ) "Preflight readback $name must be a JSON boolean."
+  }
+  Assert-BinderUnattendedConditionV1 (
+    [string]$readback.checks.stable_catalog_fingerprint_sha256 -ceq
+      $policy.StableCatalogFingerprintSha256 -and
+    [string]$manifest.stable_catalog_fingerprint_sha256 -ceq
+      $policy.StableCatalogFingerprintSha256
+  ) 'Stable production catalog fingerprint differs from the reviewed value.'
+  foreach ($property in $policy.ExpectedPreApply.PSObject.Properties) {
+    Assert-BinderUnattendedConditionV1 (
+      $readback.checks.($property.Name) -eq $property.Value
+    ) "Preflight readback $($property.Name) is not the authorized zero state."
+  }
+  foreach ($name in @(
+    'external_trigger_name_collisions',
+    'unexpected_public_default_acl_grantees',
+    'unexpected_schema_create_privileges',
+    'missing_relations',
+    'missing_columns',
+    'missing_functions',
+    'drifted_functions',
+    'missing_roles'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $readback.checks.($name) -is [object[]] -and
+      @($readback.checks.($name)).Count -eq 0
+    ) "Preflight readback contains unexpected $name."
+  }
+  $readbackFingerprint = Get-CanonicalSha256V1 -Value $readback
+  Assert-BinderUnattendedConditionV1 (
+    $readbackFingerprint -ceq $manifest.preapply_readback_sha256
+  ) 'Preflight readback canonical hash differs from the manifest.'
+
+  $backupDigestFields = @(
+    'Path',
+    'Sha256',
+    'Kind',
+    'VerifiedAtUtc',
+    'RecoverableThroughUtc',
+    'EvidenceReference',
+    'RestorePathReviewed',
+    'Operator'
+  )
+  $backupDigest = Read-BinderUnattendedJsonFileV1 `
+    -Path (Join-Path $PreflightRoot 'backup-evidence.digest.json') `
+    -RequiredTopLevelNames $backupDigestFields `
+    -AllowedTopLevelNames $backupDigestFields
+  foreach ($name in @(
+    'Path',
+    'Sha256',
+    'Kind',
+    'VerifiedAtUtc',
+    'RecoverableThroughUtc',
+    'EvidenceReference',
+    'Operator'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $backupDigest.PSObject.Properties[$name].Value -is [string]
+    ) "Preflight backup digest $name must be a JSON string."
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $backupDigest.RestorePathReviewed -is [bool]
+  ) 'Preflight backup digest RestorePathReviewed must be a JSON boolean.'
+  Assert-BinderUnattendedConditionV1 (
+    $backupEvidence.schema_version -is [long] -and
+    $backupEvidence.project_ref -is [string] -and
+    $backupEvidence.backup_kind -is [string] -and
+    $backupEvidence.verified_at_utc -is [string] -and
+    $backupEvidence.recoverable_through_utc -is [string] -and
+    $backupEvidence.evidence_reference -is [string] -and
+    $backupEvidence.restore_path_reviewed -is [bool] -and
+    $backupEvidence.operator -is [string]
+  ) 'Supervisor backup evidence primitive types are not exact.'
+  $digestVerified = ConvertTo-BinderUnattendedUtcV1 `
+    -Value ([string]$backupDigest.VerifiedAtUtc) `
+    -Label 'Preflight backup digest verification time'
+  $evidenceVerified = ConvertTo-BinderUnattendedUtcV1 `
+    -Value ([string]$backupEvidence.verified_at_utc) `
+    -Label 'Supervisor backup evidence verification time'
+  $digestRecoverable = ConvertTo-BinderUnattendedUtcV1 `
+    -Value ([string]$backupDigest.RecoverableThroughUtc) `
+    -Label 'Preflight backup digest recovery time'
+  $evidenceRecoverable = ConvertTo-BinderUnattendedUtcV1 `
+    -Value ([string]$backupEvidence.recoverable_through_utc) `
+    -Label 'Supervisor backup evidence recovery time'
+  Assert-BinderUnattendedConditionV1 (
+    $backupDigest.Path -ceq $BackupEvidencePath -and
+    $backupDigest.Sha256 -ceq $actualBackupHash -and
+    $backupDigest.Kind -ceq 'supabase_platform_backup' -and
+    $digestVerified -eq $evidenceVerified -and
+    $digestRecoverable -eq $evidenceRecoverable -and
+    $backupDigest.EvidenceReference -ceq
+      $backupEvidence.evidence_reference -and
+    $backupDigest.RestorePathReviewed -eq
+      $Authorization.restore_path_reviewed -and
+    $backupDigest.Operator -ceq $Authorization.operator -and
+    $backupEvidence.schema_version -eq 1 -and
+    $backupEvidence.project_ref -ceq $Authorization.project_ref -and
+    $backupEvidence.backup_kind -ceq
+      'supabase_platform_backup' -and
+    $backupEvidence.restore_path_reviewed -eq
+      $Authorization.restore_path_reviewed -and
+    $backupEvidence.operator -ceq $Authorization.operator
+  ) 'Preflight backup digest differs from the authorized fresh evidence.'
+
+  $approval = Read-BinderUnattendedStrictApprovalV1 `
+    -Path (Join-Path $PreflightRoot 'approval.txt') `
+    -Manifest $manifest
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    ManifestPath = $manifestPath
+    ManifestFileSha256 = $manifestFileSha256
+    ManifestFingerprintSha256 =
+      $manifest.manifest_fingerprint_sha256
+    BackupEvidenceSha256 = $actualBackupHash
+    ApplyAck = $approval.ApplyAck
+    BackupAck = $approval.BackupAck
+    ChecksumFileSha256 = $checksum.ChecksumFileSha256
+  }
+}
+
+function Open-BinderUnattendedFileSealsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Paths
+  )
+
+  $streams = [System.Collections.Generic.List[System.IO.FileStream]]::new()
+  $seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  try {
+    foreach ($path in $Paths) {
+      $fullPath = Assert-BinderUnattendedLocalPathV1 `
+        -Path $path -Label 'Sealed rollout input' -RequiredType Leaf
+      Assert-BinderUnattendedConditionV1 (
+        $seen.Add($fullPath)
+      ) 'Sealed rollout input list contains a duplicate path.'
+      $streams.Add(
+        [System.IO.File]::Open(
+          $fullPath,
+          [System.IO.FileMode]::Open,
+          [System.IO.FileAccess]::Read,
+          [System.IO.FileShare]::Read
+        )
+      )
+    }
+    return @($streams)
+  } catch {
+    foreach ($stream in $streams) {
+      $stream.Dispose()
+    }
+    throw
+  }
+}
+
+function Close-BinderUnattendedFileSealsV1 {
+  param(
+    [object[]]$Streams = @()
+  )
+
+  foreach ($stream in @($Streams)) {
+    if ($null -ne $stream) {
+      $stream.Dispose()
+    }
+  }
+}
+
+function Open-BinderUnattendedBundleSealsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+    [Parameter(Mandatory = $true)]
+    [object]$SupabaseExecutable
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $paths = @(
+    $policy.SupervisorModuleRelativePath,
+    $policy.SupervisorEntrypointRelativePath,
+    $policy.RolloutModuleRelativePath,
+    $policy.PreflightEntrypointRelativePath,
+    $policy.ApplyEntrypointRelativePath,
+    $policy.PackageManifestRelativePath,
+    $policy.PreflightSqlRelativePath,
+    $policy.PostApplySqlRelativePath,
+    $policy.RestoreProcedureRelativePath
+  ) | ForEach-Object {
+    [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $_))
+  }
+  $paths += @(
+    $SupabaseExecutable.LauncherPath,
+    $SupabaseExecutable.ShimDescriptorPath,
+    $SupabaseExecutable.BinaryPath
+  )
+  $paths += @(
+    (Join-Path $RepoRoot 'supabase/config.toml'),
+    (Join-Path $RepoRoot 'supabase/.temp/project-ref'),
+    (Join-Path $RepoRoot 'supabase/.temp/pooler-url'),
+    (Join-Path $RepoRoot 'supabase/.temp/linked-project.json'),
+    $policy.GitExecutablePath,
+    $policy.GitHttpsHelperPath
+  )
+  $paths += @(
+    Get-ChildItem -LiteralPath (
+      Join-Path $RepoRoot 'supabase/migrations'
+    ) -File -Filter '*.sql' |
+      ForEach-Object FullName
+  )
+  return Open-BinderUnattendedFileSealsV1 -Paths $paths
+}
+
+function Open-BinderUnattendedPreflightArtifactSealsV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PreflightRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$BackupEvidencePath
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $paths = @(
+    foreach ($relative in $policy.PreflightArtifacts) {
+      Join-Path $PreflightRoot $relative
+    }
+  )
+  $paths += Join-Path $PreflightRoot 'checksums.sha256'
+  $paths += $BackupEvidencePath
+  return Open-BinderUnattendedFileSealsV1 -Paths $paths
+}
+
+function Wait-BinderUnattendedUntilV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [datetimeoffset]$TargetUtc,
+    [Parameter(Mandatory = $true)]
+    [datetimeoffset]$ExpiresUtc
+  )
+
+  while ([datetimeoffset]::UtcNow -lt $TargetUtc) {
+    $now = [datetimeoffset]::UtcNow
+    Assert-BinderUnattendedConditionV1 (
+      $now -lt $ExpiresUtc
+    ) 'Authorization expired while waiting for its not-before time.'
+    $seconds = [math]::Min(
+      60,
+      [math]::Max(
+        1,
+        [math]::Ceiling(($TargetUtc - $now).TotalSeconds)
+      )
+    )
+    Start-Sleep -Seconds $seconds
+  }
+}
+
+function Test-BinderUnattendedLiveSourceV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [string]$RepoRoot = (Get-BinderUnattendedRepoRootV1)
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  [void](Test-BinderUnattendedBundleV1 `
+    -Authorization $Authorization -RepoRoot $RepoRoot)
+  $modulePath = Join-Path $RepoRoot $policy.RolloutModuleRelativePath
+  Import-Module $modulePath -Force
+  $source = Test-BinderSourceV1 -RepoRoot $RepoRoot
+  Assert-BinderUnattendedConditionV1 (
+    $source.Status -ceq 'pass' -and
+    $source.PackageId -ceq $Authorization.package_id -and
+    $source.PackageFingerprintSha256 -ceq
+      $Authorization.package_fingerprint_sha256 -and
+    $source.PackageManifestFileSha256 -ceq
+      $Authorization.package_manifest_sha256 -and
+    $source.ProjectRef -ceq $Authorization.project_ref -and
+    $source.SupabaseCliVersion -ceq
+      $Authorization.supabase_cli_version -and
+    $source.SupabaseCliLauncherSha256 -ceq
+      $Authorization.supabase_cli_launcher_sha256 -and
+    $source.SupabaseCliBinarySha256 -ceq
+      $Authorization.supabase_cli_binary_sha256 -and
+    $source.SupabaseCliShimDescriptorSha256 -ceq
+      $Authorization.supabase_cli_shim_descriptor_sha256 -and
+    $source.TrackedMigrationCount -eq
+      $Authorization.tracked_migration_count -and
+    $source.TrackedMigrationSetSha256 -ceq
+      $Authorization.tracked_migration_set_sha256
+  ) 'Live source identity differs from the authorization envelope.'
+  $repository = Assert-BinderRepositoryStateV1 `
+    -RepoRoot $RepoRoot `
+    -ExpectedHeadSha $Authorization.reviewed_main_sha
+  Assert-BinderUnattendedConditionV1 (
+    $repository.GitCommonConfigSha256 -ceq
+      $Authorization.git_common_config_sha256 -and
+    $repository.GitMetadataCount -eq
+      $Authorization.git_metadata_count -and
+    $repository.GitMetadataSha256 -ceq
+      $Authorization.git_metadata_sha256
+  ) 'Live repository Git metadata differs from signed authorization.'
+  foreach ($entry in @(
+    @(
+      'supabase/.temp/project-ref',
+      $Authorization.linked_project_ref_sha256
+    ),
+    @(
+      'supabase/.temp/pooler-url',
+      $Authorization.linked_pooler_url_sha256
+    ),
+    @(
+      'supabase/.temp/linked-project.json',
+      $Authorization.linked_project_metadata_sha256
+    )
+  )) {
+    $path = [System.IO.Path]::GetFullPath(
+      (Join-Path $RepoRoot ([string]$entry[0]))
+    )
+    [void](Assert-BinderUnattendedLocalPathV1 `
+      -Path $path -Label 'Linked Supabase identity' `
+      -RequiredType Leaf)
+    Assert-BinderUnattendedConditionV1 (
+      (Get-BinderUnattendedSha256FileV1 -Path $path) -ceq
+        [string]$entry[1]
+    ) 'Linked Supabase identity differs from signed authorization.'
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $env:SUPABASE_URL -ceq $Authorization.project_url
+  ) 'SUPABASE_URL is not the exact authorized production project origin.'
+  return $source
+}
+
+function Wait-BinderUnattendedBackupV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [Parameter(Mandatory = $true)]
+    [datetimeoffset]$PollDeadlineUtc,
+    [string]$RepoRoot = (Get-BinderUnattendedRepoRootV1)
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $modulePath = Join-Path $RepoRoot $policy.RolloutModuleRelativePath
+  Import-Module $modulePath -Force
+  $pollCount = 0
+  while ([datetimeoffset]::UtcNow -lt $PollDeadlineUtc) {
+    $pollCount += 1
+    $firstResult = Invoke-BinderPhysicalBackupListV1 `
+      -RepoRoot $RepoRoot
+    Assert-BinderUnattendedConditionV1 (
+      $firstResult.Status -ceq 'pass' -and
+      $firstResult.ExitCode -eq 0 -and
+      $firstResult.TimedOut -eq $false -and
+      $firstResult.ProcessTreeTerminationConfirmed -eq $true -and
+      $firstResult.OutputTruncated -eq $false
+    ) 'Contained physical-backup listing did not complete exactly.'
+    $first = Read-BinderBackupConfirmationV1 `
+      -Json $firstResult.StdOut `
+      -ProjectRef $Authorization.project_ref `
+      -BackupNotBeforeUtc $Authorization.backup_not_before_utc
+    if ($first.Status -ceq 'candidate') {
+      Assert-BinderUnattendedConditionV1 (
+        [datetimeoffset]::UtcNow.AddSeconds(
+          $policy.BackupConfirmationSeconds
+        ) -lt $PollDeadlineUtc
+      ) 'Backup confirmation cannot finish before the polling deadline.'
+      Start-Sleep -Seconds $policy.BackupConfirmationSeconds
+      $secondResult = Invoke-BinderPhysicalBackupListV1 `
+        -RepoRoot $RepoRoot
+      Assert-BinderUnattendedConditionV1 (
+        $secondResult.Status -ceq 'pass' -and
+        $secondResult.ExitCode -eq 0 -and
+        $secondResult.TimedOut -eq $false -and
+        $secondResult.ProcessTreeTerminationConfirmed -eq $true -and
+        $secondResult.OutputTruncated -eq $false
+      ) 'Second contained physical-backup listing did not complete exactly.'
+      $second = Read-BinderBackupConfirmationV1 `
+        -Json $secondResult.StdOut `
+        -ProjectRef $Authorization.project_ref `
+        -BackupNotBeforeUtc $Authorization.backup_not_before_utc
+      Assert-BinderUnattendedConditionV1 (
+        [datetimeoffset]::UtcNow -lt $PollDeadlineUtc
+      ) (
+        'Second physical-backup confirmation completed after the signed ' +
+        'polling deadline.'
+      ) 'safe_stop_pre_mutation'
+      Assert-BinderUnattendedConditionV1 (
+        $second.Status -ceq 'candidate' -and
+        $second.BackupKey -ceq $first.BackupKey -and
+        $second.ResponseFingerprintSha256 -ceq
+          $first.ResponseFingerprintSha256
+      ) (
+        'Physical-backup confirmations were not identical; refusing an ' +
+        'ambiguous or changing recovery point.'
+      ) 'safe_stop_pre_mutation'
+      return [pscustomobject][ordered]@{
+        Status = 'confirmed'
+        ProjectRef = $Authorization.project_ref
+        InsertedAtUtc = $second.InsertedAtUtc
+        BackupKey = $second.BackupKey
+        ResponseFingerprintSha256 =
+          $second.ResponseFingerprintSha256
+        Region = $second.Region
+        Confirmations = 2
+        PollCount = $pollCount + 1
+        VerifiedAtUtc = [datetimeoffset]::UtcNow.ToString('o')
+      }
+    }
+    $remaining = (
+      $PollDeadlineUtc - [datetimeoffset]::UtcNow
+    ).TotalSeconds
+    if ($remaining -gt 0) {
+      Start-Sleep -Seconds (
+        [math]::Min($policy.BackupPollSeconds, [math]::Max(1, $remaining))
+      )
+    }
+  }
+  Stop-BinderUnattendedV1 `
+    -ExitClass 'safe_stop_pre_mutation' `
+    -Message 'No eligible physical backup was confirmed before the signed deadline.'
+}
+
+function New-BinderUnattendedBackupEvidenceV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [Parameter(Mandatory = $true)]
+    [object]$BackupConfirmation,
+    [Parameter(Mandatory = $true)]
+    [string]$SupervisorArtifactRoot
+  )
+
+  $evidence = [ordered]@{
+    schema_version = 1
+    project_ref = $Authorization.project_ref
+    backup_kind = 'supabase_platform_backup'
+    verified_at_utc = $BackupConfirmation.VerifiedAtUtc
+    recoverable_through_utc = $BackupConfirmation.InsertedAtUtc
+    evidence_reference = (
+      'Supabase CLI 2.90.0 physical backups list; two identical ' +
+      'COMPLETED confirmations; backup key ' +
+      $BackupConfirmation.BackupKey + '; response sha256 ' +
+      $BackupConfirmation.ResponseFingerprintSha256
+    )
+    restore_path_reviewed = [bool]$Authorization.restore_path_reviewed
+    operator = [string]$Authorization.operator
+  }
+  $json = $evidence | ConvertTo-Json -Depth 8
+  $path = Join-Path $SupervisorArtifactRoot 'backup-evidence.json'
+  [void](Write-BinderUnattendedCreateNewDurableV1 `
+    -Path $path `
+    -Bytes (
+      [System.Text.UTF8Encoding]::new($false).GetBytes(
+        $json + [Environment]::NewLine
+      )
+    ))
+  return [pscustomobject][ordered]@{
+    Path = $path
+    Sha256 = Get-BinderUnattendedSha256FileV1 -Path $path
+    Data = [pscustomobject]$evidence
+  }
+}
+
+function Assert-BinderUnattendedFinalLiveBackupV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [Parameter(Mandatory = $true)]
+    [object]$OriginalConfirmation,
+    [Parameter(Mandatory = $true)]
+    [object]$AuthorizationTimes,
+    [string]$RepoRoot = (Get-BinderUnattendedRepoRootV1)
+  )
+
+  $policy = Get-BinderUnattendedPolicyV1
+  $rolloutModulePath = Join-Path (
+    $RepoRoot
+  ) $policy.RolloutModuleRelativePath
+  Import-Module $rolloutModulePath -Force
+  $result = Invoke-BinderPhysicalBackupListV1 -RepoRoot $RepoRoot
+  Assert-BinderUnattendedConditionV1 (
+    $result.Status -ceq 'pass' -and
+    $result.ProjectRef -ceq $Authorization.project_ref -and
+    $result.ExitCode -eq 0 -and
+    $result.TimedOut -eq $false -and
+    $result.ProcessTreeTerminationConfirmed -eq $true -and
+    $result.OutputTruncated -eq $false
+  ) (
+    'Final contained physical-backup listing did not complete exactly.'
+  ) 'safe_stop_pre_mutation'
+  $observed = Read-BinderBackupConfirmationV1 `
+    -Json $result.StdOut `
+    -ProjectRef $Authorization.project_ref `
+    -BackupNotBeforeUtc $Authorization.backup_not_before_utc
+  Assert-BinderUnattendedConditionV1 (
+    $observed.Status -ceq 'candidate' -and
+    $observed.BackupKey -ceq $OriginalConfirmation.BackupKey -and
+    $observed.ResponseFingerprintSha256 -ceq
+      $OriginalConfirmation.ResponseFingerprintSha256 -and
+    $observed.Region -ceq $policy.BackupExpectedRegion
+  ) (
+    'The final live backup candidate, response, mode, or region drifted ' +
+    'after its two signed-window confirmations.'
+  ) 'safe_stop_pre_mutation'
+  $now = [datetimeoffset]::UtcNow
+  $recoverable = ConvertTo-BinderUnattendedUtcV1 `
+    -Value $observed.InsertedAtUtc `
+    -Label 'Final live physical backup recovery point'
+  $maximumAgeWithReserve = (
+    $policy.BackupGuardMaximumAgeMinutes -
+    $policy.BackupApplyReserveMinutes
+  )
+  Assert-BinderUnattendedConditionV1 (
+    $now -lt $AuthorizationTimes.MutationDeadlineUtc -and
+    $now -lt $AuthorizationTimes.ExpiresAtUtc -and
+    $recoverable -le $now -and
+    $recoverable -ge $now.AddMinutes(-$maximumAgeWithReserve)
+  ) (
+    'The final live backup observation exhausted the signed outer ' +
+    'apply-launch deadline or five-minute backup reserve.'
+  ) 'safe_stop_pre_mutation'
+  return [pscustomobject][ordered]@{
+    Status = 'pass'
+    BackupKey = $observed.BackupKey
+    ResponseFingerprintSha256 =
+      $observed.ResponseFingerprintSha256
+    ObservedAtUtc = $now.ToString('o')
+  }
+}
+
+function ConvertFrom-BinderUnattendedJsonTextV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Json,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $document = $null
+  try {
+    $document = [System.Text.Json.JsonDocument]::Parse($Json)
+    Assert-BinderUnattendedNoJsonCollisionsV1 `
+      -Element $document.RootElement -Label $Label
+    return ConvertFrom-BinderUnattendedJsonElementV1 `
+      -Element $document.RootElement
+  } catch {
+    if ($_.Exception.Data.Contains('BinderSupervisorExitClass')) {
+      throw
+    }
+    Stop-BinderUnattendedV1 `
+      -ExitClass 'mutation_possible_stop' `
+      -Message "$Label is not strict JSON."
+  } finally {
+    if ($null -ne $document) {
+      $document.Dispose()
+    }
+  }
+}
+
+function Test-BinderUnattendedApplyResultV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Result,
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization
+  )
+
+  $fields = @(
+    'status',
+    'package_id',
+    'project_ref',
+    'head_sha',
+    'package_fingerprint_sha256',
+    'completed_at_utc',
+    'push_attempted',
+    'push_started',
+    'push_started_at_utc',
+    'push_supervisor_process_id',
+    'push_ended_at_utc',
+    'push_succeeded',
+    'push_timed_out',
+    'push_kill_attempted',
+    'push_kill_request_succeeded',
+    'push_kill_request_error',
+    'push_root_exited',
+    'push_process_tree_empty',
+    'push_termination_confirmed',
+    'push_exit_code',
+    'push_output_capture_completed',
+    'push_stdout_truncated',
+    'push_stderr_truncated',
+    'mutation_possible',
+    'feature_flags_enabled',
+    'excluded_flags'
+  )
+  Assert-BinderUnattendedObjectPropertySetV1 `
+    -Value $Result -ExpectedNames $fields `
+    -Label 'Guarded apply result'
+  foreach ($name in @(
+    'push_attempted',
+    'push_started',
+    'push_succeeded',
+    'push_timed_out',
+    'push_kill_attempted',
+    'push_root_exited',
+    'push_process_tree_empty',
+    'push_termination_confirmed',
+    'push_output_capture_completed',
+    'push_stdout_truncated',
+    'push_stderr_truncated',
+    'mutation_possible'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $Result.($name) -is [bool]
+    ) "Guarded apply result $name must be a JSON boolean."
+  }
+  foreach ($name in @(
+    'push_supervisor_process_id',
+    'push_exit_code',
+    'feature_flags_enabled'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $Result.($name) -is [long]
+    ) "Guarded apply result $name must be a JSON integer."
+  }
+  foreach ($name in @(
+    'status',
+    'package_id',
+    'project_ref',
+    'head_sha',
+    'package_fingerprint_sha256',
+    'completed_at_utc',
+    'push_started_at_utc',
+    'push_ended_at_utc'
+  )) {
+    Assert-BinderUnattendedConditionV1 (
+      $Result.($name) -is [string] -and
+      -not [string]::IsNullOrWhiteSpace($Result.($name))
+    ) "Guarded apply result $name must be a nonempty JSON string."
+  }
+  Assert-BinderUnattendedConditionV1 (
+    $null -eq $Result.push_kill_request_succeeded -and
+    $null -eq $Result.push_kill_request_error -and
+    $Result.excluded_flags -is [object[]]
+  ) (
+    'Guarded apply result must show no kill request and an exact JSON ' +
+    'excluded-flags array.'
+  ) 'mutation_possible_stop'
+  [void](ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Result.completed_at_utc `
+    -Label 'Guarded apply completion time')
+  [void](ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Result.push_started_at_utc `
+    -Label 'Guarded apply process start time')
+  [void](ConvertTo-BinderUnattendedUtcV1 `
+    -Value $Result.push_ended_at_utc `
+    -Label 'Guarded apply process end time')
+  Assert-BinderUnattendedConditionV1 (
+    $Result.status -ceq 'pass' -and
+    $Result.package_id -ceq $Authorization.package_id -and
+    $Result.project_ref -ceq $Authorization.project_ref -and
+    $Result.head_sha -ceq $Authorization.reviewed_main_sha -and
+    $Result.package_fingerprint_sha256 -ceq
+      $Authorization.package_fingerprint_sha256 -and
+    $Result.push_attempted -ceq $true -and
+    $Result.push_started -ceq $true -and
+    $Result.push_succeeded -ceq $true -and
+    $Result.push_timed_out -ceq $false -and
+    $Result.push_kill_attempted -ceq $false -and
+    $Result.push_root_exited -ceq $true -and
+    $Result.push_process_tree_empty -ceq $true -and
+    $Result.push_termination_confirmed -ceq $true -and
+    $Result.push_exit_code -ceq 0L -and
+    $Result.push_output_capture_completed -ceq $true -and
+    $Result.push_stdout_truncated -ceq $false -and
+    $Result.push_stderr_truncated -ceq $false -and
+    $Result.mutation_possible -ceq $true -and
+    $Result.feature_flags_enabled -ceq 0L
+  ) (
+    'Guarded apply did not return exact pass, contained termination, ' +
+    'complete output, and zero enabled flags.'
+  ) 'mutation_possible_stop'
+  Assert-BinderUnattendedArrayEqualV1 `
+    -Actual @($Result.excluded_flags) `
+    -Expected @((Get-BinderUnattendedPolicyV1).ExcludedFlags) `
+    -Label 'Guarded apply excluded flags'
+  return $true
+}
+
+function Write-BinderUnattendedTerminalV1 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet(
+      'pass_applied_verified',
+      'safe_stop_pre_mutation',
+      'local_integrity_stop',
+      'mutation_possible_stop'
+    )]
+    [string]$ExitClass,
+    [Parameter(Mandatory = $true)]
+    [string]$Phase,
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+    [Parameter(Mandatory = $true)]
+    [object]$Authorization,
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorizationSha256,
+    [Parameter(Mandatory = $true)]
+    [string]$StateRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$SupervisorArtifactRoot,
+    [bool]$AttemptClaimWriteStarted,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('present', 'absent', 'unknown')]
+    [string]$AttemptMarkerState,
+    [bool]$MutationClaimWriteStarted,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('present', 'absent', 'unknown')]
+    [string]$MutationMarkerState,
+    [string]$BackupEvidenceSha256 = '',
+    [string]$PreflightManifestSha256 = ''
+  )
+
+  $terminal = [ordered]@{
+    schema_version = 1
+    status = if ($ExitClass -ceq 'pass_applied_verified') {
+      'pass'
+    } else {
+      'stop'
+    }
+    exit_class = $ExitClass
+    phase = $Phase
+    message = Protect-BinderUnattendedTextV1 -Text $Message
+    recorded_at_utc = [datetimeoffset]::UtcNow.ToString('o')
+    project_ref = $Authorization.project_ref
+    package_id = $Authorization.package_id
+    package_fingerprint_sha256 =
+      $Authorization.package_fingerprint_sha256
+    authorization_id = $Authorization.authorization_id
+    authorization_sha256 = $AuthorizationSha256
+    reviewed_main_sha = $Authorization.reviewed_main_sha
+    attempt_claim_write_started = $AttemptClaimWriteStarted
+    attempt_marker_state = $AttemptMarkerState
+    attempt_claimed = $AttemptMarkerState -ceq 'present'
+    mutation_claim_write_started = $MutationClaimWriteStarted
+    mutation_marker_state = $MutationMarkerState
+    mutation_launch_committed = $MutationMarkerState -ceq 'present'
+    backup_evidence_sha256 = $BackupEvidenceSha256
+    preflight_manifest_sha256 = $PreflightManifestSha256
+    automatic_retry_permitted = $false
+    feature_flag_writes_attempted = $false
+    feature_flags_verified_enabled_count =
+      if ($ExitClass -ceq 'pass_applied_verified') { 0 } else { $null }
+    deployment_performed = $false
+  }
+  $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes(
+    ($terminal | ConvertTo-Json -Compress -Depth 8)
+  )
+  [void](Write-BinderUnattendedCreateNewDurableV1 `
+    -Path (Join-Path $StateRoot 'TERMINAL') `
+    -Bytes $bytes)
+  [void](Write-BinderUnattendedCreateNewDurableV1 `
+    -Path (Join-Path $SupervisorArtifactRoot 'terminal.json') `
+    -Bytes $bytes)
+  return [pscustomobject]$terminal
+}
+
+# The public entry point intentionally accepts no executable, repository,
+# command, project, state, artifact, acknowledgement, hook, or passthrough
+# parameters. All authority is inside the byte-hash-pinned external envelope.
+function Invoke-BinderUnattendedSupervisorV1 {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorizationPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedAuthorizationSha256
+  )
+
+  $repoRoot = Get-BinderUnattendedRepoRootV1
+  $policy = Get-BinderUnattendedPolicyV1
+  $savedEnvironment = $null
+  $mutex = $null
+  $wakeLock = $false
+  $authorizationEnvelope = $null
+  $authorization = $null
+  $secureRoots = $null
+  $supervisorArtifactRoot = $null
+  $bundleSeals = @()
+  $gitMetadataSeals = @()
+  $backupSeals = @()
+  $preflightSeals = @()
+  $attemptClaimWriteStarted = $false
+  $attemptMarkerState = 'absent'
+  $mutationCommitted = $false
+  $mutationClaimWriteStarted = $false
+  $mutationMarkerState = 'absent'
+  $backupEvidenceSha256 = ''
+  $preflightManifestSha256 = ''
+  $supabaseExecutable = $null
+  $phase = 'startup'
+
+  try {
+    $savedEnvironment =
+      Enter-BinderUnattendedSanitizedEnvironmentV1
+    $mutex = New-BinderUnattendedMutexV1
+    $wakeLock = Enter-BinderUnattendedWakeLockV1
+    [void](Assert-BinderUnattendedAcPowerV1)
+
+    $phase = 'authorization'
+    $authorizationEnvelope = Open-BinderUnattendedAuthorizationV1 `
+      -AuthorizationPath $AuthorizationPath `
+      -ExpectedAuthorizationSha256 $ExpectedAuthorizationSha256 `
+      -RepoRoot $repoRoot
+    $authorization = $authorizationEnvelope.Data
+    $issued = ConvertTo-BinderUnattendedUtcV1 `
+      -Value $authorization.issued_at_utc `
+      -Label 'Authorization issued time'
+    $notBefore = ConvertTo-BinderUnattendedUtcV1 `
+      -Value $authorization.not_before_utc `
+      -Label 'Authorization not-before time'
+    $expires = ConvertTo-BinderUnattendedUtcV1 `
+      -Value $authorization.expires_at_utc `
+      -Label 'Authorization expiry time'
+    Assert-BinderUnattendedConditionV1 (
+      $issued -le [datetimeoffset]::UtcNow.AddMinutes(5) -and
+      [datetimeoffset]::UtcNow -lt $expires
+    ) 'Authorization is not valid for unattended waiting.'
+    [void](Test-BinderUnattendedAuthorizationV1 `
+      -Authorization $authorization `
+      -NowUtc $notBefore)
+
+    $phase = 'signed_bundle_bootstrap'
+    [void](Test-BinderUnattendedBundleV1 `
+      -Authorization $authorization -RepoRoot $repoRoot)
+    $supabaseExecutable =
+      Get-BinderUnattendedSupabaseExecutableV1 `
+        -Authorization $authorization
+    $bundleSeals = Open-BinderUnattendedBundleSealsV1 `
+      -RepoRoot $repoRoot `
+      -SupabaseExecutable $supabaseExecutable
+    $sealedSupabaseExecutable =
+      Get-BinderUnattendedSupabaseExecutableV1 `
+        -Authorization $authorization
+    Assert-BinderUnattendedConditionV1 (
+      $sealedSupabaseExecutable.LauncherPath -ceq
+        $supabaseExecutable.LauncherPath -and
+      $sealedSupabaseExecutable.ShimDescriptorPath -ceq
+        $supabaseExecutable.ShimDescriptorPath -and
+      $sealedSupabaseExecutable.BinaryPath -ceq
+        $supabaseExecutable.BinaryPath
+    ) 'Supabase CLI path identity changed under retained seals.'
+    [void](Test-BinderUnattendedBundleV1 `
+      -Authorization $authorization -RepoRoot $repoRoot)
+    $rolloutModulePath = Join-Path (
+      $repoRoot
+    ) $policy.RolloutModuleRelativePath
+    Import-Module $rolloutModulePath -Force -ErrorAction Stop
+    $gitSeal = Open-BinderGitMetadataSealV1 -RepoRoot $repoRoot
+    Assert-BinderUnattendedConditionV1 (
+      $gitSeal.Guard.ExecutablePath -ceq
+        $authorization.git_executable_path -and
+      $gitSeal.Guard.ExecutableSha256 -ceq
+        $authorization.git_executable_sha256 -and
+      $gitSeal.Guard.Version -ceq $authorization.git_version -and
+      $gitSeal.Guard.ExecPath -ceq
+        $authorization.git_exec_path -and
+      $gitSeal.Guard.HttpsHelperPath -ceq
+        $authorization.git_https_helper_path -and
+      $gitSeal.Guard.HttpsHelperSha256 -ceq
+        $authorization.git_https_helper_sha256 -and
+      $gitSeal.Guard.CommonConfigSha256 -ceq
+        $authorization.git_common_config_sha256 -and
+      $gitSeal.Guard.MetadataCount -eq
+        $authorization.git_metadata_count -and
+      $gitSeal.Guard.MetadataSha256 -ceq
+        $authorization.git_metadata_sha256
+    ) 'Sealed Git identity differs from signed authorization.'
+    $gitMetadataSeals = @($gitSeal.Streams)
+    [void](Assert-BinderUnattendedOutsideEveryWorktreeV1 `
+      -Path $authorizationEnvelope.Path `
+      -RepoRoot $repoRoot `
+      -Label 'AuthorizationPath')
+
+    $phase = 'secure_state_early'
+    $secureRoots = Initialize-BinderUnattendedSecureRootsV1 `
+      -Authorization $authorization
+    Assert-BinderUnattendedStateAvailableV1 `
+      -StateRoot $secureRoots.StateRoot
+    [void](Assert-BinderUnattendedOutsideEveryWorktreeV1 `
+      -Path $secureRoots.StateRoot `
+      -RepoRoot $repoRoot `
+      -Label 'Stable supervisor state root')
+    [void](Assert-BinderUnattendedOutsideEveryWorktreeV1 `
+      -Path $secureRoots.ArtifactNamespaceRoot `
+      -RepoRoot $repoRoot `
+      -Label 'Supervisor artifact namespace')
+
+    $phase = 'not_before_wait'
+    Wait-BinderUnattendedUntilV1 `
+      -TargetUtc $notBefore `
+      -ExpiresUtc $expires
+    [void](Test-BinderUnattendedAuthorizationV1 `
+      -Authorization $authorization)
+    [void](Assert-BinderUnattendedAcPowerV1)
+
+    $phase = 'secure_state_recheck'
+    Assert-BinderUnattendedStateAvailableV1 `
+      -StateRoot $secureRoots.StateRoot
+    [void](New-BinderUnattendedArtifactRunRootV1 `
+      -ArtifactRoot $authorization.artifact_root)
+    [void](Assert-BinderUnattendedOutsideEveryWorktreeV1 `
+      -Path $authorization.artifact_root `
+      -RepoRoot $repoRoot `
+      -Label 'Supervisor artifact run root')
+    $supervisorArtifactRoot =
+      New-BinderUnattendedPrivateDirectoryV1 `
+        -Path (Join-Path $authorization.artifact_root 'supervisor')
+
+    $phase = 'source_before_backup'
+    [void](Test-BinderUnattendedLiveSourceV1 `
+      -Authorization $authorization -RepoRoot $repoRoot)
+
+    $phase = 'backup_poll'
+    $authorizationTimes = Test-BinderUnattendedAuthorizationV1 `
+      -Authorization $authorization
+    $backupConfirmation = Wait-BinderUnattendedBackupV1 `
+      -Authorization $authorization `
+      -PollDeadlineUtc $authorizationTimes.BackupPollDeadlineUtc `
+      -RepoRoot $repoRoot
+    Assert-BinderUnattendedConditionV1 (
+      $backupConfirmation.Confirmations -eq 2
+    ) 'Physical backup did not receive exactly two confirmations.'
+    $backupEvidence = New-BinderUnattendedBackupEvidenceV1 `
+      -Authorization $authorization `
+      -BackupConfirmation $backupConfirmation `
+      -SupervisorArtifactRoot $supervisorArtifactRoot
+    $backupEvidenceSha256 = $backupEvidence.Sha256
+    $backupSeals = Open-BinderUnattendedFileSealsV1 `
+      -Paths @($backupEvidence.Path)
+
+    $phase = 'preflight_claim'
+    [void](Test-BinderUnattendedLiveSourceV1 `
+      -Authorization $authorization -RepoRoot $repoRoot)
+    $attemptClaimWriteStarted = $true
+    [void](New-BinderUnattendedClaimV1 `
+      -Kind attempt `
+      -Authorization $authorization `
+      -AuthorizationSha256 $authorizationEnvelope.Sha256 `
+      -StateRoot $secureRoots.StateRoot `
+      -PreflightManifestSha256 ('0' * 64))
+    $attemptMarkerState = 'present'
+
+    $phase = 'preflight'
+    $preflightRoot = Join-Path (
+      $authorization.artifact_root
+    ) 'preflight'
+    $preflightEntrypoint = Join-Path (
+      $repoRoot
+    ) $policy.PreflightEntrypointRelativePath
+    & $preflightEntrypoint `
+      -ExpectedHeadSha $authorization.reviewed_main_sha `
+      -BackupEvidencePath $backupEvidence.Path `
+      -ArtifactRoot $preflightRoot |
+      Out-Null
+
+    $phase = 'artifact_review'
+    $firstReview = Test-BinderUnattendedPreflightArtifactsV1 `
+      -PreflightRoot $preflightRoot `
+      -Authorization $authorization `
+      -BackupEvidencePath $backupEvidence.Path `
+      -RepoRoot $repoRoot
+    $preflightSeals =
+      Open-BinderUnattendedPreflightArtifactSealsV1 `
+        -PreflightRoot $preflightRoot `
+        -BackupEvidencePath $backupEvidence.Path
+    $secondReview = Test-BinderUnattendedPreflightArtifactsV1 `
+      -PreflightRoot $preflightRoot `
+      -Authorization $authorization `
+      -BackupEvidencePath $backupEvidence.Path `
+      -RepoRoot $repoRoot
+    Assert-BinderUnattendedConditionV1 (
+      $firstReview.ManifestFileSha256 -ceq
+        $secondReview.ManifestFileSha256 -and
+      $firstReview.ManifestFingerprintSha256 -ceq
+        $secondReview.ManifestFingerprintSha256 -and
+      $firstReview.ChecksumFileSha256 -ceq
+        $secondReview.ChecksumFileSha256 -and
+      $firstReview.ApplyAck -ceq $secondReview.ApplyAck -and
+      $firstReview.BackupAck -ceq $secondReview.BackupAck
+    ) 'Preflight artifacts changed while the retained seals were opening.'
+    $preflightManifestSha256 =
+      $secondReview.ManifestFileSha256
+
+    $phase = 'pre_apply_gate'
+    [void](Test-BinderUnattendedAuthorizationV1 `
+      -Authorization $authorization)
+    [void](Test-BinderUnattendedLiveSourceV1 `
+      -Authorization $authorization -RepoRoot $repoRoot)
+    [void](Test-BackupEvidenceV1 `
+      -Path $backupEvidence.Path -RepoRoot $repoRoot)
+    [void](Assert-BinderUnattendedAcPowerV1)
+    $now = [datetimeoffset]::UtcNow
+    $recoverable = ConvertTo-BinderUnattendedUtcV1 `
+      -Value $backupConfirmation.InsertedAtUtc `
+      -Label 'Confirmed physical backup recovery point'
+    $maximumAgeWithReserve = (
+      $policy.BackupGuardMaximumAgeMinutes -
+      $policy.BackupApplyReserveMinutes
+    )
+    Assert-BinderUnattendedConditionV1 (
+      $now -lt $authorizationTimes.MutationDeadlineUtc -and
+      $now -lt $authorizationTimes.ExpiresAtUtc -and
+      $recoverable -le $now -and
+      $recoverable -ge $now.AddMinutes(-$maximumAgeWithReserve)
+    ) (
+      'The signed outer apply-launch deadline or five-minute backup ' +
+      'reserve was exhausted before mutation authorization.'
+    ) 'safe_stop_pre_mutation'
+    [void](Test-BinderUnattendedLiveSourceV1 `
+      -Authorization $authorization -RepoRoot $repoRoot)
+    [void](Assert-BinderUnattendedFinalLiveBackupV1 `
+      -Authorization $authorization `
+      -OriginalConfirmation $backupConfirmation `
+      -AuthorizationTimes $authorizationTimes `
+      -RepoRoot $repoRoot)
+    [void](Assert-BinderUnattendedAcPowerV1)
+
+    $phase = 'mutation_launch_commit'
+    # Once mutation-marker creation is attempted, classification is
+    # deliberately conservative. CreateNew+Flush(true) can succeed even if
+    # a subsequent local validation or return path fails.
+    $mutationClaimWriteStarted = $true
+    [void](New-BinderUnattendedClaimV1 `
+      -Kind mutation `
+      -Authorization $authorization `
+      -AuthorizationSha256 $authorizationEnvelope.Sha256 `
+      -StateRoot $secureRoots.StateRoot `
+      -PreflightManifestSha256 $preflightManifestSha256)
+    $mutationCommitted = $true
+    $mutationMarkerState = 'present'
+
+    $phase = 'guarded_apply'
+    $env:GROOKAI_BINDER_PROD_APPLY_ACK = $secondReview.ApplyAck
+    $env:GROOKAI_BINDER_PROD_BACKUP_ACK = $secondReview.BackupAck
+    $env:GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC =
+      [string]$authorization.mutation_deadline_utc
+    $env:GROOKAI_BINDER_PROD_AUTH_EXPIRES_AT_UTC =
+      [string]$authorization.expires_at_utc
+    try {
+      $applyEntrypoint = Join-Path (
+        $repoRoot
+      ) $policy.ApplyEntrypointRelativePath
+      $applyOutput = & $applyEntrypoint `
+        -ManifestPath $secondReview.ManifestPath `
+        -ConfirmProduction `
+        -Confirm:$false
+    } finally {
+      Remove-Item Env:GROOKAI_BINDER_PROD_APPLY_ACK `
+        -ErrorAction SilentlyContinue
+      Remove-Item Env:GROOKAI_BINDER_PROD_BACKUP_ACK `
+        -ErrorAction SilentlyContinue
+      Remove-Item Env:GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC `
+        -ErrorAction SilentlyContinue
+      Remove-Item Env:GROOKAI_BINDER_PROD_AUTH_EXPIRES_AT_UTC `
+        -ErrorAction SilentlyContinue
+    }
+    $applyJson = (@($applyOutput) -join [Environment]::NewLine)
+    $applyResult = ConvertFrom-BinderUnattendedJsonTextV1 `
+      -Json $applyJson -Label 'Guarded apply result'
+    [void](Test-BinderUnattendedApplyResultV1 `
+      -Result $applyResult `
+      -Authorization $authorization)
+
+    $phase = 'terminal_pass'
+    $terminal = Write-BinderUnattendedTerminalV1 `
+      -ExitClass pass_applied_verified `
+      -Phase $phase `
+      -Message 'Guarded apply and mandatory post-apply readback passed.' `
+      -Authorization $authorization `
+      -AuthorizationSha256 $authorizationEnvelope.Sha256 `
+      -StateRoot $secureRoots.StateRoot `
+      -SupervisorArtifactRoot $supervisorArtifactRoot `
+      -AttemptClaimWriteStarted $attemptClaimWriteStarted `
+      -AttemptMarkerState $attemptMarkerState `
+      -MutationClaimWriteStarted $mutationClaimWriteStarted `
+      -MutationMarkerState $mutationMarkerState `
+      -BackupEvidenceSha256 $backupEvidenceSha256 `
+      -PreflightManifestSha256 $preflightManifestSha256
+    return [pscustomobject][ordered]@{
+      status = 'pass'
+      exit_class = 'pass_applied_verified'
+      project_ref = $authorization.project_ref
+      package_id = $authorization.package_id
+      reviewed_main_sha = $authorization.reviewed_main_sha
+      authorization_sha256 = $authorizationEnvelope.Sha256
+      artifact_root = $authorization.artifact_root
+      terminal_recorded_at_utc = $terminal.recorded_at_utc
+      feature_flags_enabled = 0
+      automatic_retry_permitted = $false
+    }
+  } catch {
+    $caught = $_
+    if ($null -ne $secureRoots) {
+      try {
+        $attemptMarkerState = if (Test-Path -LiteralPath (
+          Join-Path $secureRoots.StateRoot $policy.AttemptClaimFileName
+        )) {
+          'present'
+        } else {
+          'absent'
+        }
+      } catch {
+        $attemptMarkerState = 'unknown'
+      }
+      try {
+        $mutationMarkerState = if (Test-Path -LiteralPath (
+          Join-Path $secureRoots.StateRoot $policy.MutationClaimFileName
+        )) {
+          'present'
+        } else {
+          'absent'
+        }
+      } catch {
+        $mutationMarkerState = 'unknown'
+      }
+    }
+    $exitClass = [string]$caught.Exception.Data[
+      'BinderSupervisorExitClass'
+    ]
+    if (
+      $mutationCommitted -or
+      $mutationClaimWriteStarted -or
+      $mutationMarkerState -ceq 'present'
+    ) {
+      $exitClass = 'mutation_possible_stop'
+    } elseif ([string]::IsNullOrWhiteSpace($exitClass)) {
+      $exitClass = 'local_integrity_stop'
+    }
+    $safeMessage = Protect-BinderUnattendedTextV1 `
+      -Text $caught.Exception.Message
+    if (
+      $null -ne $secureRoots -and
+      -not [string]::IsNullOrWhiteSpace($supervisorArtifactRoot) -and
+      $null -ne $authorization
+    ) {
+      try {
+        [void](Write-BinderUnattendedTerminalV1 `
+          -ExitClass $exitClass `
+          -Phase $phase `
+          -Message $safeMessage `
+          -Authorization $authorization `
+          -AuthorizationSha256 $ExpectedAuthorizationSha256 `
+          -StateRoot $secureRoots.StateRoot `
+          -SupervisorArtifactRoot $supervisorArtifactRoot `
+          -AttemptClaimWriteStarted $attemptClaimWriteStarted `
+          -AttemptMarkerState $attemptMarkerState `
+          -MutationClaimWriteStarted $mutationClaimWriteStarted `
+          -MutationMarkerState $mutationMarkerState `
+          -BackupEvidenceSha256 $backupEvidenceSha256 `
+          -PreflightManifestSha256 $preflightManifestSha256)
+      } catch {
+      }
+    }
+    Stop-BinderUnattendedV1 `
+      -ExitClass $exitClass `
+      -Message $safeMessage
+  } finally {
+    Remove-Item Env:GROOKAI_BINDER_PROD_APPLY_ACK `
+      -ErrorAction SilentlyContinue
+    Remove-Item Env:GROOKAI_BINDER_PROD_BACKUP_ACK `
+      -ErrorAction SilentlyContinue
+    Remove-Item Env:GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC `
+      -ErrorAction SilentlyContinue
+    Remove-Item Env:GROOKAI_BINDER_PROD_AUTH_EXPIRES_AT_UTC `
+      -ErrorAction SilentlyContinue
+    Close-BinderUnattendedFileSealsV1 -Streams $preflightSeals
+    Close-BinderUnattendedFileSealsV1 -Streams $backupSeals
+    Close-BinderUnattendedFileSealsV1 -Streams $gitMetadataSeals
+    Close-BinderUnattendedFileSealsV1 -Streams $bundleSeals
+    if ($null -ne $authorizationEnvelope) {
+      $authorizationEnvelope.Stream.Dispose()
+    }
+    if ($wakeLock) {
+      Exit-BinderUnattendedWakeLockV1
+    }
+    if ($null -ne $mutex) {
+      try {
+        $mutex.ReleaseMutex()
+      } catch {
+      }
+      $mutex.Dispose()
+    }
+    if ($null -ne $savedEnvironment) {
+      Exit-BinderUnattendedSanitizedEnvironmentV1 `
+        -Saved $savedEnvironment
+    }
+  }
+}
+
+Export-ModuleMember -Function @(
+  'Get-BinderUnattendedPolicyV1',
+  'Protect-BinderUnattendedTextV1',
+  'Read-BinderUnattendedAuthorizationV1',
+  'Read-BinderBackupConfirmationV1',
+  'Test-BinderUnattendedAuthorizationV1',
+  'Test-BinderUnattendedBundleV1',
+  'Test-BinderUnattendedChecksumsV1',
+  'Test-BinderUnattendedPreflightArtifactsV1',
+  'Invoke-BinderUnattendedSupervisorV1'
+)

--- a/scripts/ops/CollaborativeBindersUnattendedSupervisorV1.psm1
+++ b/scripts/ops/CollaborativeBindersUnattendedSupervisorV1.psm1
@@ -1949,6 +1949,7 @@ function Test-BinderRoutingEnvironmentNameForSupervisorV1 {
       'SUPABASE_.*|' +
       'XDG_CONFIG_HOME|' +
       'GIT_.*|' +
+      'GCM_.*|' +
       'MSYS.*|CYGWIN.*|CHERE_INVOKING|BASH_ENV|ENV|' +
       'NODE_OPTIONS|' +
       'PSMODULEPATH|' +

--- a/scripts/ops/collaborative_binders_production_apply_v1.ps1
+++ b/scripts/ops/collaborative_binders_production_apply_v1.ps1
@@ -9,16 +9,79 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$modulePath = Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
-Import-Module $modulePath -Force
+$mutationDeadlineName =
+  'GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC'
+$authorizationExpiryName =
+  'GROOKAI_BINDER_PROD_AUTH_EXPIRES_AT_UTC'
+$mutationDeadline = [Environment]::GetEnvironmentVariable(
+  $mutationDeadlineName,
+  [EnvironmentVariableTarget]::Process
+)
+$authorizationExpiry = [Environment]::GetEnvironmentVariable(
+  $authorizationExpiryName,
+  [EnvironmentVariableTarget]::Process
+)
+[Environment]::SetEnvironmentVariable(
+  $mutationDeadlineName,
+  $null,
+  [EnvironmentVariableTarget]::Process
+)
+[Environment]::SetEnvironmentVariable(
+  $authorizationExpiryName,
+  $null,
+  [EnvironmentVariableTarget]::Process
+)
 
-$target = 'Supabase production project ycdxbpibncqcchqiihfz'
-$action = 'Apply the exact five Collaborative Binders V1 migrations once; leave every feature flag disabled'
+try {
+  $hasMutationDeadline = -not [string]::IsNullOrWhiteSpace(
+    $mutationDeadline
+  )
+  $hasAuthorizationExpiry = -not [string]::IsNullOrWhiteSpace(
+    $authorizationExpiry
+  )
+  if ($hasMutationDeadline -ne $hasAuthorizationExpiry) {
+    throw 'Production deadline transport is incomplete.'
+  }
 
-if ($PSCmdlet.ShouldProcess($target, $action)) {
-  $result = Invoke-BinderProductionApplyV1 `
-    -ManifestPath $ManifestPath `
-    -ConfirmProduction $ConfirmProduction.IsPresent `
-    -Confirm:$false
-  $result | ConvertTo-Json -Depth 12
+  $modulePath = Join-Path (
+    $PSScriptRoot
+  ) 'CollaborativeBindersProductionRolloutV1.psm1'
+  Import-Module $modulePath -Force -ErrorAction Stop
+
+  $target = 'Supabase production project ycdxbpibncqcchqiihfz'
+  $action = (
+    'Apply the exact five Collaborative Binders V1 migrations once; ' +
+    'leave every feature flag disabled'
+  )
+
+  if ($PSCmdlet.ShouldProcess($target, $action)) {
+    $result = Invoke-BinderProductionApplyV1 `
+      -ManifestPath $ManifestPath `
+      -ConfirmProduction $ConfirmProduction.IsPresent `
+      -MutationDeadlineUtc ([string]$mutationDeadline) `
+      -AuthorizationExpiresAtUtc ([string]$authorizationExpiry) `
+      -Confirm:$false
+    $result | ConvertTo-Json -Depth 12
+  }
+} catch {
+  [pscustomobject][ordered]@{
+    status = 'stop'
+    phase = 'apply_entrypoint'
+    message = (
+      'Production apply stopped before completion; inspect the ' +
+      'private local evidence directory.'
+    )
+  } | ConvertTo-Json -Depth 4 -Compress
+  exit 40
+} finally {
+  [Environment]::SetEnvironmentVariable(
+    $mutationDeadlineName,
+    $null,
+    [EnvironmentVariableTarget]::Process
+  )
+  [Environment]::SetEnvironmentVariable(
+    $authorizationExpiryName,
+    $null,
+    [EnvironmentVariableTarget]::Process
+  )
 }

--- a/scripts/ops/collaborative_binders_unattended_supervisor_v1.ps1
+++ b/scripts/ops/collaborative_binders_unattended_supervisor_v1.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$AuthorizationPath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9a-f]{64}$')]
+  [string]$ExpectedAuthorizationSha256
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path $PSScriptRoot (
+  'CollaborativeBindersUnattendedSupervisorV1.psm1'
+)
+$moduleLoaded = $false
+
+try {
+  Import-Module $modulePath -Force -ErrorAction Stop
+  $moduleLoaded = $true
+  $result = Invoke-BinderUnattendedSupervisorV1 `
+    -AuthorizationPath $AuthorizationPath `
+    -ExpectedAuthorizationSha256 $ExpectedAuthorizationSha256
+  $result | ConvertTo-Json -Depth 16
+  exit 0
+} catch {
+  if (-not $moduleLoaded) {
+    [pscustomobject][ordered]@{
+      status = 'stop'
+      exit_class = 'local_integrity_stop'
+      message = 'The unattended supervisor module could not be loaded.'
+    } | ConvertTo-Json -Depth 4
+    exit 40
+  }
+  $exitClass = [string]$_.Exception.Data[
+    'BinderSupervisorExitClass'
+  ]
+  if ($exitClass -cnotin @(
+    'safe_stop_pre_mutation',
+    'mutation_possible_stop',
+    'local_integrity_stop'
+  )) {
+    $exitClass = 'local_integrity_stop'
+  }
+  $exitCode = switch ($exitClass) {
+    'safe_stop_pre_mutation' { 20 }
+    'mutation_possible_stop' { 30 }
+    default { 40 }
+  }
+  $safeMessage = 'The unattended supervisor stopped safely.'
+  try {
+    $safeMessage = Protect-BinderUnattendedTextV1 `
+      -Text $_.Exception.Message
+  } catch {
+  }
+  [pscustomobject][ordered]@{
+    status = 'stop'
+    exit_class = $exitClass
+    message = $safeMessage
+  } | ConvertTo-Json -Depth 8
+  exit $exitCode
+}

--- a/tests/contracts/collaborative_binders_process_containment_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_process_containment_v1.test.mjs
@@ -91,13 +91,50 @@ exit 7
   -TimeoutSeconds 10 \`
   -SanitizeDatabaseEnvironment
 
-$timeout = Invoke-LocalContained \`
-  -Script @'
-[Console]::Out.WriteLine('before-timeout-out')
-[Console]::Error.WriteLine('before-timeout-err')
-Start-Sleep -Seconds 30
-'@ \`
-  -TimeoutSeconds 1
+$timeoutReadyName = (
+  'Local\GrookaiBinderTimeoutReadyV1-' +
+  [guid]::NewGuid().ToString('N')
+)
+$timeoutReadyCreated = $false
+$timeoutReady = [Threading.EventWaitHandle]::new(
+  $false,
+  [Threading.EventResetMode]::ManualReset,
+  $timeoutReadyName,
+  [ref]$timeoutReadyCreated
+)
+if (-not $timeoutReadyCreated) {
+  throw 'A unique timeout-readiness event could not be created.'
+}
+$timeoutReadySignaled = $false
+try {
+  $timeoutTarget = @'
+$ready = [Threading.EventWaitHandle]::OpenExisting(
+  '__TIMEOUT_READY_EVENT__'
+)
+try {
+  [Console]::Out.WriteLine('before-timeout-out')
+  [Console]::Error.WriteLine('before-timeout-err')
+  [Console]::Out.Flush()
+  [Console]::Error.Flush()
+  if (-not $ready.Set()) {
+    throw 'The timeout-readiness event could not be signaled.'
+  }
+  Start-Sleep -Seconds 60
+} finally {
+  $ready.Dispose()
+}
+'@
+  $timeoutTarget = $timeoutTarget.Replace(
+    '__TIMEOUT_READY_EVENT__',
+    $timeoutReadyName
+  )
+  $timeout = Invoke-LocalContained \`
+    -Script $timeoutTarget \`
+    -TimeoutSeconds 10
+  $timeoutReadySignaled = $timeoutReady.WaitOne(0)
+} finally {
+  $timeoutReady.Dispose()
+}
 
 $descendant = Invoke-LocalContained \`
   -Script @'
@@ -202,6 +239,7 @@ $handleCountAfterSetupFailures = (
   }
   timeout = [ordered]@{
     exit_code = $timeout.ExitCode
+    ready_signaled = $timeoutReadySignaled
     timed_out = $timeout.TimedOut
     kill_attempted = $timeout.KillAttempted
     kill_request_succeeded = $timeout.KillRequestSucceeded
@@ -261,7 +299,7 @@ $handleCountAfterSetupFailures = (
       cwd: REPO_ROOT,
       encoding: "utf8",
       maxBuffer: 5 * 1024 * 1024,
-      timeout: 45_000,
+      timeout: 90_000,
       windowsHide: true,
     },
   );
@@ -299,6 +337,7 @@ test(
     await context.test(
       "terminates and confirms an ordinary timeout",
       () => {
+        assert.equal(report.timeout.ready_signaled, true);
         assert.equal(report.timeout.timed_out, true);
         assert.equal(report.timeout.kill_attempted, true);
         assert.equal(report.timeout.kill_request_succeeded, true);

--- a/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
@@ -472,15 +472,35 @@ function Write-ManifestFixture {
     expires_at_utc = $ExpiresAtUtc
     project_ref = $policy.ProjectRef
     package_fingerprint_sha256 = $policy.PackageFingerprintSha256
+    package_manifest_file_sha256 = ('d' * 64)
     head_sha = ('a' * 40)
     origin_main_sha = ('a' * 40)
+    supabase_config_sha256 = $policy.SupabaseConfigSha256
+    linked_project_ref_sha256 = $policy.LinkedProjectRefSha256
+    linked_pooler_url_sha256 = $policy.LinkedPoolerUrlSha256
+    linked_project_metadata_sha256 = $policy.LinkedProjectMetadataSha256
+    git_executable_path = $policy.GitExecutablePath
+    git_executable_sha256 = $policy.GitExecutableSha256
+    git_version = $policy.GitVersion
+    git_exec_path = $policy.GitExecPath
+    git_https_helper_path = $policy.GitHttpsHelperPath
+    git_https_helper_sha256 = $policy.GitHttpsHelperSha256
+    git_common_config_sha256 = ('e' * 64)
+    git_metadata_count = 1
+    git_metadata_sha256 = ('f' * 64)
     supabase_cli_version = $policy.SupportedSupabaseCliVersion
     supabase_cli_launcher_sha256 = $policy.SupabaseCliLauncherSha256
     supabase_cli_binary_sha256 = $policy.SupabaseCliBinarySha256
     supabase_cli_shim_descriptor_sha256 = $policy.SupabaseCliShimDescriptorSha256
     tracked_migration_count = 1
     tracked_migration_set_sha256 = ('b' * 64)
+    migration_files = @()
+    pending_versions = @()
+    dry_run_files = @()
+    preapply_readback_sha256 = ('9' * 64)
     stable_catalog_fingerprint_sha256 = ('c' * 64)
+    backup_evidence_path = 'C:\\binder-backup-evidence.json'
+    backup_evidence_sha256 = ('8' * 64)
     apply_argv = @($policy.ApplyArguments)
   }
   $fingerprint = & $module {
@@ -940,10 +960,30 @@ try {
   [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/migrations'))
   $migration = Join-Path $fixture 'supabase/migrations/20260723100000_fixture.sql'
   [IO.File]::WriteAllText($migration, 'select 1;')
-  $null = & git -C $fixture init --quiet 2>&1
-  if ($LASTEXITCODE -ne 0) { throw 'fixture git init failed' }
-  $null = & git -C $fixture add -- 'supabase/migrations/20260723100000_fixture.sql' 2>&1
-  if ($LASTEXITCODE -ne 0) { throw 'fixture git add failed' }
+  $savedGitEnvironment = [ordered]@{}
+  foreach ($entry in Get-ChildItem Env:) {
+    if ($entry.Name.StartsWith(
+      'GIT_',
+      [StringComparison]::OrdinalIgnoreCase
+    )) {
+      $savedGitEnvironment[$entry.Name] = [string]$entry.Value
+      Remove-Item -LiteralPath ("Env:" + $entry.Name)
+    }
+  }
+  try {
+    $null = & git -C $fixture init --quiet 2>&1
+    if ($LASTEXITCODE -ne 0) { throw 'fixture git init failed' }
+    $null = & git -C $fixture add -- 'supabase/migrations/20260723100000_fixture.sql' 2>&1
+    if ($LASTEXITCODE -ne 0) { throw 'fixture git add failed' }
+  } finally {
+    foreach ($entry in $savedGitEnvironment.GetEnumerator()) {
+      [Environment]::SetEnvironmentVariable(
+        [string]$entry.Key,
+        [string]$entry.Value,
+        [EnvironmentVariableTarget]::Process
+      )
+    }
+  }
   $module = Get-Module CollaborativeBindersProductionRolloutV1
   $exact = & $module {
     param($root)
@@ -1010,18 +1050,40 @@ $stage = $null
 try {
   [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/migrations'))
   [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/.temp'))
-  [IO.File]::WriteAllText(
-    (Join-Path $fixture 'supabase/config.toml'),
-    'project_id = "${PRODUCTION_PROJECT_REF}"'
+  $module = Get-Module CollaborativeBindersProductionRolloutV1
+  $policy = Get-BinderRolloutPolicyV1
+  $sourceRoot = & $module { Get-BinderRepoRootV1 }
+  [IO.File]::Copy(
+    (Join-Path $sourceRoot 'supabase/config.toml'),
+    (Join-Path $fixture 'supabase/config.toml')
   )
   [IO.File]::WriteAllText(
     (Join-Path $fixture 'supabase/.temp/project-ref'),
     '${PRODUCTION_PROJECT_REF}'
   )
+  [IO.File]::WriteAllText(
+    (Join-Path $fixture 'supabase/.temp/pooler-url'),
+    $policy.LinkedPoolerUrl
+  )
+  $linkedProject = [ordered]@{
+    ref = $policy.ProjectRef
+    name = $policy.LinkedProjectName
+    organization_id = $policy.LinkedProjectOrganizationId
+    organization_slug = $policy.LinkedProjectOrganizationSlug
+  } | ConvertTo-Json -Compress
+  [IO.File]::WriteAllText(
+    (Join-Path $fixture 'supabase/.temp/linked-project.json'),
+    $linkedProject
+  )
+  $fixtureSqlDirectory = Join-Path $fixture 'scripts/ops/sql'
+  [void][IO.Directory]::CreateDirectory($fixtureSqlDirectory)
+  [IO.File]::Copy(
+    (Join-Path $sourceRoot $policy.PreflightSqlRelativePath),
+    (Join-Path $fixture $policy.PreflightSqlRelativePath)
+  )
   $migration = Join-Path $fixture 'supabase/migrations/20260723100000_fixture.sql'
   [IO.File]::WriteAllText($migration, 'select 1;')
   $hash = (Get-FileHash -LiteralPath $migration -Algorithm SHA256).Hash.ToLowerInvariant()
-  $module = Get-Module CollaborativeBindersProductionRolloutV1
   $setHash = & $module {
     param($line)
     Get-BinderSha256StringV1 -Value $line
@@ -1139,6 +1201,13 @@ try {
   assert.equal(result.SealedManifest.migration_set_sha256.length, 64);
   assert.equal(result.SealedManifest.config_sha256.length, 64);
   assert.equal(result.SealedManifest.project_ref, PRODUCTION_PROJECT_REF);
+  assert.equal(result.SealedManifest.project_ref_sha256.length, 64);
+  assert.equal(result.SealedManifest.pooler_url_sha256.length, 64);
+  assert.equal(
+    result.SealedManifest.linked_project_metadata_sha256.length,
+    64,
+  );
+  assert.equal(result.SealedManifest.preflight_sql_sha256.length, 64);
   assert.deepEqual(result.SealedManifest.migrations, [
     {
       file: "20260723100000_fixture.sql",
@@ -1326,6 +1395,7 @@ test("apply implementation revalidates every source guard before its sole push",
     "Assert-BinderFinalLocalSealV1",
     "New-BinderApplyCommandPlanV1",
     "New-BinderSupabaseStageV1",
+    "Assert-BinderFinalRemoteGateV1",
     "-Arguments @($plan[0].Arguments)",
     "-RepoRoot $stage.Root",
   ];
@@ -1362,7 +1432,7 @@ test("apply implementation revalidates every source guard before its sole push",
   );
   assert.match(
     applySource,
-    /New-BinderSupabaseStageV1[\s\S]*?sealed-source-manifest\.json[\s\S]*?\$pushAttempted = \$true/,
+    /New-BinderSupabaseStageV1[\s\S]*?sealed-source-manifest\.json[\s\S]*?Assert-BinderFinalRemoteGateV1[\s\S]*?final-remote-gate\.json[\s\S]*?\$pushAttempted = \$true/,
   );
   assert.match(
     applySource,
@@ -1381,6 +1451,49 @@ test("apply implementation revalidates every source guard before its sole push",
   assert.match(
     applySource,
     /mutation_possible = \[bool\]\$pushLifecycle\.Started/,
+  );
+});
+
+test("final remote gate closes expiry, backup, project, and origin TOCTOU", () => {
+  const moduleSource = source(MODULE_PATH);
+  const gateStart = moduleSource.indexOf(
+    "function Assert-BinderFinalRemoteGateV1",
+  );
+  const gateEnd = moduleSource.indexOf(
+    "\nfunction Invoke-BinderProductionApplyV1",
+    gateStart,
+  );
+  assert.ok(gateStart >= 0 && gateEnd > gateStart);
+  const gateSource = moduleSource.slice(gateStart, gateEnd);
+
+  const orderedMarkers = [
+    "Test-PreflightManifestV1",
+    "Assert-BinderApplyAuthorizationV1",
+    "Assert-BinderRepositoryStateV1",
+    "Assert-ProjectBindingV1",
+    "Test-BackupEvidenceV1",
+  ];
+  let previous = -1;
+  for (const marker of orderedMarkers) {
+    const index = gateSource.indexOf(marker);
+    assert.ok(
+      index > previous,
+      `missing or out-of-order final remote guard: ${marker}`,
+    );
+    previous = index;
+  }
+
+  assert.match(
+    gateSource,
+    /ExpectedHeadSha \$freshEnvelope\.Data\.head_sha/,
+  );
+  assert.match(
+    gateSource,
+    /freshBackup\.Sha256[\s\S]*?backup_evidence_sha256/,
+  );
+  assert.doesNotMatch(
+    gateSource,
+    /Invoke-BinderSupabaseV1|db['"`]?\s*,?\s*['"`]?push/i,
   );
 });
 

--- a/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
@@ -960,53 +960,70 @@ try {
   [void][IO.Directory]::CreateDirectory((Join-Path $fixture 'supabase/migrations'))
   $migration = Join-Path $fixture 'supabase/migrations/20260723100000_fixture.sql'
   [IO.File]::WriteAllText($migration, 'select 1;')
-  $savedGitEnvironment = [ordered]@{}
-  foreach ($entry in Get-ChildItem Env:) {
-    if ($entry.Name.StartsWith(
-      'GIT_',
-      [StringComparison]::OrdinalIgnoreCase
-    )) {
-      $savedGitEnvironment[$entry.Name] = [string]$entry.Value
-      Remove-Item -LiteralPath ("Env:" + $entry.Name)
-    }
-  }
-  try {
-    $null = & git -C $fixture init --quiet 2>&1
-    if ($LASTEXITCODE -ne 0) { throw 'fixture git init failed' }
-    $null = & git -C $fixture add -- 'supabase/migrations/20260723100000_fixture.sql' 2>&1
-    if ($LASTEXITCODE -ne 0) { throw 'fixture git add failed' }
-  } finally {
-    foreach ($entry in $savedGitEnvironment.GetEnumerator()) {
-      [Environment]::SetEnvironmentVariable(
-        [string]$entry.Key,
-        [string]$entry.Value,
-        [EnvironmentVariableTarget]::Process
-      )
-    }
-  }
   $module = Get-Module CollaborativeBindersProductionRolloutV1
-  $exact = & $module {
+  $result = & $module {
     param($root)
-    Get-BinderTrackedMigrationSetV1 -RepoRoot $root
+    $gitProbe = [pscustomobject]@{
+      Count = 0
+      RepoRoot = [IO.Path]::GetFullPath($root)
+    }
+    function Invoke-BinderGitV1 {
+      param(
+        [string[]]$Arguments,
+        [string]$RepoRoot,
+        [int]$TimeoutSeconds = 60
+      )
+      $expectedArguments = @(
+        'ls-files',
+        '--stage',
+        '--',
+        ':(top,glob)supabase/migrations/*.sql'
+      )
+      if (
+        @($Arguments).Count -ne $expectedArguments.Count -or
+        (@($Arguments) -join [char]0) -cne
+          ($expectedArguments -join [char]0)
+      ) {
+        throw 'fixture received an unexpected Git command'
+      }
+      if (
+        [IO.Path]::GetFullPath($RepoRoot) -cne $gitProbe.RepoRoot
+      ) {
+        throw 'fixture received an unexpected Git repository root'
+      }
+      $gitProbe.Count += 1
+      [pscustomobject]@{
+        ExitCode = 0
+        TimedOut = $false
+        TerminationConfirmed = $true
+        OutputCaptureCompleted = $true
+        StdOut = (
+          '100644 ' + ('a' * 40) + ' 0' + [char]9 +
+          'supabase/migrations/20260723100000_fixture.sql'
+        )
+        StdErr = ''
+      }
+    }
+
+    $exact = Get-BinderTrackedMigrationSetV1 -RepoRoot $root
+    [IO.File]::WriteAllText(
+      (Join-Path $root 'supabase/migrations/20260723100001_injected.sql'),
+      'select 2;'
+    )
+    $failure = ''
+    try {
+      [void](Get-BinderTrackedMigrationSetV1 -RepoRoot $root)
+    } catch {
+      $failure = $_.Exception.Message
+    }
+    [pscustomobject]@{
+      ExactCount = $exact.Count
+      ExactFingerprint = $exact.Sha256
+      Failure = $failure
+      GitCallCount = $gitProbe.Count
+    }
   } $fixture
-  [IO.File]::WriteAllText(
-    (Join-Path $fixture 'supabase/migrations/20260723100001_injected.sql'),
-    'select 2;'
-  )
-  $failure = ''
-  try {
-    [void](& $module {
-      param($root)
-      Get-BinderTrackedMigrationSetV1 -RepoRoot $root
-    } $fixture)
-  } catch {
-    $failure = $_.Exception.Message
-  }
-  [pscustomobject]@{
-    ExactCount = $exact.Count
-    ExactFingerprint = $exact.Sha256
-    Failure = $failure
-  } | ConvertTo-Json -Compress
+  $result | ConvertTo-Json -Compress
 } finally {
   if (
     (Test-Path -LiteralPath $fixture) -and
@@ -1031,6 +1048,7 @@ try {
   );
   assert.equal(result.ExactCount, 1);
   assert.match(result.ExactFingerprint, /^[0-9a-f]{64}$/);
+  assert.equal(result.GitCallCount, 2);
   assert.match(
     result.Failure,
     /does not exactly match the tracked top-level SQL set/i,

--- a/tests/contracts/collaborative_binders_unattended_supervisor_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_unattended_supervisor_v1.test.mjs
@@ -5,6 +5,7 @@ import {
   copyFileSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -260,7 +261,14 @@ test(
       path.join(os.tmpdir(), "binder-supervisor-auth-"),
     );
     try {
-      const authorizationPath = path.join(tempRoot, "authorization.json");
+      const canonicalTempRoot = realpathSync.native(tempRoot).replace(
+        /^[a-z](?=:)/,
+        (drive) => drive.toUpperCase(),
+      );
+      const authorizationPath = path.join(
+        canonicalTempRoot,
+        "authorization.json",
+      );
       const bytes = Buffer.from("{}", "utf8");
       writeFileSync(authorizationPath, bytes);
 
@@ -990,6 +998,10 @@ test(
       $env:DB_URL = 'postgresql://user:pass@malicious.invalid/db'
       $env:GIT_CONFIG_COUNT = '99'
       $env:GIT_ASKPASS = 'C:\\malicious-askpass.exe'
+      $env:GCM_INTERACTIVE = 'Always'
+      $env:GCM_TRACE = '1'
+      $env:MSYS2_ARG_CONV_EXCL = 'malicious'
+      $env:MSYS_NO_PATHCONV = 'malicious'
       $env:AWS_SECRET_ACCESS_KEY = 'LOCAL_TEST_AWS_SECRET'
       $env:GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC =
         '2099-01-01T00:00:00Z'
@@ -1010,6 +1022,7 @@ $names = @(
   'GIT_TERMINAL_PROMPT',
   'GIT_OPTIONAL_LOCKS',
   'GCM_INTERACTIVE',
+  'GCM_TRACE',
   'MSYS2_ARG_CONV_EXCL',
   'MSYS_NO_PATHCONV'
 )
@@ -1103,6 +1116,7 @@ foreach ($name in $names) {
       "GIT_TERMINAL_PROMPT",
       "GIT_OPTIONAL_LOCKS",
       "GCM_INTERACTIVE",
+      "GCM_TRACE",
       "MSYS2_ARG_CONV_EXCL",
       "MSYS_NO_PATHCONV",
     ]) {
@@ -1121,6 +1135,7 @@ foreach ($name in $names) {
       "AWS_SECRET_ACCESS_KEY",
       "GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC",
       "GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1",
+      "GCM_TRACE",
     ]) {
       assert.ok(
         value.git[name] === null || value.git[name] === "",

--- a/tests/contracts/collaborative_binders_unattended_supervisor_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_unattended_supervisor_v1.test.mjs
@@ -1,0 +1,1368 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+const MODULE_PATH = path.join(
+  REPO_ROOT,
+  "scripts",
+  "ops",
+  "CollaborativeBindersUnattendedSupervisorV1.psm1",
+);
+const ENTRYPOINT_PATH = path.join(
+  REPO_ROOT,
+  "scripts",
+  "ops",
+  "collaborative_binders_unattended_supervisor_v1.ps1",
+);
+const ROLLOUT_MODULE_PATH = path.join(
+  REPO_ROOT,
+  "scripts",
+  "ops",
+  "CollaborativeBindersProductionRolloutV1.psm1",
+);
+const APPLY_ENTRYPOINT_PATH = path.join(
+  REPO_ROOT,
+  "scripts",
+  "ops",
+  "collaborative_binders_production_apply_v1.ps1",
+);
+const WORKFLOW_PATH = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "contracts-runtime-protection.yml",
+);
+const WINDOWS_ONLY = process.platform === "win32";
+const POWERSHELL = "pwsh.exe";
+const NOW = "2026-07-24T12:00:00.0000000Z";
+const BACKUP_FLOOR = "2026-07-24T10:25:37.891Z";
+const PRODUCTION_PROJECT_REF = "ycdxbpibncqcchqiihfz";
+const PROBE_PREFIX = "__BINDER_SUPERVISOR_PROBE__";
+
+const moduleSource = readFileSync(MODULE_PATH, "utf8");
+const entrypointSource = readFileSync(ENTRYPOINT_PATH, "utf8");
+const rolloutSource = readFileSync(ROLLOUT_MODULE_PATH, "utf8");
+const applyEntrypointSource = readFileSync(APPLY_ENTRYPOINT_PATH, "utf8");
+const workflowSource = readFileSync(WORKFLOW_PATH, "utf8");
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function psQuote(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function encodedPowerShell(script) {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function runPowerShell(script, options = {}) {
+  return spawnSync(
+    POWERSHELL,
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      encodedPowerShell(script),
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      env: options.env ?? process.env,
+    },
+  );
+}
+
+function probePowerShell(body) {
+  const processResult = runPowerShell(`
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+Import-Module ${psQuote(MODULE_PATH)} -Force -ErrorAction Stop
+try {
+  $probeResult = & {
+${body}
+  }
+  $payload = [ordered]@{
+    ok = $true
+    result = $probeResult
+    exit_class = $null
+    message = $null
+  }
+} catch {
+  $exitClass = $null
+  if ($_.Exception.Data.Contains('BinderSupervisorExitClass')) {
+    $exitClass = [string]$_.Exception.Data['BinderSupervisorExitClass']
+  }
+  $payload = [ordered]@{
+    ok = $false
+    result = $null
+    exit_class = $exitClass
+    message = [string]$_.Exception.Message
+  }
+}
+[Console]::Out.Write(
+  ${psQuote(PROBE_PREFIX)} +
+  ($payload | ConvertTo-Json -Compress -Depth 32)
+)
+`);
+  assert.equal(
+    processResult.status,
+    0,
+    `PowerShell probe failed.\nstdout: ${processResult.stdout}\nstderr: ${processResult.stderr}`,
+  );
+  const marker = processResult.stdout.lastIndexOf(PROBE_PREFIX);
+  assert.notEqual(
+    marker,
+    -1,
+    `PowerShell probe emitted no payload.\nstdout: ${processResult.stdout}\nstderr: ${processResult.stderr}`,
+  );
+  return JSON.parse(
+    processResult.stdout.slice(marker + PROBE_PREFIX.length).trim(),
+  );
+}
+
+function probeRolloutPowerShell(body) {
+  const processResult = runPowerShell(`
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+Import-Module ${psQuote(ROLLOUT_MODULE_PATH)} -Force -ErrorAction Stop
+try {
+  $probeResult = & {
+${body}
+  }
+  $payload = [ordered]@{
+    ok = $true
+    result = $probeResult
+    message = $null
+  }
+} catch {
+  $payload = [ordered]@{
+    ok = $false
+    result = $null
+    message = [string]$_.Exception.Message
+  }
+}
+[Console]::Out.Write(
+  ${psQuote(PROBE_PREFIX)} +
+  ($payload | ConvertTo-Json -Compress -Depth 32)
+)
+`);
+  assert.equal(
+    processResult.status,
+    0,
+    `Rollout PowerShell probe failed.\nstdout: ${processResult.stdout}\nstderr: ${processResult.stderr}`,
+  );
+  const marker = processResult.stdout.lastIndexOf(PROBE_PREFIX);
+  assert.notEqual(
+    marker,
+    -1,
+    `Rollout PowerShell probe emitted no payload.\nstdout: ${processResult.stdout}\nstderr: ${processResult.stderr}`,
+  );
+  return JSON.parse(
+    processResult.stdout.slice(marker + PROBE_PREFIX.length).trim(),
+  );
+}
+
+function backupJson(rows, overrides = {}) {
+  return JSON.stringify({
+    backups: rows,
+    physical_backup_data: {},
+    pitr_enabled: false,
+    region: "us-east-2",
+    walg_enabled: true,
+    ...overrides,
+  });
+}
+
+function backupRow(insertedAt, overrides = {}) {
+  return {
+    inserted_at: insertedAt,
+    is_physical_backup: true,
+    status: "COMPLETED",
+    ...overrides,
+  };
+}
+
+function probeBackup(json) {
+  const encodedJson = Buffer.from(json, "utf8").toString("base64");
+  return probePowerShell(`
+    $json = [System.Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String(${psQuote(encodedJson)})
+    )
+    Read-BinderBackupConfirmationV1 \`
+      -Json $json \`
+      -ProjectRef ${psQuote(PRODUCTION_PROJECT_REF)} \`
+      -BackupNotBeforeUtc ${psQuote(BACKUP_FLOOR)} \`
+      -NowUtc ([datetimeoffset]${psQuote(NOW)})
+`);
+}
+
+function functionBody(source, functionName, nextMarker = "\nfunction ") {
+  const start = source.indexOf(`function ${functionName}`);
+  assert.notEqual(start, -1, `Missing ${functionName}`);
+  const next = source.indexOf(nextMarker, start + 10);
+  return source.slice(start, next === -1 ? source.length : next);
+}
+
+test("authorization reader is a closed, canonical, independently hash-bound envelope", () => {
+  const propertyReader = functionBody(
+    moduleSource,
+    "Get-BinderUnattendedJsonObjectPropertiesV1",
+  );
+  const authorizationBytes = functionBody(
+    moduleSource,
+    "ConvertFrom-BinderUnattendedAuthorizationBytesV1",
+  );
+  const authorizationOpen = functionBody(
+    moduleSource,
+    "Open-BinderUnattendedAuthorizationV1",
+  );
+
+  assert.match(propertyReader, /field count does not match the closed V1 schema/);
+  assert.match(propertyReader, /field order does not match the closed V1 schema/);
+  assert.match(propertyReader, /OrdinalIgnoreCase/);
+  assert.match(propertyReader, /duplicate or case-colliding JSON field/);
+  assert.match(authorizationBytes, /UTF8Encoding\]::new\(\$false,\s*\$true\)/s);
+  assert.match(authorizationBytes, /exact compact canonical UTF-8/);
+  assert.match(authorizationBytes, /\$Bytes\[\$index\]\s+-ne\s+\$canonicalBytes\[\$index\]/);
+  assert.match(
+    authorizationOpen,
+    /ExpectedAuthorizationSha256 must be an independently supplied lowercase SHA-256/,
+  );
+  assert.match(authorizationOpen, /\$actualSha256\s+-ceq\s+\$ExpectedAuthorizationSha256/);
+  assert.doesNotMatch(authorizationOpen, /sidecar/i);
+});
+
+test(
+  "authorization hash mismatch and a closed-schema violation both fail locally",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "binder-supervisor-auth-"),
+    );
+    try {
+      const authorizationPath = path.join(tempRoot, "authorization.json");
+      const bytes = Buffer.from("{}", "utf8");
+      writeFileSync(authorizationPath, bytes);
+
+      const wrongHash = probePowerShell(`
+        Read-BinderUnattendedAuthorizationV1 \`
+          -AuthorizationPath ${psQuote(authorizationPath)} \`
+          -ExpectedAuthorizationSha256 $('0' * 64) \`
+          -RepoRoot ${psQuote(REPO_ROOT)}
+      `);
+      assert.equal(wrongHash.ok, false);
+      assert.match(wrongHash.message, /caller-supplied SHA-256/);
+
+      const closedSchema = probePowerShell(`
+        Read-BinderUnattendedAuthorizationV1 \`
+          -AuthorizationPath ${psQuote(authorizationPath)} \`
+          -ExpectedAuthorizationSha256 ${psQuote(sha256(bytes))} \`
+          -RepoRoot ${psQuote(REPO_ROOT)}
+      `);
+      assert.equal(closedSchema.ok, false);
+      assert.match(closedSchema.message, /closed V1 schema|field count/);
+
+      const outerResult = spawnSync(
+        POWERSHELL,
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-File",
+          ENTRYPOINT_PATH,
+          "-AuthorizationPath",
+          authorizationPath,
+          "-ExpectedAuthorizationSha256",
+          "0".repeat(64),
+        ],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf8",
+          maxBuffer: 1024 * 1024,
+        },
+      );
+      assert.equal(outerResult.status, 40);
+      const outerPayload = JSON.parse(outerResult.stdout);
+      assert.equal(outerPayload.status, "stop");
+      assert.equal(outerPayload.exit_class, "local_integrity_stop");
+      assert.doesNotMatch(
+        outerResult.stdout + outerResult.stderr,
+        new RegExp(authorizationPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"),
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "backup parser distinguishes wait and one exact fresh candidate",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const wait = probeBackup(backupJson([]));
+    assert.equal(wait.ok, true);
+    assert.equal(wait.result.Status, "wait");
+    assert.equal(wait.result.EligibleCount, 0);
+
+    const candidate = probeBackup(
+      backupJson([backupRow("2026-07-24T11:58:00Z")]),
+    );
+    assert.equal(candidate.ok, true);
+    assert.equal(candidate.result.Status, "candidate");
+    assert.equal(candidate.result.EligibleCount, 1);
+    assert.equal(candidate.result.Region, "us-east-2");
+    assert.match(candidate.result.BackupKey, /PHYSICAL\|COMPLETED$/);
+  },
+);
+
+test(
+  "future COMPLETED physical backup newer than the floor hard-stops",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const result = probeBackup(
+      backupJson([backupRow("2026-07-24T12:00:01Z")]),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.exit_class, "safe_stop_pre_mutation");
+    assert.match(result.message, /future|clock|after the current/i);
+  },
+);
+
+test(
+  "already-stale COMPLETED physical backup newer than the floor hard-stops",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const result = probeBackup(
+      backupJson([backupRow("2026-07-24T11:54:59Z")]),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.exit_class, "safe_stop_pre_mutation");
+    assert.match(result.message, /stale|older|five|age/i);
+  },
+);
+
+test(
+  "more than one eligible backup is ambiguous and hard-stops",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const result = probeBackup(
+      backupJson([
+        backupRow("2026-07-24T11:58:00Z"),
+        backupRow("2026-07-24T11:59:00Z"),
+      ]),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.exit_class, "safe_stop_pre_mutation");
+    assert.match(result.message, /ambiguous|more than one/i);
+  },
+);
+
+test("preflight artifact equality checks are guarded by exact JSON primitive types", () => {
+  const body = functionBody(
+    moduleSource,
+    "Test-BinderUnattendedPreflightArtifactsV1",
+  );
+  const requiredGuards = [
+    [String.raw`\$manifest\.schema_version`, "long"],
+    [String.raw`\$manifest\.tracked_migration_count`, "long"],
+    [String.raw`\$repository\.Clean`, "bool"],
+    [String.raw`\$readback\.read_only`, "bool"],
+    [String.raw`\$readback\.ok`, "bool"],
+    [String.raw`\$backupEvidence\.schema_version`, "long"],
+    [String.raw`\$backupEvidence\.restore_path_reviewed`, "bool"],
+    [String.raw`\$backupDigest\.RestorePathReviewed`, "bool"],
+  ];
+  for (const [field, type] of requiredGuards) {
+    assert.match(
+      body,
+      new RegExp(`${field}\\s+-is\\s+\\[${type}\\]`, "i"),
+      `${field} must reject a string that PowerShell -eq would coerce`,
+    );
+  }
+});
+
+test(
+  "entrypoint import failure returns only a fixed generic JSON error",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "binder-supervisor-entrypoint-"),
+    );
+    const copiedEntrypoint = path.join(
+      tempRoot,
+      "collaborative_binders_unattended_supervisor_v1.ps1",
+    );
+    const copiedModule = path.join(
+      tempRoot,
+      "CollaborativeBindersUnattendedSupervisorV1.psm1",
+    );
+    const secret = "sb_secret_NEVER_EXPOSE_THIS_TEST_VALUE";
+    try {
+      copyFileSync(ENTRYPOINT_PATH, copiedEntrypoint);
+      writeFileSync(
+        copiedModule,
+        `throw '${secret} https://user:password@example.invalid/private'\n`,
+        "utf8",
+      );
+      const result = spawnSync(
+        POWERSHELL,
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-File",
+          copiedEntrypoint,
+          "-AuthorizationPath",
+          path.join(tempRoot, "unused.json"),
+          "-ExpectedAuthorizationSha256",
+          "0".repeat(64),
+        ],
+        {
+          cwd: tempRoot,
+          encoding: "utf8",
+          maxBuffer: 1024 * 1024,
+        },
+      );
+      assert.equal(result.status, 40);
+      const payload = JSON.parse(result.stdout);
+      assert.deepEqual(payload, {
+        status: "stop",
+        exit_class: "local_integrity_stop",
+        message: "The unattended supervisor module could not be loaded.",
+      });
+      assert.doesNotMatch(result.stdout + result.stderr, new RegExp(secret));
+      assert.doesNotMatch(result.stdout + result.stderr, /user:password/);
+      assert.doesNotMatch(
+        result.stdout + result.stderr,
+        new RegExp(tempRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"),
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "redactor removes bearer, URL, query, JSON, JWT, and Supabase secrets",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const secretText = [
+      "Bearer abc.DEF_1234567890-xyz",
+      "apikey=QUERY_SECRET_123456",
+      '"password":"JSON_SECRET_123456"',
+      "eyJheaderheader12.eyJpayloadpayload12.signature1234",
+      "https://user:pass@example.invalid/private",
+      "sb_secret_SUPABASE_SECRET_123456",
+    ].join(" ");
+    const encoded = Buffer.from(secretText, "utf8").toString("base64");
+    const result = probePowerShell(`
+      $text = [System.Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String(${psQuote(encoded)})
+      )
+      Protect-BinderUnattendedTextV1 -Text $text
+    `);
+    assert.equal(result.ok, true);
+    for (const fragment of [
+      "abc.DEF",
+      "QUERY_SECRET",
+      "JSON_SECRET",
+      "eyJheader",
+      "user:pass",
+      "SUPABASE_SECRET",
+    ]) {
+      assert.doesNotMatch(result.result, new RegExp(fragment, "i"));
+    }
+  },
+);
+
+test("supervisor source has one apply launch, durable markers, and no activation/retry path", () => {
+  const invoke = functionBody(
+    moduleSource,
+    "Invoke-BinderUnattendedSupervisorV1",
+    "\nExport-ModuleMember",
+  );
+  const durableWrite = functionBody(
+    moduleSource,
+    "Write-BinderUnattendedCreateNewDurableV1",
+  );
+  const policy = functionBody(moduleSource, "Get-BinderUnattendedPolicyV1");
+
+  assert.equal((invoke.match(/&\s+\$preflightEntrypoint\b/g) ?? []).length, 1);
+  assert.equal((invoke.match(/&\s+\$applyEntrypoint\b/g) ?? []).length, 1);
+  assert.equal(
+    (invoke.match(/New-BinderUnattendedClaimV1\s+`\s*\n\s*-Kind mutation/g) ?? [])
+      .length,
+    1,
+  );
+  assert.ok(
+    invoke.indexOf("$mutationClaimWriteStarted = $true") <
+      invoke.indexOf("-Kind mutation"),
+    "mutation-possible classification must begin before durable marker creation",
+  );
+  assert.match(
+    invoke,
+    /\$mutationClaimWriteStarted\s+-or[\s\S]*\$mutationMarkerState\s+-ceq\s+'present'/,
+  );
+  assert.match(durableWrite, /FileMode\]::CreateNew/);
+  assert.match(durableWrite, /FileOptions\]::WriteThrough/);
+  assert.match(durableWrite, /\$stream\.Flush\(\$true\)/);
+  assert.match(policy, /ApplyArguments\s*=\s*@\('db', 'push', '--linked', '--yes'\)/);
+  assert.match(invoke, /automatic_retry_permitted\s*=\s*\$false/);
+  assert.match(invoke, /feature_flags_enabled\s*=\s*0/);
+  assert.doesNotMatch(invoke, /migration\s+repair/i);
+  assert.doesNotMatch(invoke, /functions\s+deploy|deploy\s+function/i);
+  assert.doesNotMatch(invoke, /automatic_retry_permitted\s*=\s*\$true/);
+});
+
+test("entrypoint exposes only authorization path and independent hash parameters", () => {
+  const parameterBlock = entrypointSource.slice(
+    entrypointSource.indexOf("param("),
+    entrypointSource.indexOf("Set-StrictMode"),
+  );
+  assert.match(parameterBlock, /\$AuthorizationPath/);
+  assert.match(parameterBlock, /\$ExpectedAuthorizationSha256/);
+  assert.equal((parameterBlock.match(/\[string\]\$/g) ?? []).length, 2);
+  assert.doesNotMatch(
+    parameterBlock,
+    /Project|Repo|Command|Executable|Ack|State|Artifact|Retry|Force|Hook/i,
+  );
+});
+
+test("bootstrap verifies and retains the signed bundle before importing rollout code", () => {
+  const invoke = functionBody(
+    moduleSource,
+    "Invoke-BinderUnattendedSupervisorV1",
+    "\nExport-ModuleMember",
+  );
+  const openAuthorization = functionBody(
+    moduleSource,
+    "Open-BinderUnattendedAuthorizationV1",
+  );
+  const openBundleSeals = functionBody(
+    moduleSource,
+    "Open-BinderUnattendedBundleSealsV1",
+  );
+  const resolveSupabase = functionBody(
+    moduleSource,
+    "Get-BinderUnattendedSupabaseExecutableV1",
+  );
+  const verifyBundle = functionBody(
+    moduleSource,
+    "Test-BinderUnattendedBundleV1",
+  );
+
+  assert.match(openAuthorization, /Assert-BinderUnattendedOutsideRepositoryV1/);
+  assert.doesNotMatch(openAuthorization, /Import-Module/);
+  assert.doesNotMatch(openAuthorization, /OutsideEveryWorktree/);
+
+  const authorization = invoke.indexOf(
+    "Open-BinderUnattendedAuthorizationV1",
+  );
+  const firstBundleCheck = invoke.indexOf(
+    "Test-BinderUnattendedBundleV1",
+    authorization,
+  );
+  const firstCliResolution = invoke.indexOf(
+    "Get-BinderUnattendedSupabaseExecutableV1",
+    firstBundleCheck,
+  );
+  const retainedBundleSeal = invoke.indexOf(
+    "Open-BinderUnattendedBundleSealsV1",
+    firstCliResolution,
+  );
+  const secondCliResolution = invoke.indexOf(
+    "Get-BinderUnattendedSupabaseExecutableV1",
+    retainedBundleSeal + 1,
+  );
+  const secondBundleCheck = invoke.indexOf(
+    "Test-BinderUnattendedBundleV1",
+    secondCliResolution,
+  );
+  const rolloutImport = invoke.indexOf(
+    "Import-Module $rolloutModulePath",
+    secondBundleCheck,
+  );
+  const gitSeal = invoke.indexOf(
+    "Open-BinderGitMetadataSealV1",
+    rolloutImport,
+  );
+  const everyWorktreeCheck = invoke.indexOf(
+    "Assert-BinderUnattendedOutsideEveryWorktreeV1",
+    gitSeal,
+  );
+  for (const [left, right, label] of [
+    [authorization, firstBundleCheck, "authorization -> bundle verification"],
+    [firstBundleCheck, firstCliResolution, "bundle -> CLI resolution"],
+    [firstCliResolution, retainedBundleSeal, "CLI -> retained seals"],
+    [retainedBundleSeal, secondCliResolution, "seal -> CLI re-resolution"],
+    [secondCliResolution, secondBundleCheck, "CLI rehash -> bundle reverify"],
+    [secondBundleCheck, rolloutImport, "bundle reverify -> rollout import"],
+    [rolloutImport, gitSeal, "rollout import -> retained Git seal"],
+    [gitSeal, everyWorktreeCheck, "Git seal -> all-worktree path check"],
+  ]) {
+    assert.ok(left >= 0 && right > left, `Invalid bootstrap order: ${label}`);
+  }
+
+  for (const required of [
+    "SupervisorModuleRelativePath",
+    "SupervisorEntrypointRelativePath",
+    "RolloutModuleRelativePath",
+    "PreflightEntrypointRelativePath",
+    "ApplyEntrypointRelativePath",
+    "PackageManifestRelativePath",
+    "PreflightSqlRelativePath",
+    "PostApplySqlRelativePath",
+    "RestoreProcedureRelativePath",
+    "LauncherPath",
+    "ShimDescriptorPath",
+    "BinaryPath",
+    "supabase/config.toml",
+    "supabase/.temp/project-ref",
+    "supabase/.temp/pooler-url",
+    "supabase/.temp/linked-project.json",
+    "GitExecutablePath",
+    "GitHttpsHelperPath",
+    "supabase/migrations",
+  ]) {
+    assert.match(openBundleSeals, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.match(resolveSupabase, /supabase_cli_launcher_sha256/);
+  assert.match(resolveSupabase, /supabase_cli_shim_descriptor_sha256/);
+  assert.match(resolveSupabase, /supabase_cli_binary_sha256/);
+  assert.match(verifyBundle, /supabase_config_sha256/);
+  assert.match(verifyBundle, /linked_project_ref_sha256/);
+  assert.match(verifyBundle, /linked_pooler_url_sha256/);
+  assert.match(verifyBundle, /linked_project_metadata_sha256/);
+  assert.match(verifyBundle, /git_executable_sha256/);
+  assert.match(verifyBundle, /git_https_helper_sha256/);
+});
+
+test("authorization, preflight, and apply seals bind Git and Supabase routing identity", () => {
+  const authorizationOrder = functionBody(
+    moduleSource,
+    "Get-BinderUnattendedAuthorizationPropertyOrderV1",
+  );
+  const authorizationParser = functionBody(
+    moduleSource,
+    "ConvertFrom-BinderUnattendedAuthorizationJsonV1",
+  );
+  const preflightGuard = functionBody(
+    moduleSource,
+    "Test-BinderUnattendedPreflightArtifactsV1",
+  );
+  const rolloutManifestGuard = functionBody(
+    rolloutSource,
+    "Test-PreflightManifestV1",
+  );
+  const applySeal = functionBody(rolloutSource, "Open-BinderApplySealV1");
+  const finalLocalSeal = functionBody(
+    rolloutSource,
+    "Assert-BinderFinalLocalSealV1",
+  );
+
+  const closedFields = [
+    "supabase_config_sha256",
+    "linked_project_ref_sha256",
+    "linked_pooler_url_sha256",
+    "linked_project_metadata_sha256",
+    "git_executable_path",
+    "git_executable_sha256",
+    "git_version",
+    "git_exec_path",
+    "git_https_helper_path",
+    "git_https_helper_sha256",
+    "git_common_config_sha256",
+    "git_metadata_count",
+    "git_metadata_sha256",
+  ];
+  for (const field of closedFields) {
+    assert.match(authorizationOrder, new RegExp(`'${field}'`));
+    assert.match(
+      authorizationParser,
+      new RegExp(field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+    assert.match(
+      preflightGuard,
+      new RegExp(field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"),
+    );
+    assert.match(
+      rolloutManifestGuard,
+      new RegExp(`'${field}'`),
+    );
+  }
+  assert.match(authorizationParser, /Get-BinderUnattendedJsonInt32V1[\s\S]*git_metadata_count/);
+  assert.match(preflightGuard, /\$manifest\.git_metadata_count\s+-is\s+\[long\]/);
+  assert.match(rolloutManifestGuard, /\$data\.git_metadata_count\s+-is\s+\[long\]/);
+
+  for (const sealedPath of [
+    "supabase/config.toml",
+    "supabase/.temp/project-ref",
+    "supabase/.temp/pooler-url",
+    "supabase/.temp/linked-project.json",
+    "gitGuard.ExecutablePath",
+    "gitGuard.HttpsHelperPath",
+    "PreflightManifestEnvelope.Path",
+    "preflight-manifest.sha256",
+    "backup_evidence_path",
+  ]) {
+    assert.match(
+      applySeal,
+      new RegExp(sealedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  }
+  assert.match(applySeal, /gitGuard\.Topology\.Metadata/);
+  assert.match(applySeal, /TrackedMigrationSet\.Entries/);
+  assert.match(applySeal, /Git metadata changed after apply seals were retained/);
+  assert.match(applySeal, /Linked Supabase identity changed after apply seals were retained/);
+  assert.match(finalLocalSeal, /SupabaseCliLauncherSha256/);
+  assert.match(finalLocalSeal, /SupabaseCliBinarySha256/);
+  assert.match(finalLocalSeal, /SupabaseCliShimDescriptorSha256/);
+  assert.match(finalLocalSeal, /GitHttpsHelperSha256/);
+});
+
+test("Git execution is pinned, isolated from ambient config, and seals linked-worktree metadata", () => {
+  const policy = functionBody(rolloutSource, "Get-BinderRolloutPolicyV1");
+  const gitExecutable = functionBody(
+    rolloutSource,
+    "Get-BinderGitExecutableV1",
+  );
+  const invokeGit = functionBody(rolloutSource, "Invoke-BinderGitV1");
+  const topology = functionBody(rolloutSource, "Get-BinderGitTopologyV1");
+  const localConfig = functionBody(
+    rolloutSource,
+    "Assert-BinderGitLocalConfigurationV1",
+  );
+  const processRunner = functionBody(rolloutSource, "Invoke-BinderProcessV1");
+
+  for (const token of [
+    "GitExecutablePath",
+    "GitExecutableSha256",
+    "GitVersion",
+    "GitExecPath",
+    "GitHttpsHelperPath",
+    "GitHttpsHelperSha256",
+  ]) {
+    assert.match(policy, new RegExp(token));
+    assert.match(gitExecutable, new RegExp(token));
+  }
+  for (const override of [
+    "extensions.worktreeConfig=false",
+    "core.fsmonitor=false",
+    "core.hooksPath=NUL",
+    "core.askPass=",
+    "core.sshCommand=",
+    "credential.helper=",
+    "credential.interactive=false",
+    "http.proxy=",
+    "http.extraHeader=",
+    "remote.origin.proxy=",
+  ]) {
+    assert.match(
+      invokeGit,
+      new RegExp(override.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  }
+  assert.match(invokeGit, /-SanitizeGitEnvironment/);
+  assert.match(invokeGit, /-TrustedGitExecPath\s+\$git\.ExecPath/);
+  assert.match(processRunner, /GIT_CONFIG_NOSYSTEM'\]\s*=\s*'1'/);
+  assert.match(processRunner, /GIT_CONFIG_GLOBAL'\]\s*=\s*'NUL'/);
+  assert.match(processRunner, /GIT_EXEC_PATH/);
+  assert.match(processRunner, /GIT_TERMINAL_PROMPT'\]\s*=\s*'0'/);
+
+  for (const metadata of [
+    "common_config",
+    "common_config_worktree",
+    "git_config_worktree",
+    "worktree_dot_git_pointer",
+    "worktree_commondir",
+    "worktree_gitdir",
+    "worktree_head",
+    "worktree_index",
+    "current_head_ref",
+    "common_packed_refs",
+  ]) {
+    assert.match(topology, new RegExp(metadata));
+  }
+  assert.match(topology, /MetadataSha256/);
+  assert.match(localConfig, /include\\\./);
+  assert.match(localConfig, /credential\\\./);
+  assert.match(localConfig, /http\\\./);
+  assert.match(localConfig, /url\\\./);
+  assert.match(localConfig, /remote\\\.\.\*\\\.\(proxy/);
+  assert.match(localConfig, /remote\\\.origin\\\.pushurl/);
+  assert.match(
+    localConfig,
+    /remote\.origin\.url https:\/\/github\.com\/OriginalSoseji\/grookai_vault\.git/,
+  );
+  assert.match(
+    localConfig,
+    /remote\.origin\.fetch \+refs\/heads\/\*:refs\/remotes\/origin\/\*/,
+  );
+});
+
+test("deadline transport is scrubbed and the final gate uses the earliest authority", () => {
+  const supervisorInvoke = functionBody(
+    moduleSource,
+    "Invoke-BinderUnattendedSupervisorV1",
+    "\nExport-ModuleMember",
+  );
+  const containedWrapper = functionBody(
+    rolloutSource,
+    "Get-BinderSupervisorEncodedCommandV1",
+  );
+  const finalGate = functionBody(
+    rolloutSource,
+    "Assert-BinderFinalRemoteGateV1",
+  );
+  const apply = functionBody(
+    rolloutSource,
+    "Invoke-BinderProductionApplyV1",
+  );
+
+  const deadlineRead = applyEntrypointSource.indexOf(
+    "[Environment]::GetEnvironmentVariable",
+  );
+  const deadlineScrub = applyEntrypointSource.indexOf(
+    "[Environment]::SetEnvironmentVariable",
+    deadlineRead,
+  );
+  const rolloutImport = applyEntrypointSource.indexOf("Import-Module");
+  assert.ok(
+    deadlineRead >= 0 && deadlineScrub > deadlineRead && rolloutImport > deadlineScrub,
+    "Apply entrypoint must read and scrub deadline authority before module import",
+  );
+  assert.match(
+    applyEntrypointSource,
+    /finally[\s\S]*\$mutationDeadlineName[\s\S]*\$authorizationExpiryName/,
+  );
+
+  const mutationMarker = supervisorInvoke.indexOf("-Kind mutation");
+  const transportedDeadline = supervisorInvoke.indexOf(
+    "GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC",
+  );
+  const applyLaunch = supervisorInvoke.indexOf("& $applyEntrypoint");
+  assert.ok(
+    mutationMarker >= 0 &&
+      transportedDeadline > mutationMarker &&
+      applyLaunch > transportedDeadline,
+  );
+  assert.match(
+    containedWrapper,
+    /\$payloadName[\s\S]*SetEnvironmentVariable\(\s*\$payloadName,\s*\$null/s,
+  );
+  assert.match(
+    containedWrapper,
+    /expired at the child-start gate[\s\S]*if \(-not \$child\.Start\(\)\)/,
+  );
+
+  assert.match(finalGate, /\[string\]\$FinalRemoteRepoRoot/);
+  assert.match(finalGate, /\[string\]\$SupabaseExecutablePath/);
+  const backupBound = finalGate.indexOf("BackupRecoveryLagMinutes");
+  const mutationBound = finalGate.indexOf(
+    "$parsedMutationDeadline -lt $effectiveNotAfter",
+  );
+  const expiryBound = finalGate.indexOf(
+    "$parsedAuthorizationExpiry -lt $effectiveNotAfter",
+  );
+  const finalNowCheck = finalGate.indexOf(
+    "[datetimeoffset]::UtcNow -lt $effectiveNotAfter",
+  );
+  assert.ok(
+    backupBound >= 0 &&
+      mutationBound > backupBound &&
+      expiryBound > mutationBound &&
+      finalNowCheck > expiryBound,
+    "Final child-start deadline must be min(backup horizon, mutation, expiry)",
+  );
+  assert.match(apply, /-NotAfterUtc \(\[string\]\$finalRemoteGate\.NotAfterUtc\)/);
+});
+
+test("final sealed stage runs dry-run, ledger, readback, then one guarded push", () => {
+  const finalGate = functionBody(
+    rolloutSource,
+    "Assert-BinderFinalRemoteGateV1",
+  );
+  const apply = functionBody(
+    rolloutSource,
+    "Invoke-BinderProductionApplyV1",
+  );
+  const plan = functionBody(
+    rolloutSource,
+    "New-BinderApplyCommandPlanV1",
+  );
+
+  const dryRun = finalGate.indexOf("$freshDryRun = Get-BinderDryRunV1");
+  const ledger = finalGate.indexOf("$freshLedger = Get-BinderLedgerV1");
+  const readback = finalGate.indexOf(
+    "$freshReadback = Invoke-BinderReadbackV1",
+  );
+  assert.ok(dryRun >= 0 && ledger > dryRun && readback > ledger);
+  for (const command of ["Get-BinderDryRunV1", "Get-BinderLedgerV1", "Invoke-BinderReadbackV1"]) {
+    const start = finalGate.indexOf(command);
+    const end = finalGate.indexOf("\n  Assert-BinderConditionV1", start);
+    const call = finalGate.slice(start, end);
+    assert.match(call, /\$FinalRemoteRepoRoot/);
+    assert.match(call, /\$SupabaseExecutablePath/);
+  }
+
+  const openSeal = apply.indexOf("Open-BinderApplySealV1");
+  const localSeal = apply.indexOf("Assert-BinderFinalLocalSealV1");
+  const stage = apply.indexOf("New-BinderSupabaseStageV1");
+  const remoteGate = apply.indexOf("Assert-BinderFinalRemoteGateV1");
+  const push = apply.indexOf("$push = Invoke-BinderSupabaseV1");
+  assert.ok(
+    openSeal >= 0 &&
+      localSeal > openSeal &&
+      stage > localSeal &&
+      remoteGate > stage &&
+      push > remoteGate,
+  );
+  assert.match(
+    apply.slice(push, apply.indexOf("$pushSucceeded", push)),
+    /-Arguments @\(\$plan\[0\]\.Arguments\)[\s\S]*-RepoRoot \$stage\.Root[\s\S]*-ExecutablePath \$supabaseExecutable\.BinaryPath[\s\S]*-NotAfterUtc/,
+  );
+  assert.equal((apply.match(/\$push\s*=\s*Invoke-BinderSupabaseV1/g) ?? []).length, 1);
+  assert.match(plan, /Apply command plan cannot be constructed before authorization validation/);
+  assert.match(plan, /MutatesRemote\s*=\s*\$true/);
+  assert.match(plan, /Arguments\s*=\s*@\(\$policy\.ApplyArguments\)/);
+  assert.doesNotMatch(apply, /migration\s+repair/i);
+  assert.doesNotMatch(apply, /functions\s+deploy|deploy\s+function/i);
+  assert.doesNotMatch(apply, /automatic_retry\s*=\s*\$true/i);
+});
+
+test("Windows CI runs the supervisor suite and source exposes no activation path", () => {
+  assert.match(workflowSource, /binder-rollout-windows:/);
+  assert.match(
+    workflowSource,
+    /tests\/contracts\/collaborative_binders_unattended_supervisor_v1\.test\.mjs/,
+  );
+  const executableSource = [
+    moduleSource,
+    rolloutSource,
+    entrypointSource,
+    applyEntrypointSource,
+  ].join("\n");
+  assert.doesNotMatch(executableSource, /migration\s+repair/i);
+  assert.doesNotMatch(executableSource, /--include-all\b/i);
+  assert.doesNotMatch(
+    executableSource,
+    /\b(?:insert\s+into|update|delete\s+from)\s+(?:public\.)?binder_feature_flags\b/i,
+  );
+  assert.doesNotMatch(executableSource, /automatic_retry_permitted\s*=\s*\$true/i);
+  assert.match(moduleSource, /p8_excluded\s*=\s+Get-BinderUnattendedJsonBooleanV1/);
+  assert.match(moduleSource, /activation_allowed\s*=\s+Get-BinderUnattendedJsonBooleanV1/);
+  assert.match(moduleSource, /deployment_allowed\s*=\s+Get-BinderUnattendedJsonBooleanV1/);
+  assert.match(moduleSource, /feature_flags_enabled\s*=\s*0/);
+});
+
+test(
+  "contained database and Git children receive only their minimum environment",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const result = probeRolloutPowerShell(`
+      $module = Get-Module CollaborativeBindersProductionRolloutV1
+      $pwsh = [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+      $directory = (Get-Location).Path
+      $policy = Get-BinderRolloutPolicyV1
+
+      $env:SUPABASE_ACCESS_TOKEN = 'sbp_LOCAL_TEST_TOKEN_123456'
+      $env:SUPABASE_URL = 'https://malicious.invalid'
+      $env:DB_URL = 'postgresql://user:pass@malicious.invalid/db'
+      $env:GIT_CONFIG_COUNT = '99'
+      $env:GIT_ASKPASS = 'C:\\malicious-askpass.exe'
+      $env:AWS_SECRET_ACCESS_KEY = 'LOCAL_TEST_AWS_SECRET'
+      $env:GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC =
+        '2099-01-01T00:00:00Z'
+
+      $childScript = @'
+$names = @(
+  'SUPABASE_ACCESS_TOKEN',
+  'SUPABASE_URL',
+  'DB_URL',
+  'GIT_CONFIG_COUNT',
+  'GIT_ASKPASS',
+  'AWS_SECRET_ACCESS_KEY',
+  'GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC',
+  'GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_GLOBAL',
+  'GIT_EXEC_PATH',
+  'GIT_TERMINAL_PROMPT',
+  'GIT_OPTIONAL_LOCKS',
+  'GCM_INTERACTIVE',
+  'MSYS2_ARG_CONV_EXCL',
+  'MSYS_NO_PATHCONV'
+)
+$values = [ordered]@{}
+foreach ($name in $names) {
+  $observed = [Environment]::GetEnvironmentVariable(
+    $name,
+    [EnvironmentVariableTarget]::Process
+  )
+  $values[$name] = if (
+    $name -ceq 'SUPABASE_ACCESS_TOKEN' -and
+    -not [string]::IsNullOrWhiteSpace($observed)
+  ) {
+    'present'
+  } else {
+    $observed
+  }
+}
+[Console]::Out.Write(($values | ConvertTo-Json -Compress))
+'@
+
+      $database = & $module {
+        param($exe, $cwd, $script)
+        Invoke-BinderProcessV1 \`
+          -FilePath $exe \`
+          -Arguments @(
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            $script
+          ) \`
+          -WorkingDirectory $cwd \`
+          -TimeoutSeconds 15 \`
+          -SanitizeDatabaseEnvironment
+      } $pwsh $directory $childScript
+
+      $git = & $module {
+        param($exe, $cwd, $script, $execPath)
+        Invoke-BinderProcessV1 \`
+          -FilePath $exe \`
+          -Arguments @(
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            $script
+          ) \`
+          -WorkingDirectory $cwd \`
+          -TimeoutSeconds 15 \`
+          -SanitizeGitEnvironment \`
+          -TrustedGitExecPath $execPath
+      } $pwsh $directory $childScript $policy.GitExecPath
+
+      [pscustomobject][ordered]@{
+        database = $database.StdOut | ConvertFrom-Json
+        database_exit_code = $database.ExitCode
+        database_terminated = $database.TerminationConfirmed
+        database_output_complete = $database.OutputCaptureCompleted
+        git = $git.StdOut | ConvertFrom-Json
+        git_exit_code = $git.ExitCode
+        git_terminated = $git.TerminationConfirmed
+        git_output_complete = $git.OutputCaptureCompleted
+        expected_git_exec_path = $policy.GitExecPath
+      }
+    `);
+    assert.equal(result.ok, true, result.message);
+    const value = result.result;
+    assert.equal(value.database_exit_code, 0);
+    assert.equal(value.database_terminated, true);
+    assert.equal(value.database_output_complete, true);
+    assert.equal(value.git_exit_code, 0);
+    assert.equal(value.git_terminated, true);
+    assert.equal(value.git_output_complete, true);
+
+    assert.equal(
+      value.database.SUPABASE_ACCESS_TOKEN,
+      "present",
+    );
+    for (const name of [
+      "SUPABASE_URL",
+      "DB_URL",
+      "GIT_CONFIG_COUNT",
+      "GIT_ASKPASS",
+      "AWS_SECRET_ACCESS_KEY",
+      "GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC",
+      "GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1",
+      "GIT_CONFIG_NOSYSTEM",
+      "GIT_CONFIG_GLOBAL",
+      "GIT_EXEC_PATH",
+      "GIT_TERMINAL_PROMPT",
+      "GIT_OPTIONAL_LOCKS",
+      "GCM_INTERACTIVE",
+      "MSYS2_ARG_CONV_EXCL",
+      "MSYS_NO_PATHCONV",
+    ]) {
+      assert.ok(
+        value.database[name] === null || value.database[name] === "",
+        `database child leaked ${name}`,
+      );
+    }
+
+    for (const name of [
+      "SUPABASE_ACCESS_TOKEN",
+      "SUPABASE_URL",
+      "DB_URL",
+      "GIT_CONFIG_COUNT",
+      "GIT_ASKPASS",
+      "AWS_SECRET_ACCESS_KEY",
+      "GROOKAI_BINDER_PROD_MUTATION_NOT_AFTER_UTC",
+      "GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1",
+    ]) {
+      assert.ok(
+        value.git[name] === null || value.git[name] === "",
+        `Git child leaked ${name}`,
+      );
+    }
+    assert.equal(value.git.GIT_CONFIG_NOSYSTEM, "1");
+    assert.equal(value.git.GIT_CONFIG_GLOBAL, "NUL");
+    assert.equal(value.git.GIT_EXEC_PATH, value.expected_git_exec_path);
+    assert.equal(value.git.GIT_TERMINAL_PROMPT, "0");
+    assert.equal(value.git.GIT_OPTIONAL_LOCKS, "0");
+    assert.equal(value.git.GCM_INTERACTIVE, "Never");
+    assert.equal(value.git.MSYS2_ARG_CONV_EXCL, "*");
+    assert.equal(value.git.MSYS_NO_PATHCONV, "1");
+  },
+);
+
+test(
+  "expired NotAfter at the released gate prevents the actual target child start",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const result = probeRolloutPowerShell(`
+      $module = Get-Module CollaborativeBindersProductionRolloutV1
+      $encodedSupervisor = & $module {
+        Get-BinderSupervisorEncodedCommandV1
+      }
+      $tempRoot = Join-Path (
+        [IO.Path]::GetTempPath()
+      ) ('binder-deadline-gate-' + [guid]::NewGuid().ToString('N'))
+      [void][IO.Directory]::CreateDirectory($tempRoot)
+      $markerPath = Join-Path $tempRoot 'TARGET_CHILD_STARTED'
+      $gate = $null
+      $process = $null
+      try {
+        $gateName = (
+          'Local\\GrookaiBinderDeadlineTest-' +
+          [guid]::NewGuid().ToString('N')
+        )
+        $createdNew = $false
+        $gate = [Threading.EventWaitHandle]::new(
+          $false,
+          [Threading.EventResetMode]::ManualReset,
+          $gateName,
+          [ref]$createdNew
+        )
+        if (-not $createdNew) {
+          throw 'Deadline-test gate was not unique.'
+        }
+        $pwsh = [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+        $targetCommand = (
+          '[IO.File]::WriteAllText(' +
+          "'" + $markerPath.Replace("'", "''") + "'," +
+          "'started')"
+        )
+        $notAfter = [datetimeoffset]::UtcNow.AddSeconds(1).ToString(
+          "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'",
+          [cultureinfo]::InvariantCulture
+        )
+        $payload = [ordered]@{
+          GateName = $gateName
+          FilePath = $pwsh
+          WorkingDirectory = (Get-Location).Path
+          Arguments = @(
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            $targetCommand
+          )
+          NotAfterUtc = $notAfter
+        }
+        $payloadBase64 = [Convert]::ToBase64String(
+          [Text.Encoding]::UTF8.GetBytes(
+            ($payload | ConvertTo-Json -Compress -Depth 4)
+          )
+        )
+        $start = [Diagnostics.ProcessStartInfo]::new()
+        $start.FileName = $pwsh
+        $start.WorkingDirectory = (Get-Location).Path
+        $start.UseShellExecute = $false
+        $start.CreateNoWindow = $true
+        $start.RedirectStandardOutput = $true
+        $start.RedirectStandardError = $true
+        foreach ($argument in @(
+          '-NoLogo',
+          '-NoProfile',
+          '-NonInteractive',
+          '-EncodedCommand',
+          $encodedSupervisor
+        )) {
+          [void]$start.ArgumentList.Add($argument)
+        }
+        $start.Environment[
+          'GROOKAI_BINDER_SUPERVISOR_PAYLOAD_V1'
+        ] = $payloadBase64
+        $process = [Diagnostics.Process]::new()
+        $process.StartInfo = $start
+        if (-not $process.Start()) {
+          throw 'Deadline-test supervisor did not start.'
+        }
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        Start-Sleep -Milliseconds 1800
+        [void]$gate.Set()
+        $process.WaitForExit()
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+        [pscustomobject][ordered]@{
+          supervisor_exit_code = $process.ExitCode
+          target_child_started = Test-Path -LiteralPath $markerPath
+          stdout = $stdout
+          stderr = $stderr
+        }
+      } finally {
+        if ($null -ne $process) {
+          $process.Dispose()
+        }
+        if ($null -ne $gate) {
+          $gate.Dispose()
+        }
+        if (Test-Path -LiteralPath $tempRoot) {
+          Remove-Item -LiteralPath $tempRoot -Recurse -Force
+        }
+      }
+    `);
+    assert.equal(result.ok, true, result.message);
+    assert.equal(result.result.supervisor_exit_code, 250);
+    assert.equal(result.result.target_child_started, false);
+    assert.match(result.result.stderr, /authority expired before child start|expired at the child-start gate/i);
+  },
+);
+
+test(
+  "strict deadlines accept 0-7 fractional Z forms, reject malformed/past values, and allow a future child",
+  { skip: !WINDOWS_ONLY },
+  () => {
+    const result = probeRolloutPowerShell(`
+      $module = Get-Module CollaborativeBindersProductionRolloutV1
+      $valid = @(
+        '2099-01-01T00:00:00Z',
+        '2099-01-01T00:00:00.1Z',
+        '2099-01-01T00:00:00.12Z',
+        '2099-01-01T00:00:00.123Z',
+        '2099-01-01T00:00:00.1234Z',
+        '2099-01-01T00:00:00.12345Z',
+        '2099-01-01T00:00:00.123456Z',
+        '2099-01-01T00:00:00.1234567Z'
+      )
+      $validCount = 0
+      foreach ($value in $valid) {
+        [void](& $module {
+          param($deadline)
+          ConvertTo-BinderStrictUtcDeadlineV1 \`
+            -Value $deadline \`
+            -Label 'deadline fixture'
+        } $value)
+        $validCount += 1
+      }
+
+      $invalid = @(
+        '2099-01-01T00:00:00',
+        '2099-01-01T00:00:00+00:00',
+        '2099-01-01T00:00:00.12345678Z',
+        '2099-01-01 00:00:00Z',
+        "2099-01-01T00:00:00Z\`n"
+      )
+      $invalidRejected = 0
+      foreach ($value in $invalid) {
+        try {
+          [void](& $module {
+            param($deadline)
+            ConvertTo-BinderStrictUtcDeadlineV1 \`
+              -Value $deadline \`
+              -Label 'deadline fixture'
+          } $value)
+        } catch {
+          $invalidRejected += 1
+        }
+      }
+
+      $pwsh = [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+      $directory = (Get-Location).Path
+      $futureDeadline = [datetimeoffset]::UtcNow.AddMinutes(1).UtcDateTime.ToString(
+        "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'",
+        [cultureinfo]::InvariantCulture
+      )
+      $future = & $module {
+        param($exe, $cwd, $deadline)
+        Invoke-BinderProcessV1 \`
+          -FilePath $exe \`
+          -Arguments @(
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            "[Console]::Out.Write('future-deadline-started')"
+          ) \`
+          -WorkingDirectory $cwd \`
+          -TimeoutSeconds 15 \`
+          -NotAfterUtc $deadline
+      } $pwsh $directory $futureDeadline
+
+      $pastRejected = $false
+      try {
+        [void](& $module {
+          param($exe, $cwd)
+          Invoke-BinderProcessV1 \`
+            -FilePath $exe \`
+            -Arguments @(
+              '-NoLogo',
+              '-NoProfile',
+              '-NonInteractive',
+              '-Command',
+              "[Console]::Out.Write('past-deadline-must-not-start')"
+            ) \`
+            -WorkingDirectory $cwd \`
+            -TimeoutSeconds 15 \`
+            -NotAfterUtc '2000-01-01T00:00:00Z'
+        } $pwsh $directory)
+      } catch {
+        $pastRejected = $true
+      }
+
+      [pscustomobject][ordered]@{
+        valid_count = $validCount
+        invalid_rejected = $invalidRejected
+        future_exit_code = $future.ExitCode
+        future_started = $future.Started
+        future_terminated = $future.TerminationConfirmed
+        future_output_complete = $future.OutputCaptureCompleted
+        future_stdout = $future.StdOut
+        past_rejected = $pastRejected
+      }
+    `);
+    assert.equal(result.ok, true, result.message);
+    assert.equal(result.result.valid_count, 8);
+    assert.equal(result.result.invalid_rejected, 5);
+    assert.equal(result.result.future_exit_code, 0);
+    assert.equal(result.result.future_started, true);
+    assert.equal(result.result.future_terminated, true);
+    assert.equal(result.result.future_output_complete, true);
+    assert.equal(result.result.future_stdout, "future-deadline-started");
+    assert.equal(result.result.past_rejected, true);
+  },
+);


### PR DESCRIPTION
## Summary

Adds the fail-closed unattended supervisor and operating contract for the Collaborative Binders P1–P7 production rollout.

- exact canonical authorization envelope with independent SHA-256 binding
- retained Git, Supabase CLI, linked-project, source, migration, backup, and deadline seals
- strict one-shot mutation claims with no retry, repair, force, restore, or activation path
- final dry-run → ledger → catalog readback → one guarded `db push` order
- process containment, minimum child environment, output redaction, and durable evidence
- human-only Supabase platform backup/restore procedure
- Windows CI coverage and adversarial contract tests

## Scope

Exactly 10 files changed across 2 commits (8,677 additions, 102 deletions). No new migrations, package/lockfile changes, pubspec changes, or pre/post readback SQL changes. All 11 Binder flags remain off. P8 and activation are explicitly out of scope.

## Verification

- independent threat audit: A–K PASS
- independent follow-up security audit: PASS
- dedicated supervisor suite: 20/20
- focused rollout aggregate: 48/48
- exact Windows CI command under hostile `GIT_*`, `GCM_*`, and `MSYS*` environment: 48/48 on repeated runs
- full contracts: 867/867
- full pre-commit and pre-push `shipcheck`: PASS on both commits
  - secret guard
  - runtime preflight (`PASS_WITH_DEFERRED_DEBT`, 0 critical failures)
  - runtime health/reports
  - web typecheck, lint, and strict build
  - Flutter analyze
  - Flutter tests: 526/526
- `git diff --check`: PASS
- shared Git config remained healthy and byte-identical through hostile-environment tests

## Windows CI follow-up

The first Windows run exposed runner-specific harness assumptions and one real environment-isolation gap. The follow-up commit:

- synchronizes the timeout test on actual child readiness before asserting captured output
- isolates the migration-inventory negative fixture from the hosted runner's unreviewed Git binary while still exercising the real inventory guard
- canonicalizes only the authorization test's temporary path; the production canonical-path guard is unchanged
- strips ambient `GCM_*` credential-manager variables from database children and supervisor routing state, while Git children receive only the fixed safe `GCM_INTERACTIVE=Never`

These changes were independently reviewed as security-strengthening, stress-tested, and committed through the full hooks.

## Safety / promotion gate

**DO NOT MERGE YET.** The repository's Vercel integration has previously created a Production deployment for a `main` merge. Merging this PR is therefore expected to trigger a production web deployment and is outside the current no-deploy boundary.

This draft may be reviewed and CI may run. Merge requires a separate explicit decision about that automatic Vercel deployment. Even after merge, the supervisor must not be launched until a post-merge exact authorization envelope and its SHA-256 are generated, independently audited, and explicitly approved. No production mutation has occurred.