### PR TITLE
Fix sealed Binder activation after safe main advance

### DIFF
--- a/scripts/ops/CollaborativeBindersActivationV1.psm1
+++ b/scripts/ops/CollaborativeBindersActivationV1.psm1
@@ -1434,16 +1434,13 @@ function Assert-BinderActivationRepositoryV1 {
     [string]$ExpectedHeadSha
   )
 
-  $repository = & $script:RolloutModule {
-    param($TargetRepoRoot, $TargetHeadSha)
-    Assert-BinderRepositoryStateV1 `
-      -RepoRoot $TargetRepoRoot `
-      -ExpectedHeadSha $TargetHeadSha
-  } $RepoRoot $ExpectedHeadSha
-
   $installationHeadSha =
     'a29680bdf79409823eedab8a62f0bd5cc89d675c'
-  $allowedTransitionPaths = @(
+  $sealedActivationHeadSha =
+    '67a33dbe0b69e930d064094ece9c8cf167fe6536'
+  $reviewedSafeMainHeadSha =
+    'd01a2d818513175061db8b6e9280c9850319b5ab'
+  $allowedInstallationTransitionPaths = @(
     'scripts/ops/CollaborativeBindersActivationV1.psm1',
     'scripts/ops/collaborative_binders_activation_apply_v1.ps1',
     'scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1',
@@ -1454,52 +1451,228 @@ function Assert-BinderActivationRepositoryV1 {
     'scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1',
     'tests/contracts/collaborative_binders_activation_v1.test.mjs'
   )
-  $transition = & $script:RolloutModule {
+  $allowedCurrentGuardTransitionPaths = @(
+    'scripts/ops/CollaborativeBindersActivationV1.psm1',
+    'scripts/ops/collaborative_binders_activation_apply_v1.ps1',
+    'scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1',
+    'scripts/ops/collaborative_binders_activation_manifest_v1.json',
+    'scripts/ops/collaborative_binders_activation_preflight_v1.ps1',
+    'scripts/ops/collaborative_binders_activation_recovery_v1.ps1',
+    'scripts/ops/collaborative_binders_activation_source_validate_v1.ps1',
+    'scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1',
+    'tests/contracts/collaborative_binders_activation_v1.test.mjs'
+  )
+  $protectedTreePaths = @(
+    '.metadata',
+    'analysis_options.yaml',
+    'android',
+    'apps',
+    'backend',
+    'deno.lock',
+    'ios',
+    'lib',
+    'linux',
+    'macos',
+    'package-lock.json',
+    'pubspec.lock',
+    'pubspec.yaml',
+    'scripts/ops',
+    'supabase',
+    'test',
+    'web',
+    'windows'
+  )
+  $policy = Get-BinderActivationPolicyV1 -RepoRoot $RepoRoot
+  $manifest = $policy.Manifest
+  Assert-BinderActivationConditionV1 (
+    [string]$manifest.required_installation_head_sha -ceq
+      $installationHeadSha -and
+    [string]$manifest.sealed_activation_head_sha -ceq
+      $sealedActivationHeadSha -and
+    [string]$manifest.reviewed_safe_main_head_sha -ceq
+      $reviewedSafeMainHeadSha -and
+    (@($manifest.installation_to_sealed_transition_paths) -join "`n") -ceq
+      (@($allowedInstallationTransitionPaths) -join "`n") -and
+    (@($manifest.safe_main_to_current_transition_paths) -join "`n") -ceq
+      (@($allowedCurrentGuardTransitionPaths) -join "`n") -and
+    (@($manifest.protected_tree_paths) -join "`n") -ceq
+      (@($protectedTreePaths) -join "`n")
+  ) 'Binder activation repository continuity policy is not exact.'
+  Assert-BinderActivationConditionV1 (
+    $ExpectedHeadSha -ceq $sealedActivationHeadSha
+  ) 'Binder activation evidence HEAD is not the sealed activation HEAD.'
+
+  $currentRepositoryHeadSha = & $script:RolloutModule {
+    param($TargetRepoRoot)
+    $head = Invoke-BinderGitV1 `
+      -Arguments @('rev-parse', 'HEAD') `
+      -RepoRoot $TargetRepoRoot
+    Assert-BinderCommandSucceededV1 `
+      -Result $head `
+      -Label 'Binder current repository HEAD check'
+    $headSha = $head.StdOut.Trim()
+    Assert-BinderConditionV1 (
+      $headSha -cmatch '^[0-9a-f]{40}$'
+    ) 'Binder current repository HEAD is invalid.'
+    return $headSha
+  } $RepoRoot
+  $repository = & $script:RolloutModule {
+    param($TargetRepoRoot, $TargetHeadSha)
+    Assert-BinderRepositoryStateV1 `
+      -RepoRoot $TargetRepoRoot `
+      -ExpectedHeadSha $TargetHeadSha
+  } $RepoRoot $currentRepositoryHeadSha
+
+  $installationTransition = & $script:RolloutModule {
     param(
       $TargetRepoRoot,
       $InstallationHead,
-      $ActivationHead
+      $SealedActivationHead
     )
     $ancestor = Invoke-BinderGitV1 `
       -Arguments @(
         'merge-base',
         '--is-ancestor',
         $InstallationHead,
-        $ActivationHead
+        $SealedActivationHead
       ) `
       -RepoRoot $TargetRepoRoot
     Assert-BinderCommandSucceededV1 `
       -Result $ancestor `
-      -Label 'Binder installation-to-activation ancestor check'
+      -Label 'Binder installation-to-sealed-activation ancestor check'
     $diff = Invoke-BinderGitV1 `
       -Arguments @(
         'diff',
         '--name-only',
         '--diff-filter=ACDMRTUXB',
-        "$InstallationHead..$ActivationHead"
+        "$InstallationHead..$SealedActivationHead"
       ) `
       -RepoRoot $TargetRepoRoot
     Assert-BinderCommandSucceededV1 `
       -Result $diff `
-      -Label 'Binder installation-to-activation path check'
+      -Label 'Binder installation-to-sealed-activation path check'
     return @(
       $diff.StdOut -split '\r?\n' |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
     )
   } $RepoRoot $installationHeadSha $ExpectedHeadSha
   Assert-BinderActivationConditionV1 (
-    (@($transition | Sort-Object) -join "`n") -ceq
-      (@($allowedTransitionPaths | Sort-Object) -join "`n")
-  ) 'Binder installation-to-activation transition changed outside the exact guard allowlist.'
+    (@($installationTransition | Sort-Object) -join "`n") -ceq
+      (@($allowedInstallationTransitionPaths | Sort-Object) -join "`n")
+  ) 'Binder installation-to-sealed-activation transition changed outside the exact guard allowlist.'
+
+  $repositoryContinuity = & $script:RolloutModule {
+    param(
+      $TargetRepoRoot,
+      $SealedActivationHead,
+      $ReviewedSafeMainHead,
+      $CurrentHead,
+      $ProtectedPaths
+    )
+    $sealedToReviewedAncestor = Invoke-BinderGitV1 `
+      -Arguments @(
+        'merge-base',
+        '--is-ancestor',
+        $SealedActivationHead,
+        $ReviewedSafeMainHead
+      ) `
+      -RepoRoot $TargetRepoRoot
+    Assert-BinderCommandSucceededV1 `
+      -Result $sealedToReviewedAncestor `
+      -Label 'Binder sealed-to-reviewed-main ancestor check'
+    $reviewedToCurrentAncestor = Invoke-BinderGitV1 `
+      -Arguments @(
+        'merge-base',
+        '--is-ancestor',
+        $ReviewedSafeMainHead,
+        $CurrentHead
+      ) `
+      -RepoRoot $TargetRepoRoot
+    Assert-BinderCommandSucceededV1 `
+      -Result $reviewedToCurrentAncestor `
+      -Label 'Binder reviewed-main-to-current ancestor check'
+
+    $protectedObjects = @(
+      foreach ($path in @($ProtectedPaths)) {
+        $sealedObject = Invoke-BinderGitV1 `
+          -Arguments @(
+            'rev-parse',
+            ('{0}:{1}' -f $SealedActivationHead, $path)
+          ) `
+          -RepoRoot $TargetRepoRoot
+        Assert-BinderCommandSucceededV1 `
+          -Result $sealedObject `
+          -Label "Binder sealed protected object check: $path"
+        $reviewedObject = Invoke-BinderGitV1 `
+          -Arguments @(
+            'rev-parse',
+            ('{0}:{1}' -f $ReviewedSafeMainHead, $path)
+          ) `
+          -RepoRoot $TargetRepoRoot
+        Assert-BinderCommandSucceededV1 `
+          -Result $reviewedObject `
+          -Label "Binder reviewed-main protected object check: $path"
+        $sealedObjectSha = $sealedObject.StdOut.Trim()
+        $reviewedObjectSha = $reviewedObject.StdOut.Trim()
+        Assert-BinderConditionV1 (
+          $sealedObjectSha -cmatch '^[0-9a-f]{40}$' -and
+          $reviewedObjectSha -cmatch '^[0-9a-f]{40}$' -and
+          $sealedObjectSha -ceq $reviewedObjectSha
+        ) "Binder protected object changed in reviewed main: $path"
+        [pscustomobject][ordered]@{
+          path = [string]$path
+          sealed_object_sha = $sealedObjectSha
+          reviewed_main_object_sha = $reviewedObjectSha
+        }
+      }
+    )
+
+    $diff = Invoke-BinderGitV1 `
+      -Arguments @(
+        'diff',
+        '--name-only',
+        '--diff-filter=ACDMRTUXB',
+        "$ReviewedSafeMainHead..$CurrentHead"
+      ) `
+      -RepoRoot $TargetRepoRoot
+    Assert-BinderCommandSucceededV1 `
+      -Result $diff `
+      -Label 'Binder reviewed-main-to-current guard path check'
+    $transitionPaths = @(
+      $diff.StdOut -split '\r?\n' |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    return [pscustomobject][ordered]@{
+      TransitionPaths = @($transitionPaths)
+      ProtectedObjects = @($protectedObjects)
+    }
+  } `
+    $RepoRoot `
+    $sealedActivationHeadSha `
+    $reviewedSafeMainHeadSha `
+    $currentRepositoryHeadSha `
+    $protectedTreePaths
+  Assert-BinderActivationConditionV1 (
+    (@($repositoryContinuity.TransitionPaths | Sort-Object) -join "`n") -ceq
+      (@($allowedCurrentGuardTransitionPaths | Sort-Object) -join "`n")
+  ) 'Binder reviewed-main-to-current transition changed outside the exact guard allowlist.'
 
   return [pscustomobject][ordered]@{
-    HeadSha = [string]$repository.HeadSha
+    HeadSha = $ExpectedHeadSha
+    ActivationHeadSha = $ExpectedHeadSha
+    CurrentRepositoryHeadSha = [string]$repository.HeadSha
     OriginMainSha = [string]$repository.OriginMainSha
     Branch = [string]$repository.Branch
     Clean = [bool]$repository.Clean
     InstallationHeadSha = $installationHeadSha
     InstallationHeadIsAncestor = $true
-    TransitionPaths = @($transition)
+    SealedActivationHeadSha = $sealedActivationHeadSha
+    ReviewedSafeMainHeadSha = $reviewedSafeMainHeadSha
+    ProtectedTreePaths = @($protectedTreePaths)
+    ProtectedObjects = @($repositoryContinuity.ProtectedObjects)
+    InstallationTransitionPaths = @($installationTransition)
+    CurrentGuardTransitionPaths =
+      @($repositoryContinuity.TransitionPaths)
   }
 }
 

--- a/scripts/ops/collaborative_binders_activation_apply_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_apply_v1.ps1
@@ -19,7 +19,7 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  '30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748'
+  '7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826'
 $expectedProductionModuleSha256 =
   '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 

--- a/scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1
@@ -22,7 +22,7 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  '30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748'
+  '7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826'
 $expectedProductionModuleSha256 =
   '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 

--- a/scripts/ops/collaborative_binders_activation_manifest_v1.json
+++ b/scripts/ops/collaborative_binders_activation_manifest_v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "package_id": "COLLABORATIVE-BINDERS-ACTIVATION-V1",
-  "package_fingerprint_sha256": "fd026d0a51852ab5596c54a48b48cc8021aa1c5473fae68f19e8498c26068e88",
+  "package_fingerprint_sha256": "32c31b7dfdd12f0f3883d45d2987a3450a424ebbea3891d9fbc8074e13841352",
   "rollout_model": "clients_dark_empty_domain",
   "clients_dark_through_phase_sequence": 8,
   "binder_domain_must_remain_empty": true,
@@ -42,59 +42,59 @@
   ],
   "activation_module": {
     "file": "scripts/ops/CollaborativeBindersActivationV1.psm1",
-    "sha256": "30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748"
+    "sha256": "7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826"
   },
   "activation_wrappers": [
     {
       "role": "source_validate",
       "file": "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
-      "sha256": "0fec73f122f858cc9fed9473c91509815993b5b8e7de0013104bd07cbe80098d"
+      "sha256": "5575a09e1de9c635d8f7adcd8fd95b11ec274ced3fcc8f330bc97fc09ff2cb75"
     },
     {
       "role": "preflight",
       "file": "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
-      "sha256": "a9ccd34abeb155eac65af426ed6e951cbe8c0e48525e0c07c7447cc20429377c"
+      "sha256": "0b485aec5e7acb6adc3ce00aa663aa9c52f5eebaccd130d514c1cb009e796ff2"
     },
     {
       "role": "apply",
       "file": "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
-      "sha256": "d54b8d0c01c8a1a3f97671cace06681bd49d482c120376478bed25b7315899ff"
+      "sha256": "8a9fa7ff2b1f221b19ba81870261bf138f60eb3cdcb09da0ee65944ac5f7aab9"
     },
     {
       "role": "recovery",
       "file": "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-      "sha256": "2e36b091b7768b8b40dcce47af5ae213769118bde9ff5e3ac946610bb7335f97"
+      "sha256": "fa93c6f4b13a9c7027b9404f28a7775f78d09feab880263cf882abd9e409d381"
     },
     {
       "role": "kill_switch",
       "file": "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-      "sha256": "1d8b94389a826f8e9059f7afb146e8539d830eaa8ff122eddc3697e70eaec689"
+      "sha256": "29c752864d773e2465b4ae6b722e3741c98f19fbfbb45d053d464ab0586248a0"
     }
   ],
   "activation_sources": [
     {
       "file": "scripts/ops/CollaborativeBindersActivationV1.psm1",
-      "sha256": "30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748"
+      "sha256": "7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
-      "sha256": "d54b8d0c01c8a1a3f97671cace06681bd49d482c120376478bed25b7315899ff"
+      "sha256": "8a9fa7ff2b1f221b19ba81870261bf138f60eb3cdcb09da0ee65944ac5f7aab9"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-      "sha256": "1d8b94389a826f8e9059f7afb146e8539d830eaa8ff122eddc3697e70eaec689"
+      "sha256": "29c752864d773e2465b4ae6b722e3741c98f19fbfbb45d053d464ab0586248a0"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
-      "sha256": "a9ccd34abeb155eac65af426ed6e951cbe8c0e48525e0c07c7447cc20429377c"
+      "sha256": "0b485aec5e7acb6adc3ce00aa663aa9c52f5eebaccd130d514c1cb009e796ff2"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-      "sha256": "2e36b091b7768b8b40dcce47af5ae213769118bde9ff5e3ac946610bb7335f97"
+      "sha256": "fa93c6f4b13a9c7027b9404f28a7775f78d09feab880263cf882abd9e409d381"
     },
     {
       "file": "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
-      "sha256": "0fec73f122f858cc9fed9473c91509815993b5b8e7de0013104bd07cbe80098d"
+      "sha256": "5575a09e1de9c635d8f7adcd8fd95b11ec274ced3fcc8f330bc97fc09ff2cb75"
     },
     {
       "file": "scripts/ops/collaborative_binders_backup_watch_v1.ps1",
@@ -102,12 +102,12 @@
     },
     {
       "file": "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
-      "sha256": "398a9f0c504fe9b4caa7c49b4defe55b9adc8e119979a7d262be89428726b876"
+      "sha256": "3e9b8d57dcbf7d1e5b6e6de73804773f5b507ef0dd55c048b69f27fe67e222c6"
     }
   ],
   "recovery_entrypoint": {
     "file": "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-    "sha256": "2e36b091b7768b8b40dcce47af5ae213769118bde9ff5e3ac946610bb7335f97"
+    "sha256": "fa93c6f4b13a9c7027b9404f28a7775f78d09feab880263cf882abd9e409d381"
   },
   "recovery_policy": {
     "accepted_evidence_statuses": [
@@ -130,7 +130,7 @@
     "file": "scripts/ops/sql/collaborative_binders_activation_kill_switch_v1.sql",
     "sha256": "bf67c17722f7942ee4e02b855be3cb8ae6ff1d1fe380f214050c6aff8a9f737b",
     "entrypoint_file": "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-    "entrypoint_sha256": "1d8b94389a826f8e9059f7afb146e8539d830eaa8ff122eddc3697e70eaec689",
+    "entrypoint_sha256": "29c752864d773e2465b4ae6b722e3741c98f19fbfbb45d053d464ab0586248a0",
     "target_flag": "schema_internal",
     "set_enabled": false,
     "effective_enabled_flags_after": [],
@@ -145,6 +145,50 @@
   "production_project_ref": "ycdxbpibncqcchqiihfz",
   "canonical_git_repository": "OriginalSoseji/grookai_vault",
   "required_installation_head_sha": "a29680bdf79409823eedab8a62f0bd5cc89d675c",
+  "sealed_activation_head_sha": "67a33dbe0b69e930d064094ece9c8cf167fe6536",
+  "reviewed_safe_main_head_sha": "d01a2d818513175061db8b6e9280c9850319b5ab",
+  "installation_to_sealed_transition_paths": [
+    "scripts/ops/CollaborativeBindersActivationV1.psm1",
+    "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_manifest_v1.json",
+    "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
+    "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
+    "tests/contracts/collaborative_binders_activation_v1.test.mjs"
+  ],
+  "safe_main_to_current_transition_paths": [
+    "scripts/ops/CollaborativeBindersActivationV1.psm1",
+    "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_manifest_v1.json",
+    "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
+    "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
+    "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
+    "tests/contracts/collaborative_binders_activation_v1.test.mjs"
+  ],
+  "protected_tree_paths": [
+    ".metadata",
+    "analysis_options.yaml",
+    "android",
+    "apps",
+    "backend",
+    "deno.lock",
+    "ios",
+    "lib",
+    "linux",
+    "macos",
+    "package-lock.json",
+    "pubspec.lock",
+    "pubspec.yaml",
+    "scripts/ops",
+    "supabase",
+    "test",
+    "web",
+    "windows"
+  ],
   "required_installation_package_id": "COLLABORATIVE-BINDERS-DB-V1",
   "required_installation_package_fingerprint_sha256": "14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9",
   "supported_supabase_cli_version": "2.90.0",

--- a/scripts/ops/collaborative_binders_activation_preflight_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_preflight_v1.ps1
@@ -48,7 +48,7 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  '30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748'
+  '7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826'
 $expectedProductionModuleSha256 =
   '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 

--- a/scripts/ops/collaborative_binders_activation_recovery_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_recovery_v1.ps1
@@ -25,7 +25,7 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  '30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748'
+  '7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826'
 $expectedProductionModuleSha256 =
   '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 

--- a/scripts/ops/collaborative_binders_activation_source_validate_v1.ps1
+++ b/scripts/ops/collaborative_binders_activation_source_validate_v1.ps1
@@ -11,7 +11,7 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  '30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748'
+  '7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826'
 $expectedProductionModuleSha256 =
   '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 

--- a/scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1
+++ b/scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1
@@ -43,7 +43,7 @@ $activationModulePath =
 $productionModulePath =
   Join-Path $PSScriptRoot 'CollaborativeBindersProductionRolloutV1.psm1'
 $expectedActivationModuleSha256 =
-  '30e3553217ded512fb54219e672b9ddff9d520de267da436de69b1d92ca61748'
+  '7ad2c2bcc86bf9f8d4b40ff3fbd9d3af4f3db3bc4dc9ace6880a783bf7747826'
 $expectedProductionModuleSha256 =
   '4a3c61cec4e490f17f180c7f994041675c37fd8d39bbd95cc8e5711eabedd471'
 

--- a/tests/contracts/collaborative_binders_activation_v1.test.mjs
+++ b/tests/contracts/collaborative_binders_activation_v1.test.mjs
@@ -14,12 +14,16 @@ const REPO_ROOT = path.resolve(
 
 const PACKAGE_ID = "COLLABORATIVE-BINDERS-ACTIVATION-V1";
 const PACKAGE_FINGERPRINT =
-  "fd026d0a51852ab5596c54a48b48cc8021aa1c5473fae68f19e8498c26068e88";
+  "32c31b7dfdd12f0f3883d45d2987a3450a424ebbea3891d9fbc8074e13841352";
 const INSTALLATION_PACKAGE_ID = "COLLABORATIVE-BINDERS-DB-V1";
 const INSTALLATION_PACKAGE_FINGERPRINT =
   "14a235d9ca9bc2172ddd3bfb8e2ba8b8812849079fe0469b73f35d02b6b47fb9";
 const INSTALLATION_HEAD_SHA =
   "a29680bdf79409823eedab8a62f0bd5cc89d675c";
+const SEALED_ACTIVATION_HEAD_SHA =
+  "67a33dbe0b69e930d064094ece9c8cf167fe6536";
+const REVIEWED_SAFE_MAIN_HEAD_SHA =
+  "d01a2d818513175061db8b6e9280c9850319b5ab";
 const PRODUCTION_PROJECT_REF = "ycdxbpibncqcchqiihfz";
 const CANONICAL_REPOSITORY = "OriginalSoseji/grookai_vault";
 const WINDOWS_ONLY = process.platform === "win32";
@@ -44,6 +48,51 @@ const READBACK_PATH =
   "scripts/ops/sql/collaborative_binders_activation_readback_v1.sql";
 const KILL_SWITCH_SQL_PATH =
   "scripts/ops/sql/collaborative_binders_activation_kill_switch_v1.sql";
+
+const INSTALLATION_TO_SEALED_TRANSITION_PATHS = [
+  "scripts/ops/CollaborativeBindersActivationV1.psm1",
+  "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_manifest_v1.json",
+  "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
+  "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
+  "tests/contracts/collaborative_binders_activation_v1.test.mjs",
+];
+
+const SAFE_MAIN_TO_CURRENT_TRANSITION_PATHS = [
+  "scripts/ops/CollaborativeBindersActivationV1.psm1",
+  "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_manifest_v1.json",
+  "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
+  "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
+  "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
+  "tests/contracts/collaborative_binders_activation_v1.test.mjs",
+];
+
+const PROTECTED_TREE_PATHS = [
+  ".metadata",
+  "analysis_options.yaml",
+  "android",
+  "apps",
+  "backend",
+  "deno.lock",
+  "ios",
+  "lib",
+  "linux",
+  "macos",
+  "package-lock.json",
+  "pubspec.lock",
+  "pubspec.yaml",
+  "scripts/ops",
+  "supabase",
+  "test",
+  "web",
+  "windows",
+];
 
 const ACTIVATION_WRAPPERS = [
   {
@@ -390,6 +439,23 @@ test("activation manifest is one exact content-addressed package", () => {
     manifest.required_installation_head_sha,
     INSTALLATION_HEAD_SHA,
   );
+  assert.equal(
+    manifest.sealed_activation_head_sha,
+    SEALED_ACTIVATION_HEAD_SHA,
+  );
+  assert.equal(
+    manifest.reviewed_safe_main_head_sha,
+    REVIEWED_SAFE_MAIN_HEAD_SHA,
+  );
+  assert.deepEqual(
+    manifest.installation_to_sealed_transition_paths,
+    INSTALLATION_TO_SEALED_TRANSITION_PATHS,
+  );
+  assert.deepEqual(
+    manifest.safe_main_to_current_transition_paths,
+    SAFE_MAIN_TO_CURRENT_TRANSITION_PATHS,
+  );
+  assert.deepEqual(manifest.protected_tree_paths, PROTECTED_TREE_PATHS);
   assert.equal(manifest.supported_supabase_cli_version, EXPECTED_CLI.version);
   assert.equal(manifest.supabase_cli_launcher_sha256, EXPECTED_CLI.launcher);
   assert.equal(manifest.supabase_cli_binary_sha256, EXPECTED_CLI.binary);
@@ -1118,28 +1184,64 @@ test("phase one accepts only the production installer's exact nested apply evide
     "Assert-BinderActivationRepositoryV1",
   );
   assert.ok(repositoryBody.includes(INSTALLATION_HEAD_SHA));
+  assert.ok(repositoryBody.includes(SEALED_ACTIVATION_HEAD_SHA));
+  assert.ok(repositoryBody.includes(REVIEWED_SAFE_MAIN_HEAD_SHA));
   assert.match(
     repositoryBody,
-    /merge-base[\s\S]*?--is-ancestor[\s\S]*?\$InstallationHead[\s\S]*?\$ActivationHead/i,
+    /\$ExpectedHeadSha\s*-ceq\s*\$sealedActivationHeadSha/i,
+  );
+  assert.match(
+    repositoryBody,
+    /Assert-BinderRepositoryStateV1[\s\S]*?-ExpectedHeadSha\s+\$TargetHeadSha[\s\S]*?\}\s+\$RepoRoot\s+\$currentRepositoryHeadSha/i,
+  );
+  assert.doesNotMatch(
+    repositoryBody,
+    /\}\s+\$RepoRoot\s+\$ExpectedHeadSha[\s\S]*?Assert-BinderRepositoryStateV1/i,
+  );
+  assert.match(
+    repositoryBody,
+    /merge-base[\s\S]*?--is-ancestor[\s\S]*?\$InstallationHead[\s\S]*?\$SealedActivationHead/i,
   );
   assert.match(
     repositoryBody,
     /diff[\s\S]*?--name-only[\s\S]*?--diff-filter=ACDMRTUXB/i,
   );
-  for (const allowedPath of [
-    "scripts/ops/CollaborativeBindersActivationV1.psm1",
-    "scripts/ops/collaborative_binders_activation_apply_v1.ps1",
-    "scripts/ops/collaborative_binders_activation_kill_switch_v1.ps1",
-    "scripts/ops/collaborative_binders_activation_manifest_v1.json",
-    "scripts/ops/collaborative_binders_activation_preflight_v1.ps1",
-    "scripts/ops/collaborative_binders_activation_recovery_v1.ps1",
-    "scripts/ops/collaborative_binders_activation_source_validate_v1.ps1",
-    "scripts/ops/collaborative_binders_clients_dark_evidence_v1.ps1",
-    "tests/contracts/collaborative_binders_activation_v1.test.mjs",
-  ]) {
+  assert.match(
+    repositoryBody,
+    /\$SealedActivationHead[\s\S]*?\$ReviewedSafeMainHead[\s\S]*?\$ReviewedSafeMainHead[\s\S]*?\$CurrentHead/i,
+  );
+  assert.match(
+    repositoryBody,
+    /'rev-parse'[\s\S]*?\('\{0\}:\{1\}'\s+-f\s+\$SealedActivationHead,\s*\$path\)/i,
+  );
+  assert.match(
+    repositoryBody,
+    /'rev-parse'[\s\S]*?\('\{0\}:\{1\}'\s+-f\s+\$ReviewedSafeMainHead,\s*\$path\)/i,
+  );
+  assert.match(
+    repositoryBody,
+    /\$sealedObjectSha\s+-cmatch\s+'\^\[0-9a-f\]\{40\}\$'[\s\S]*?\$reviewedObjectSha\s+-cmatch\s+'\^\[0-9a-f\]\{40\}\$'[\s\S]*?\$sealedObjectSha\s+-ceq\s+\$reviewedObjectSha/i,
+  );
+  assert.match(
+    repositoryBody,
+    /\$ReviewedSafeMainHead\.\.\$CurrentHead/i,
+  );
+  for (const allowedPath of INSTALLATION_TO_SEALED_TRANSITION_PATHS) {
     assert.ok(
       repositoryBody.includes(`'${allowedPath}'`),
-      `Installation-to-activation allowlist is missing ${allowedPath}.`,
+      `Installation-to-sealed allowlist is missing ${allowedPath}.`,
+    );
+  }
+  for (const allowedPath of SAFE_MAIN_TO_CURRENT_TRANSITION_PATHS) {
+    assert.ok(
+      repositoryBody.includes(`'${allowedPath}'`),
+      `Safe-main-to-current allowlist is missing ${allowedPath}.`,
+    );
+  }
+  for (const protectedPath of PROTECTED_TREE_PATHS) {
+    assert.ok(
+      repositoryBody.includes(`'${protectedPath}'`),
+      `Protected tree inventory is missing ${protectedPath}.`,
     );
   }
 });


### PR DESCRIPTION
## Summary
- keep Binder activation/client evidence pinned to sealed head `67a33dbe`
- independently require the clean local checkout and live `origin/main` to match the current reviewed commit
- pin `d01a2d81` as the reviewed safe-main tail and require exact ancestry
- prove 18 protected app/runtime/database Git objects are identical between `67a33dbe` and `d01a2d81`
- restrict `d01a2d81..current` to the exact nine content-addressed guard/reseal files

## Safety
- no migrations
- no database writes
- no client feature flags changed
- P8 and notifications/Pulse/set Binder flags remain excluded
- existing activation evidence remains bound to `67a33dbe`

## Verification
- activation contract: 28/28 passed
- content-addressed source validator passed
- clean-clone private guard integration passed with activation=`67a33dbe`, current/origin matching the branch commit, 18 protected objects, and 9 transition paths
- wrong activation head rejected
- independent static audit: green
- published Git tree exactly matches the tested local tree