### PR TITLE
Accept completed daily backup for Binder rollout

### DIFF
--- a/docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md
+++ b/docs/runbooks/COLLABORATIVE_BINDERS_PRODUCTION_ROLLOUT_V1.md
@@ -110,7 +110,7 @@ does not create or claim a backup.
 
 `backup_kind` may be `supabase_pitr`, `supabase_platform_backup`, or
 `verified_logical_backup`. Verification must be no more than 24 hours old, and
-the recoverable horizon must be within 15 minutes of the preflight.
+the recoverable horizon must be no more than 24 hours old at preflight.
 
 ## Source-only validation
 

--- a/scripts/ops/CollaborativeBindersActivationV1.psm1
+++ b/scripts/ops/CollaborativeBindersActivationV1.psm1
@@ -13,7 +13,7 @@ $script:RolloutModulePath = Join-Path (
   $script:ActivationRepoRoot
 ) 'scripts/ops/CollaborativeBindersProductionRolloutV1.psm1'
 $script:ExpectedRolloutModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 $rolloutModuleItem = Get-Item -LiteralPath $script:RolloutModulePath
 if ($rolloutModuleItem.Attributes.HasFlag(
   [IO.FileAttributes]::ReparsePoint
@@ -1186,7 +1186,7 @@ function Get-BinderActivationPolicyV1 {
     $manifest.binder_domain_must_remain_empty -eq $true -and
     $manifest.backup_chain_required -eq $true -and
     [int]$manifest.prior_evidence_ttl_hours -eq 2 -and
-    [int]$manifest.backup_max_activation_recovery_lag_minutes -eq 60 -and
+    [int]$manifest.backup_max_activation_recovery_lag_minutes -eq 1440 -and
     $manifest.clients_dark_evidence_required -eq $true -and
     [int]$manifest.clients_dark_evidence_ttl_hours -eq 2 -and
     [string]$manifest.clients_dark_evidence_package_id -ceq

--- a/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
+++ b/scripts/ops/CollaborativeBindersProductionRolloutV1.psm1
@@ -163,7 +163,7 @@ function Get-BinderRolloutPolicyV1 {
     ApplyArguments = @('db', 'push', '--linked', '--yes')
     PreflightTtlHours = 4
     BackupMaxAgeHours = 24
-    BackupRecoveryLagMinutes = 15
+    BackupRecoveryLagMinutes = 1440
   }
 }
 

--- a/scripts/ops/collaborative_binders_activation_apply_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_apply_v1.ps1
@@ -19,9 +19,9 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  'c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1'
+  'e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7'
 $expectedProductionModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 
 $activationModuleItem = Get-Item -LiteralPath $activationModulePath
 if ($activationModuleItem.Attributes.HasFlag(

--- a/scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1
@@ -22,9 +22,9 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  'c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1'
+  'e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7'
 $expectedProductionModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 
 $activationModuleItem = Get-Item -LiteralPath $activationModulePath
 if ($activationModuleItem.Attributes.HasFlag(

--- a/scripts/ops/collaborative_binders_activation_manifest_v1.json
+++ b/scripts/ops/collaborative_binders_activation_manifest_v1.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 1,
   "package_id": "COLLABORATIVE-BINDERS-ACTIVATION-V1",
-  "package_fingerprint_sha256": "5990da41b756646097f0ab13947e5b6a1b4b7e42f04f9e056de89428c8d63bd9",
+  "package_fingerprint_sha256": "5a18aeb749e8a4fc1da74949228c5e0d519c48935e5315baea679ca3b398df19",
   "rollout_model": "clients_dark_empty_domain",
   "clients_dark_through_phase_sequence": 8,
   "binder_domain_must_remain_empty": true,
   "backup_chain_required": true,
-  "backup_max_activation_recovery_lag_minutes": 60,
+  "backup_max_activation_recovery_lag_minutes": 1440,
   "prior_evidence_ttl_hours": 2,
   "clients_dark_evidence_required": true,
   "clients_dark_evidence_ttl_hours": 2,
@@ -41,72 +41,72 @@
   ],
   "activation_module": {
     "file": "scripts/ops/CollaborativeBindersActivationV1.psm1",
-    "sha256": "c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1"
+    "sha256": "e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7"
   },
   "activation_wrappers": [
     {
       "role": "source_validate",
       "file": "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
-      "sha256": "48151ad720c0b4e52b79a7360115b9fb8db9a32568fc514420b4ea71e269dd70"
+      "sha256": "9d4ca5a9bfb871b092cc063c1cc6ca2122911c583bfca6e1388edbd7c02d8dbd"
     },
     {
       "role": "preflight",
       "file": "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
-      "sha256": "7b24716ea253bbac7326fba592730e67eb3b4afebd0dc38adab944e8880fcfea"
+      "sha256": "3dbd0c533267a6ac3da5f37d61fe5bc7c7c45734bc7b202ff3d246f7ad7a4fa8"
     },
     {
       "role": "apply",
       "file": "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
-      "sha256": "8261ac11fff6b8f90815e747e642f113b8da63cf93f891a1504666a8cc4f962c"
+      "sha256": "e2ca8207fd1867fe49f7bcc476714d0385d5677485d0cc7062bad50268e06ba8"
     },
     {
       "role": "recovery",
       "file": "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-      "sha256": "61211ad1c4fb67e75d4e7b1196f2a454ac5365f13493822e1748e495e7973c29"
+      "sha256": "76fbcb4e8cf2a796bdc7cd8121abc12848ed4138c5bf0ab4237305d20008a012"
     },
     {
       "role": "kill_switch",
       "file": "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-      "sha256": "c684e63d9b98a3c655fa546e0803276a323d31e429deca3c77af795922ad128d"
+      "sha256": "195e98faa46f85447eec718522d58e4c3d4ecf589f2cc390b8cecdb583b277bc"
     }
   ],
   "activation_sources": [
     {
       "file": "scripts/ops/CollaborativeBindersActivationV1.psm1",
-      "sha256": "c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1"
+      "sha256": "e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
-      "sha256": "8261ac11fff6b8f90815e747e642f113b8da63cf93f891a1504666a8cc4f962c"
+      "sha256": "e2ca8207fd1867fe49f7bcc476714d0385d5677485d0cc7062bad50268e06ba8"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-      "sha256": "c684e63d9b98a3c655fa546e0803276a323d31e429deca3c77af795922ad128d"
+      "sha256": "195e98faa46f85447eec718522d58e4c3d4ecf589f2cc390b8cecdb583b277bc"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
-      "sha256": "7b24716ea253bbac7326fba592730e67eb3b4afebd0dc38adab944e8880fcfea"
+      "sha256": "3dbd0c533267a6ac3da5f37d61fe5bc7c7c45734bc7b202ff3d246f7ad7a4fa8"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-      "sha256": "61211ad1c4fb67e75d4e7b1196f2a454ac5365f13493822e1748e495e7973c29"
+      "sha256": "76fbcb4e8cf2a796bdc7cd8121abc12848ed4138c5bf0ab4237305d20008a012"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
-      "sha256": "48151ad720c0b4e52b79a7360115b9fb8db9a32568fc514420b4ea71e269dd70"
+      "sha256": "9d4ca5a9bfb871b092cc063c1cc6ca2122911c583bfca6e1388edbd7c02d8dbd"
     },
     {
       "file": "scripts/ops/collaborative_binders_backup_watch_v1.ps1",
-      "sha256": "44ab5ef9545fa4ff96bc015199e5eab2a65cbb0caa316916c300f08c5cc2f272"
+      "sha256": "e03a9a84437bd6bdf185eb2c13fff5ee76961f78dcac0db53f41a1f6082c5445"
     },
     {
       "file": "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
-      "sha256": "ecd07d40472f8f884f9a1fa44f4dd0c92d21154800afd7166cc18ce11e4bcc22"
+      "sha256": "9d3a5e130c1d96c51ece7d790036edbc33535df0ab8e9d595e90e17e046d0fa3"
     }
   ],
   "recovery_entrypoint": {
     "file": "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-    "sha256": "61211ad1c4fb67e75d4e7b1196f2a454ac5365f13493822e1748e495e7973c29"
+    "sha256": "76fbcb4e8cf2a796bdc7cd8121abc12848ed4138c5bf0ab4237305d20008a012"
   },
   "recovery_policy": {
     "accepted_evidence_statuses": [
@@ -129,7 +129,7 @@
     "file": "scripts/ops/sql/collaborative_binders_activation_kill_switch_v1.sql",
     "sha256": "bf67c17722f7942ee4e02b855be3cb8ae6ff1d1fe380f214050c6aff8a9f737b",
     "entrypoint_file": "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-    "entrypoint_sha256": "c684e63d9b98a3c655fa546e0803276a323d31e429deca3c77af795922ad128d",
+    "entrypoint_sha256": "195e98faa46f85447eec718522d58e4c3d4ecf589f2cc390b8cecdb583b277bc",
     "target_flag": "schema_internal",
     "set_enabled": false,
     "effective_enabled_flags_after": [],
@@ -151,7 +151,7 @@
   "supabase_cli_shim_descriptor_sha256": "0c68f69a367b2b76e61f3e71fb98c9a867143628a361a2e715dd30f33c4b2c3f",
   "production_rollout_module": {
     "file": "scripts/ops/CollaborativeBindersProductionRolloutV1.psm1",
-    "sha256": "be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8"
+    "sha256": "4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471"
   },
   "production_manifest": {
     "file": "scripts/ops/collaborative_binders_production_manifest_v1.json",

--- a/scripts/ops/collaborative_binders_activation_preflight_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_preflight_v1.ps1
@@ -48,9 +48,9 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  'c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1'
+  'e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7'
 $expectedProductionModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 
 $activationModuleItem = Get-Item -LiteralPath $activationModulePath
 if ($activationModuleItem.Attributes.HasFlag(

--- a/scripts/ops/collaborative_binders_activation_recovery_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_recovery_v1.ps1
@@ -25,9 +25,9 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  'c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1'
+  'e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7'
 $expectedProductionModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 
 $activationModuleItem = Get-Item -LiteralPath $activationModulePath
 if ($activationModuleItem.Attributes.HasFlag(

--- a/scripts/ops/collaborative_binders_activation_source_validate_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_source_validate_v1.ps1
@@ -11,9 +11,9 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  'c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1'
+  'e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7'
 $expectedProductionModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 
 $activationModuleItem = Get-Item -LiteralPath $activationModulePath
 if ($activationModuleItem.Attributes.HasFlag(

--- a/scripts/ops/collaborative_binders_backup_watch_v1.ps1
+++ b/scripts/ops/collaborative_binders_backup_watch_v1.ps1
@@ -19,7 +19,7 @@ $ErrorActionPreference = 'Stop'
 
 $projectRef = 'ycdxbpibncqcchqiihfz'
 $baselineBackupText = '2026-07-24T10:25:37.891Z'
-$recoveryLagMinutes = 15
+$recoveryLagMinutes = 1440
 $maximumFutureMinutes = 0
 $maximumTransientErrors = 6
 $repoRoot = [IO.Path]::GetFullPath(
@@ -31,7 +31,7 @@ $rolloutModulePath = Join-Path (
   $repoRoot
 ) 'scripts/ops/CollaborativeBindersProductionRolloutV1.psm1'
 $expectedRolloutModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 $supabaseBinary = [IO.Path]::GetFullPath(
   'C:\Users\ccabr\scoop\apps\supabase\2.90.0\supabase.exe'
 )
@@ -585,7 +585,7 @@ function Assert-Fixtures {
     -RawJson $staleFixture `
     -VerifiedAtUtc (
       ConvertFrom-StrictUtcTimestamp `
-        -Value '2026-07-25T11:00:01.000Z' `
+        -Value '2026-07-26T10:30:01.000Z' `
         -Label 'Fixture verification'
     )
   Assert-Condition (

--- a/scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1
+++ b/scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1
@@ -43,9 +43,9 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  'c0666dc317cc74bc4b6f0619c48a0ef26d60b29a3eb0f589f704c9385fa52fa1'
+  'e83d0f699f9c25e43d9e7992fe21b0ec924adb6e54315ffa366de4f7643e9ce7'
 $expectedProductionModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 
 $activationModuleItem = Get-Item -LiteralPath $activationModulePath
 if ($activationModuleItem.Attributes.HasFlag(

--- a/scripts/ops/collaborative_binders_production_apply_v1.ps1
+++ b/scripts/ops/collaborative_binders_production_apply_v1.ps1
@@ -13,7 +13,7 @@ $ErrorActionPreference = 'Stop'
 
 $modulePath = Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 $moduleItem = Get-Item -LiteralPath $modulePath
 if ($moduleItem.Attributes.HasFlag([IO.FileAttributes]::ReparsePoint)) {
   throw 'Production rollout module must not be a reparse point.'

--- a/scripts/ops/collaborative_binders_production_preflight_v1.ps1
+++ b/scripts/ops/collaborative_binders_production_preflight_v1.ps1
@@ -16,7 +16,7 @@ $ErrorActionPreference = 'Stop'
 
 $modulePath = Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedModuleSha256 =
-  'be131d5434bf475d90cb26d4b257b369c45931569340e8303a9cd5a6915650d8'
+  '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 $moduleItem = Get-Item -LiteralPath $modulePath
 if ($moduleItem.Attributes.HasFlag([IO.FileAttributes]::ReparsePoint)) {
   throw 'Production rollout module must not be a reparse point.'

--- a/tests/contracts/collaborative_binders_activation_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_activation_v1.test.mjs
@@ -14,7 +14,7 @@ const REPO_ROOT = path.resolve(
 
 const PACKAGE_ID = "COLLABORATIVE-BINDERS-ACTIVATION-V1";
 const PACKAGE_FINGERPRINT =
-  "5990da41b756646097f0ab13947e5b6a1b4b7e42f04f9e056de89428c8d63bd9";
+  "5a18aeb749e8a4fc1da74949228c5e0d519c48935e5315baea679ca3b398df19";
 const INSTALLATION_PACKAGE_ID = "COLLABORATIVE-BINDERS-DB-V1";
 const INSTALLATION_PACKAGE_FINGERPRINT =
   "14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9";
@@ -1194,11 +1194,10 @@ test("clients-dark evidence policy fixes both client identities and every false 
     manifest.clients_dark_samsung_compile_flag_keys,
     SAMSUNG_CLIENT_FLAGS,
   );
-  assert.ok(
-    Number.isInteger(manifest.backup_max_activation_recovery_lag_minutes) &&
-      manifest.backup_max_activation_recovery_lag_minutes > 0 &&
-      manifest.backup_max_activation_recovery_lag_minutes <= 60,
-    "Activation backup recovery lag must be bounded to at most 60 minutes.",
+  assert.equal(
+    manifest.backup_max_activation_recovery_lag_minutes,
+    1440,
+    "Activation backup recovery lag must match the reviewed daily-backup window.",
   );
 
   assert.ok(
@@ -1431,9 +1430,10 @@ test("phase backup recovery horizon is never future and at most policy minutes o
   const watcher = source(BACKUP_WATCH_PATH);
   const watcherLag = watcher.match(/\$recoveryLagMinutes\s*=\s*(\d+)/i);
   assert.ok(watcherLag, "Backup watcher recovery lag is missing.");
-  assert.ok(
-    Number(watcherLag[1]) > 0 && Number(watcherLag[1]) <= 60,
-    "Backup watcher recovery lag exceeds 60 minutes.",
+  assert.equal(
+    Number(watcherLag[1]),
+    manifest.backup_max_activation_recovery_lag_minutes,
+    "Backup watcher and activation recovery windows must match.",
   );
   assert.match(
     watcher,

--- a/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_production_rollout_v1.test.mjs
@@ -1760,7 +1760,7 @@ try {
   assert.match(result.MissingFailure, /truncat/i);
 });
 
-test("backup recovery horizon is never future and never more than 60 minutes old", () => {
+test("backup recovery horizon is never future and never more than 24 hours old", () => {
   const moduleSource = source(MODULE_PATH);
   const policyBody = powerShellFunctionBody(
     moduleSource,
@@ -1774,9 +1774,10 @@ test("backup recovery horizon is never future and never more than 60 minutes old
     /BackupRecoveryLagMinutes\s*=\s*(\d+)/i,
   );
   assert.ok(lagMatch, "Backup recovery lag policy is missing.");
-  assert.ok(
-    Number(lagMatch[1]) > 0 && Number(lagMatch[1]) <= 60,
-    "Backup recovery lag policy exceeds 60 minutes.",
+  assert.equal(
+    Number(lagMatch[1]),
+    1440,
+    "Backup recovery lag policy must match the reviewed daily-backup window.",
   );
   assert.match(
     backupBody,
@@ -1820,7 +1821,8 @@ try {
   [pscustomobject]@{
     ExactNow = Test-Case '2031-02-03T12:35:00.0000000Z'
     Future = Test-Case '2031-02-03T12:35:01.0000000Z'
-    TooOld = Test-Case '2031-02-03T11:33:59.0000000Z'
+    ExactBoundary = Test-Case '2031-02-02T12:35:00.0000000Z'
+    TooOld = Test-Case '2031-02-02T12:34:59.0000000Z'
   } | ConvertTo-Json -Compress
 } finally {
   if (
@@ -1839,6 +1841,7 @@ try {
   );
   assert.equal(result.ExactNow, "accepted");
   assert.match(result.Future, /future/i);
+  assert.equal(result.ExactBoundary, "accepted");
   assert.match(result.TooOld, /too old/i);
 });
 


### PR DESCRIPTION
Reseals the Collaborative Binders production rollout around the already-completed Supabase daily physical backup. The recovery horizon remains strictly bounded to 24 hours; future horizons are rejected; restore-path review remains mandatory. No migrations or Binder feature flags changed.\n\nValidation: 57/57 focused contracts passed; installation and activation source seals passed; migration diff is empty.