### PR TITLE
Add Founder governed pricing visibility

### DIFF
--- a/apps/web/src/app/founder/page.tsx
+++ b/apps/web/src/app/founder/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FounderPricingPlatformSummaryCard } from "@/components/founder/FounderGovernedPricingPlatform";
 import FounderMarketSignalsSection from "@/components/founder/FounderMarketSignalsSection";
 import PublicCardImage from "@/components/PublicCardImage";
 import PageContainer from "@/components/layout/PageContainer";
@@ -14,6 +15,7 @@ import {
   getFounderPricingOpsSummary,
   type FounderPricingOpsSummary,
 } from "@/lib/founder/getPricingOpsSummary";
+import { getFounderGovernedPricingPlatformSummary } from "@/lib/founder/getGovernedPricingPlatformSummary";
 import {
   getCatalogImageOpsSummary,
   type CatalogImageOpsSummary,
@@ -1282,8 +1284,9 @@ export default async function FounderPage() {
   const admin = createServerAdminClient();
   await requireFounderAccess("/founder");
 
-  const [pricingOps, imageOps, opsReportRegistry] = await Promise.all([
+  const [pricingOps, governedPricing, imageOps, opsReportRegistry] = await Promise.all([
     getFounderPricingOpsSummary(admin),
+    getFounderGovernedPricingPlatformSummary(admin),
     getCatalogImageOpsSummary(),
     getFounderOpsReportRegistry(),
   ]);
@@ -1411,7 +1414,7 @@ export default async function FounderPage() {
           title="Founder Tools"
           description="Use these guarded lanes for access, review, and staged operational changes."
         />
-        <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-5">
+        <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
           <FounderToolCard
             href="/founder/entitlements"
             eyebrow="Access"
@@ -1443,6 +1446,12 @@ export default async function FounderPage() {
             title="Early Access"
             description="View and copy early access emails captured through the public landing page."
           />
+          <FounderToolCard
+            href="/founder/pricing"
+            eyebrow="Pricing"
+            title="TCGPlayer Market"
+            description="Trace exact-printing publication, deployment visibility, canary evidence, and Production V1 release gates."
+          />
         </div>
       </PageSection>
 
@@ -1461,6 +1470,8 @@ export default async function FounderPage() {
       <FounderOpsReportsSection registry={opsReportRegistry} />
 
       <CatalogImageOpsSection imageOps={imageOps} />
+
+      <FounderPricingPlatformSummaryCard summary={governedPricing} />
 
       <PricingOpsSection pricingOps={pricingOps} />
 
@@ -1927,9 +1938,9 @@ function PricingOpsSection({ pricingOps }: { pricingOps: FounderPricingOpsSummar
     <section className="space-y-5">
       <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
-          <h2 className="text-2xl font-semibold tracking-tight text-slate-950">Pricing Ops</h2>
+          <h2 className="text-2xl font-semibold tracking-tight text-slate-950">Legacy eBay Pricing Jobs</h2>
           <p className="text-sm text-slate-600">
-            Live founder visibility into Browse quota, queue pressure, and retry behavior.
+            Browse quota, queue pressure, and retry behavior for the legacy eBay worker. This is not the governed TCGPlayer Market publication platform.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">

--- a/apps/web/src/app/founder/pricing/page.tsx
+++ b/apps/web/src/app/founder/pricing/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { FounderGovernedPricingPlatformDetail } from "@/components/founder/FounderGovernedPricingPlatform";
+import PageContainer from "@/components/layout/PageContainer";
+import PageIntro from "@/components/layout/PageIntro";
+import { requireFounderAccess } from "@/lib/founder/requireFounderAccess";
+import {
+  getFounderGovernedPricingPlatformSummary,
+  getFounderPricingTraceByGvId,
+} from "@/lib/founder/getGovernedPricingPlatformSummary";
+import { createServerAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: "Pricing Platform | Founder | Grookai",
+  robots: { index: false, follow: false },
+};
+
+type FounderPricingPageProps = {
+  searchParams?: {
+    gv_id?: string | string[];
+  };
+};
+
+export default async function FounderPricingPage({
+  searchParams,
+}: FounderPricingPageProps) {
+  await requireFounderAccess("/founder/pricing");
+  const admin = createServerAdminClient();
+  const summary = await getFounderGovernedPricingPlatformSummary(admin);
+  const rawGvId = Array.isArray(searchParams?.gv_id)
+    ? searchParams?.gv_id[0]
+    : searchParams?.gv_id;
+  const trace = rawGvId
+    ? await getFounderPricingTraceByGvId(admin, rawGvId, summary)
+    : null;
+
+  return (
+    <PageContainer className="space-y-9 py-8">
+      <section className="gv-collector-panel px-6 py-8 sm:px-8 lg:px-10">
+        <PageIntro
+          eyebrow="Founder / Pricing"
+          title="TCGPlayer Market Publication"
+          description="Read-only operational proof for the governed English Pokemon exact-printing price platform. Database truth, deployed visibility, and release readiness are reported as separate facts."
+          actions={
+            <Link href="/founder" className="gv-secondary-button">
+              Back to Founder
+            </Link>
+          }
+        />
+      </section>
+      <FounderGovernedPricingPlatformDetail
+        summary={summary}
+        trace={trace}
+      />
+    </PageContainer>
+  );
+}

--- a/apps/web/src/components/founder/FounderGovernedPricingPlatform.tsx
+++ b/apps/web/src/components/founder/FounderGovernedPricingPlatform.tsx
@@ -1,0 +1,858 @@
+import Link from "next/link";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import type {
+  FounderGovernedPricingPlatformSummary,
+  FounderPricingRun,
+  FounderPricingTrace,
+} from "@/lib/founder/getGovernedPricingPlatformSummary";
+import type {
+  PricingReleaseGateStatus,
+  PricingVisibilityStatus,
+} from "@/lib/founder/governedPricingVisibilityPolicy";
+import FounderPricingRefreshControl from "./FounderPricingRefreshControl";
+
+const STATUS_STYLES: Record<PricingVisibilityStatus, string> = {
+  healthy: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  warning: "border-amber-200 bg-amber-50 text-amber-800",
+  blocked: "border-rose-200 bg-rose-50 text-rose-800",
+  not_deployed: "border-slate-300 bg-slate-100 text-slate-700",
+  not_verified: "border-sky-200 bg-sky-50 text-sky-800",
+  unavailable: "border-slate-300 bg-white text-slate-700",
+};
+
+const GATE_STYLES: Record<PricingReleaseGateStatus, string> = {
+  passed: STATUS_STYLES.healthy,
+  in_progress: STATUS_STYLES.warning,
+  blocked: STATUS_STYLES.blocked,
+  pending: STATUS_STYLES.not_verified,
+  not_verified: STATUS_STYLES.not_verified,
+};
+
+function humanizeStatus(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "Unknown";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+        timeZone: "America/Denver",
+      }).format(date);
+}
+
+function formatMoney(value: number, currency = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(value);
+}
+
+function shortSha(value: string | null) {
+  return value ? value.slice(0, 12) : "Unknown";
+}
+
+function StatusBadge({
+  status,
+  gate = false,
+}: {
+  status: PricingVisibilityStatus | PricingReleaseGateStatus;
+  gate?: boolean;
+}) {
+  const className = gate
+    ? GATE_STYLES[status as PricingReleaseGateStatus]
+    : STATUS_STYLES[status as PricingVisibilityStatus];
+  return (
+    <span
+      className={`inline-flex min-h-7 items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase ${className}`}
+    >
+      {humanizeStatus(status)}
+    </span>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="min-w-0 border-l-2 border-slate-200 pl-4">
+      <p className="text-xs font-semibold uppercase text-slate-500">{label}</p>
+      <p className="mt-1 break-words text-2xl font-semibold text-slate-950">
+        {value}
+      </p>
+      <p className="mt-1 text-xs leading-5 text-slate-500">{detail}</p>
+    </div>
+  );
+}
+
+function RunPanel({
+  title,
+  run,
+  emphasize = false,
+}: {
+  title: string;
+  run: FounderPricingRun | null;
+  emphasize?: boolean;
+}) {
+  if (!run) {
+    return (
+      <div className="border-t border-slate-200 py-4">
+        <h3 className="text-sm font-semibold text-slate-950">{title}</h3>
+        <p className="mt-2 text-sm text-slate-600">No run was available.</p>
+      </div>
+    );
+  }
+
+  const status: PricingVisibilityStatus =
+    run.state === "verified" && run.reconciliationState === "reconciled"
+      ? "healthy"
+      : run.state === "failed"
+        ? "blocked"
+        : run.state === "running" || run.findings.length > 0
+          ? "warning"
+          : "not_verified";
+
+  return (
+    <div
+      className={`border-t py-4 ${
+        emphasize ? "border-amber-300 bg-amber-50/60 px-4" : "border-slate-200"
+      }`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase text-slate-500">
+            {title}
+          </p>
+          <h3 className="mt-1 break-all text-sm font-semibold text-slate-950">
+            {run.runKey}
+          </h3>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+      <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
+        <div>
+          <dt className="text-xs uppercase text-slate-500">Mode / state</dt>
+          <dd className="mt-1 font-medium text-slate-900">
+            {run.mode} / {run.state}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase text-slate-500">Reconciliation</dt>
+          <dd className="mt-1 font-medium text-slate-900">
+            {run.reconciliationState}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase text-slate-500">Started</dt>
+          <dd className="mt-1 font-medium text-slate-900">
+            {formatDate(run.startedAt)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase text-slate-500">Commit</dt>
+          <dd className="mt-1 font-mono text-xs text-slate-900">
+            {shortSha(run.commitSha)}
+          </dd>
+        </div>
+      </dl>
+      <div className="mt-4 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4 xl:grid-cols-6">
+        {[
+          ["Selected", run.selectedCount],
+          ["Mapped", run.mappedCount],
+          ["Eligible", run.eligibleCount],
+          ["Snapshots", run.snapshotCount],
+          ["Quarantined", run.quarantinedCount],
+          ["Excluded", run.excludedCount],
+        ].map(([label, value]) => (
+          <div key={String(label)}>
+            <p className="text-xs uppercase text-slate-500">{label}</p>
+            <p className="mt-1 font-semibold text-slate-950">
+              {Number(value).toLocaleString("en-US")}
+            </p>
+          </div>
+        ))}
+      </div>
+      {run.findings.length > 0 ? (
+        <ul className="mt-4 space-y-1 text-sm text-amber-900">
+          {run.findings.map((finding) => (
+            <li key={finding}>{finding}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export function FounderPricingPlatformSummaryCard({
+  summary,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+}) {
+  const activeRunDiffers =
+    summary.latestRun && summary.latestRun.id !== summary.activeRun?.id;
+
+  return (
+    <PageSection
+      spacing="default"
+      className="gv-collector-panel px-5 py-6 sm:px-7"
+    >
+      <SectionHeader
+        title="TCGPlayer Market Publication"
+        description="Governed exact-printing publication state. This is separate from the legacy eBay pricing job monitor below."
+        actions={
+          <Link href="/founder/pricing" className="gv-primary-button">
+            Open Pricing Platform
+          </Link>
+        }
+      />
+      <div className="flex flex-wrap items-center gap-3 border-y border-slate-200 py-4">
+        <StatusBadge status={summary.overall.status} />
+        <p className="text-sm font-semibold text-slate-950">
+          {summary.overall.label}
+        </p>
+        <p className="text-sm text-slate-600">{summary.overall.detail}</p>
+      </div>
+      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-5">
+        <Metric
+          label="Active exact prices"
+          value={summary.system.publicationSize.toLocaleString("en-US")}
+          detail={`Mode: ${summary.system.publicationMode}`}
+        />
+        <Metric
+          label="Current database view"
+          value={summary.system.readModelSize.toLocaleString("en-US")}
+          detail="Live database rows"
+        />
+        <Metric
+          label="Coverage"
+          value={`${summary.coverage.percentage.toFixed(3)}%`}
+          detail={`${summary.coverage.remainingGapRows.toLocaleString("en-US")} classified gaps`}
+        />
+        <Metric
+          label="Source age"
+          value={
+            summary.system.sourceAgeHours === null
+              ? "Unknown"
+              : `${summary.system.sourceAgeHours.toFixed(1)}h`
+          }
+          detail="Oldest source evidence in active set"
+        />
+        <Metric
+          label="Release gates passed"
+          value={`${summary.releaseGates.filter((gate) => gate.status === "passed").length}/${summary.releaseGates.length}`}
+          detail="Production V1 release contract"
+        />
+      </div>
+      {activeRunDiffers ? (
+        <p className="border-l-2 border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          A newer run exists than the active publication run. Open the pricing
+          platform to inspect it separately; it does not replace the active
+          published set.
+        </p>
+      ) : null}
+    </PageSection>
+  );
+}
+
+export function FounderGovernedPricingPlatformDetail({
+  summary,
+  trace,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+  trace: FounderPricingTrace | null;
+}) {
+  const latestDiffers =
+    summary.latestRun && summary.latestRun.id !== summary.activeRun?.id;
+
+  return (
+    <>
+      <PageSection spacing="default">
+        <div className="flex flex-col gap-4 border-y border-slate-200 py-5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-3">
+              <StatusBadge status={summary.overall.status} />
+              <h2 className="text-lg font-semibold text-slate-950">
+                {summary.overall.label}
+              </h2>
+            </div>
+            <p className="mt-2 max-w-4xl text-sm leading-6 text-slate-600">
+              {summary.overall.detail}
+            </p>
+          </div>
+          <FounderPricingRefreshControl />
+        </div>
+        <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+          <Metric
+            label="Publication"
+            value={summary.system.publicationSize.toLocaleString("en-US")}
+            detail={`Activated ${formatDate(summary.system.activatedAt)}`}
+          />
+          <Metric
+            label="View / governed RPC"
+            value={`${summary.system.readModelSize.toLocaleString("en-US")} / ${summary.system.governedRpcCompatibleSize.toLocaleString("en-US")}`}
+            detail="Backing current view versus rows accepted by the shared client contract"
+          />
+          <Metric
+            label="Coverage"
+            value={`${summary.coverage.percentage.toFixed(3)}%`}
+            detail={`${summary.coverage.numerator.toLocaleString("en-US")} / ${summary.coverage.denominator.toLocaleString("en-US")}`}
+          />
+          <Metric
+            label="Next expected cycle"
+            value={formatDate(summary.system.nextExpectedCycleAt)}
+            detail="Daily governed schedule, 08:15 UTC"
+          />
+        </div>
+      </PageSection>
+
+      <PageSection spacing="default">
+        <SectionHeader
+          title="Visibility Ladder"
+          description="Each step is verified independently. Database publication is not presented as deployed client visibility."
+        />
+        <div className="divide-y divide-slate-200 border-y border-slate-200">
+          {summary.visibilityLadder.map((stage) => (
+            <div
+              key={stage.id}
+              className="grid gap-3 py-4 md:grid-cols-[minmax(0,14rem)_minmax(0,1fr)_minmax(0,15rem)] md:items-start"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusBadge status={stage.status} />
+                <p className="font-semibold text-slate-950">{stage.label}</p>
+              </div>
+              <p className="text-sm leading-6 text-slate-600">{stage.detail}</p>
+              <div className="text-xs leading-5 text-slate-500">
+                <p>{stage.verificationSource}</p>
+                <p>{formatDate(stage.verifiedAt)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </PageSection>
+
+      <PageSection spacing="default">
+        <SectionHeader
+          title="Database Canary"
+          description={summary.canary.statement}
+        />
+        <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+          <Metric
+            label="Classification"
+            value={summary.canary.classification}
+            detail={`${summary.canary.observedHours.toFixed(1)} / ${summary.canary.expectedHours} hours observed`}
+          />
+          <Metric
+            label="Exact / positive"
+            value={`${summary.canary.exactPriceCount} / ${summary.canary.positivePriceCount}`}
+            detail={`${summary.canary.staleCount} stale; ${summary.canary.brokenProvenanceCount} broken provenance`}
+          />
+          <Metric
+            label="Authenticated access"
+            value={humanizeStatus(summary.canary.authenticatedAccess)}
+            detail={summary.canary.accessVerificationSource}
+          />
+          <Metric
+            label="Anonymous access"
+            value={humanizeStatus(summary.canary.anonymousAccess)}
+            detail="Verified denied under the frozen V1 contract"
+          />
+        </div>
+        <div className="grid gap-4 border-t border-slate-200 pt-4 text-sm sm:grid-cols-2">
+          <p>
+            <span className="font-semibold text-slate-950">Started:</span>{" "}
+            <span className="text-slate-600">
+              {formatDate(summary.canary.startAt)}
+            </span>
+          </p>
+          <p>
+            <span className="font-semibold text-slate-950">Required end:</span>{" "}
+            <span className="text-slate-600">
+              {formatDate(summary.canary.requiredEndAt)}
+            </span>
+          </p>
+          <p>
+            <span className="font-semibold text-slate-950">Rollback:</span>{" "}
+            <span className="text-slate-600">
+              {summary.canary.rollbackAvailable
+                ? "Previous publication pointer available"
+                : "Not available"}
+            </span>
+          </p>
+          <p>
+            <span className="font-semibold text-slate-950">
+              Client rendering:
+            </span>{" "}
+            <span className="text-slate-600">
+              Web {summary.canary.webClientsExercised ? "verified" : "unverified"};
+              Flutter{" "}
+              {summary.canary.flutterClientsExercised
+                ? "verified"
+                : "unverified"}
+            </span>
+          </p>
+        </div>
+      </PageSection>
+
+      <PageSection spacing="default">
+        <SectionHeader
+          title="Publication Runs"
+          description="The active publication run and newest observed run are deliberately separate."
+        />
+        <RunPanel title="Active publication run" run={summary.activeRun} />
+        {latestDiffers ? (
+          <RunPanel
+            title="Newest observed run, not active"
+            run={summary.latestRun}
+            emphasize
+          />
+        ) : null}
+      </PageSection>
+
+      <PhaseTable summary={summary} />
+      <CoverageSection summary={summary} />
+      <DeploymentSection summary={summary} />
+      <ReleaseGateSection summary={summary} />
+
+      <PageSection
+        spacing="default"
+        className="gv-soft-surface px-5 py-6 sm:px-7"
+      >
+        <SectionHeader
+          title="Trace One Parent GV-ID"
+          description="Read-only trace from canonical parent through exact printing, qualification, active publication, governed read model, and client visibility evidence."
+        />
+        <form
+          method="get"
+          action="/founder/pricing"
+          className="flex flex-col gap-3 sm:flex-row"
+        >
+          <label className="min-w-0 flex-1">
+            <span className="sr-only">Canonical parent GV-ID</span>
+            <input
+              type="text"
+              name="gv_id"
+              defaultValue={trace?.requestedGvId ?? ""}
+              placeholder="GV-PK-ASC-276"
+              className="min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 outline-none ring-emerald-600 focus:ring-2"
+              autoComplete="off"
+            />
+          </label>
+          <button type="submit" className="gv-primary-button min-h-11">
+            Trace price
+          </button>
+        </form>
+        {trace ? <PricingTraceResult trace={trace} /> : null}
+      </PageSection>
+
+      <RecentRunsAndAlerts summary={summary} />
+    </>
+  );
+}
+
+function PhaseTable({
+  summary,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+}) {
+  return (
+    <PageSection spacing="default">
+      <SectionHeader
+        title="Durable Phase Attempts"
+        description="Latest durable state for each phase and attempt in the active publication run."
+      />
+      <div className="overflow-x-auto border-y border-slate-200">
+        <table className="w-full min-w-[760px] text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-3 font-semibold">Phase</th>
+              <th className="px-3 py-3 font-semibold">Attempt</th>
+              <th className="px-3 py-3 font-semibold">State</th>
+              <th className="px-3 py-3 font-semibold">Input</th>
+              <th className="px-3 py-3 font-semibold">Output</th>
+              <th className="px-3 py-3 font-semibold">Reconciled</th>
+              <th className="px-3 py-3 font-semibold">Completed</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {summary.phases.map((phase) => (
+              <tr key={`${phase.name}:${phase.attempt}`}>
+                <td className="px-3 py-3">
+                  <p className="font-semibold text-slate-950">{phase.label}</p>
+                  <p className="font-mono text-xs text-slate-500">
+                    {phase.name}
+                  </p>
+                </td>
+                <td className="px-3 py-3">{phase.attempt}</td>
+                <td className="px-3 py-3">{phase.state}</td>
+                <td className="px-3 py-3">
+                  {phase.inputCount.toLocaleString("en-US")}
+                </td>
+                <td className="px-3 py-3">
+                  {phase.outputCount.toLocaleString("en-US")}
+                </td>
+                <td className="px-3 py-3">
+                  {phase.reconciledCount.toLocaleString("en-US")}
+                </td>
+                <td className="px-3 py-3">{formatDate(phase.completedAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </PageSection>
+  );
+}
+
+function CoverageSection({
+  summary,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+}) {
+  return (
+    <PageSection spacing="default">
+      <SectionHeader
+        title="Coverage Evidence"
+        description="Last committed fixed-denominator coverage audit. This is evidence from an artifact, not a live production query."
+      />
+      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+        <Metric
+          label="Coverage"
+          value={`${summary.coverage.percentage.toFixed(3)}%`}
+          detail={`Target ${summary.coverage.targetPercentage}%`}
+        />
+        <Metric
+          label="In scope"
+          value={summary.coverage.denominator.toLocaleString("en-US")}
+          detail={`${summary.coverage.numerator.toLocaleString("en-US")} covered`}
+        />
+        <Metric
+          label="Remaining gap"
+          value={summary.coverage.remainingGapRows.toLocaleString("en-US")}
+          detail="Every row classified"
+        />
+        <Metric
+          label="Policy"
+          value={summary.coverage.policyVersion}
+          detail={formatDate(summary.coverage.verifiedAt)}
+        />
+      </div>
+      <div className="overflow-x-auto border-y border-slate-200">
+        <table className="w-full min-w-[520px] text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-3 font-semibold">Gap reason</th>
+              <th className="px-3 py-3 text-right font-semibold">Rows</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {summary.coverage.gapReasons.map((gap) => (
+              <tr key={gap.reason}>
+                <td className="px-3 py-3 font-mono text-xs text-slate-800">
+                  {gap.reason}
+                </td>
+                <td className="px-3 py-3 text-right font-semibold text-slate-950">
+                  {gap.count.toLocaleString("en-US")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </PageSection>
+  );
+}
+
+function DeploymentSection({
+  summary,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+}) {
+  return (
+    <PageSection spacing="default">
+      <SectionHeader
+        title="Deployment Evidence"
+        description="Unknown means no deployed-provider evidence is available. Source code presence is never treated as deployment proof."
+      />
+      <div className="overflow-x-auto border-y border-slate-200">
+        <table className="w-full min-w-[900px] text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-3 font-semibold">Component</th>
+              <th className="px-3 py-3 font-semibold">Status</th>
+              <th className="px-3 py-3 font-semibold">Running</th>
+              <th className="px-3 py-3 font-semibold">Release target</th>
+              <th className="px-3 py-3 font-semibold">Evidence</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {summary.deployments.map((deployment) => (
+              <tr key={deployment.component}>
+                <td className="px-3 py-3 font-semibold text-slate-950">
+                  {deployment.component}
+                </td>
+                <td className="px-3 py-3">
+                  <StatusBadge status={deployment.status} />
+                </td>
+                <td className="max-w-52 break-all px-3 py-3 font-mono text-xs">
+                  {deployment.runningVersion ?? "Unknown"}
+                </td>
+                <td className="max-w-64 break-words px-3 py-3 text-xs">
+                  {deployment.releaseVersion ?? "Unknown"}
+                </td>
+                <td className="max-w-72 px-3 py-3 text-xs leading-5 text-slate-600">
+                  {deployment.verificationSource}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </PageSection>
+  );
+}
+
+function ReleaseGateSection({
+  summary,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+}) {
+  return (
+    <PageSection spacing="default">
+      <SectionHeader
+        title="Release Gates"
+        description="Frozen Production V1 gates. No control on this page changes them."
+      />
+      <div className="grid gap-x-8 md:grid-cols-2">
+        {summary.releaseGates.map((gate) => (
+          <div
+            key={gate.id}
+            className="flex items-start gap-3 border-t border-slate-200 py-4"
+          >
+            <StatusBadge status={gate.status} gate />
+            <div className="min-w-0">
+              <p className="font-semibold text-slate-950">{gate.label}</p>
+              <p className="mt-1 text-sm leading-5 text-slate-600">
+                {gate.detail}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </PageSection>
+  );
+}
+
+function PricingTraceResult({ trace }: { trace: FounderPricingTrace }) {
+  if (trace.status !== "available") {
+    return (
+      <div className="border-l-2 border-amber-400 bg-amber-50 px-4 py-3">
+        <p className="font-semibold text-amber-950">
+          {trace.status === "invalid" ? "Invalid GV-ID" : "Price unavailable"}
+        </p>
+        <p className="mt-1 text-sm text-amber-900">
+          {trace.unavailableReason}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 border-t border-slate-200 pt-4">
+      <div>
+        <p className="text-xs font-semibold uppercase text-slate-500">
+          Canonical parent
+        </p>
+        <h3 className="mt-1 text-lg font-semibold text-slate-950">
+          {trace.canonicalName} ({trace.requestedGvId})
+        </h3>
+        <p className="mt-1 break-all font-mono text-xs text-slate-500">
+          Active publication set: {trace.activePublicationSetId}
+        </p>
+      </div>
+      {trace.printings.map((printing) => (
+        <article
+          key={printing.publicationSnapshotId}
+          className="border-t border-slate-200 py-4"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="font-semibold text-slate-950">
+                {printing.printingGvId}
+              </p>
+              <p className="mt-1 text-sm text-slate-600">
+                {printing.finish} / {printing.sourceSubtypeName}
+              </p>
+            </div>
+            <p className="text-2xl font-semibold text-slate-950">
+              {formatMoney(printing.marketPrice, printing.currency)}
+            </p>
+          </div>
+          <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Canonical mapping
+              </dt>
+              <dd className="mt-1 text-slate-900">
+                {printing.mappingMethod ?? "Unknown"} (
+                {printing.mappingConfidence ?? "n/a"})
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Qualification
+              </dt>
+              <dd className="mt-1 text-slate-900">
+                {printing.qualificationStatus} / {printing.publicationLane}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Language / finish
+              </dt>
+              <dd className="mt-1 text-slate-900">
+                {printing.languageResult} / {printing.finishResult}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Source evidence
+              </dt>
+              <dd className="mt-1 text-slate-900">
+                Product {printing.sourceProductId};{" "}
+                {formatDate(printing.observedAt)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Source row fingerprint
+              </dt>
+              <dd className="mt-1 font-mono text-xs text-slate-900">
+                {printing.sourceRowFingerprint}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Artifact fingerprint
+              </dt>
+              <dd className="mt-1 font-mono text-xs text-slate-900">
+                {printing.sourceArtifactFingerprint}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Active pointer / RPC
+              </dt>
+              <dd className="mt-1 text-slate-900">
+                {printing.activePointer ? "yes" : "no"} /{" "}
+                {printing.governedRpcAvailable ? "available" : "unavailable"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-slate-500">
+                Client verification
+              </dt>
+              <dd className="mt-1 text-slate-900">
+                API {humanizeStatus(trace.deployedApiVisibility)}; web{" "}
+                {humanizeStatus(trace.webVisibility)}; Flutter{" "}
+                {humanizeStatus(trace.flutterVisibility)}
+              </dd>
+            </div>
+          </dl>
+          {printing.reasonCodes.length > 0 ? (
+            <p className="mt-3 text-xs text-slate-500">
+              Reasons: {printing.reasonCodes.join(", ")}
+            </p>
+          ) : null}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function RecentRunsAndAlerts({
+  summary,
+}: {
+  summary: FounderGovernedPricingPlatformSummary;
+}) {
+  return (
+    <PageSection spacing="default">
+      <SectionHeader
+        title="Recent Runs and Alerts"
+        description="Operational evidence only. No retries, activations, or acknowledgements are available here."
+      />
+      <div className="overflow-x-auto border-y border-slate-200">
+        <table className="w-full min-w-[820px] text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-3 font-semibold">Run</th>
+              <th className="px-3 py-3 font-semibold">Mode</th>
+              <th className="px-3 py-3 font-semibold">State</th>
+              <th className="px-3 py-3 font-semibold">Reconciliation</th>
+              <th className="px-3 py-3 font-semibold">Snapshots</th>
+              <th className="px-3 py-3 font-semibold">Completed</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {summary.recentRuns.map((run) => (
+              <tr key={run.id}>
+                <td className="max-w-72 break-all px-3 py-3 font-mono text-xs">
+                  {run.runKey}
+                </td>
+                <td className="px-3 py-3">{run.mode}</td>
+                <td className="px-3 py-3">{run.state}</td>
+                <td className="px-3 py-3">{run.reconciliationState}</td>
+                <td className="px-3 py-3">
+                  {run.snapshotCount.toLocaleString("en-US")}
+                </td>
+                <td className="px-3 py-3">{formatDate(run.completedAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {summary.alerts.recent.length > 0 ? (
+        <div className="divide-y divide-slate-200 border-y border-slate-200">
+          {summary.alerts.recent.map((alert) => (
+            <div
+              key={alert.id}
+              className="grid gap-2 py-3 text-sm sm:grid-cols-[8rem_minmax(0,1fr)_12rem]"
+            >
+              <p className="font-semibold uppercase text-slate-600">
+                {alert.severity}
+              </p>
+              <p className="break-words text-slate-900">
+                {alert.event_type} from {alert.source_host} /{" "}
+                {alert.source_unit}
+              </p>
+              <p className="text-slate-500">{formatDate(alert.received_at)}</p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-slate-600">
+          No operations notification events were returned.
+        </p>
+      )}
+      {summary.errors.length > 0 ? (
+        <div className="border-l-2 border-rose-400 bg-rose-50 px-4 py-3">
+          <p className="font-semibold text-rose-900">Read errors</p>
+          <ul className="mt-2 space-y-1 text-sm text-rose-800">
+            {summary.errors.map((error) => (
+              <li key={error}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </PageSection>
+  );
+}

--- a/apps/web/src/components/founder/FounderPricingRefreshControl.tsx
+++ b/apps/web/src/components/founder/FounderPricingRefreshControl.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+export default function FounderPricingRefreshControl() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [lastRefreshAt, setLastRefreshAt] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    startTransition(() => {
+      router.refresh();
+      setLastRefreshAt(new Date().toISOString());
+    });
+  }, [router]);
+
+  useEffect(() => {
+    const timer = window.setInterval(refresh, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs text-slate-500">
+        Auto-refreshes every 60 seconds
+        {lastRefreshAt
+          ? `; last requested ${new Date(lastRefreshAt).toLocaleTimeString()}`
+          : ""}
+      </span>
+      <button
+        type="button"
+        className="gv-secondary-button min-h-10 px-3 py-2 text-sm"
+        onClick={refresh}
+        disabled={isPending}
+        aria-label="Refresh pricing platform status"
+        title="Refresh pricing platform status"
+      >
+        {isPending ? "Refreshing" : "Refresh"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/founder/getGovernedPricingPlatformSummary.ts
+++ b/apps/web/src/lib/founder/getGovernedPricingPlatformSummary.ts
@@ -1,0 +1,1319 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getMarketPricingReadModelV1 } from "@/lib/pricing/marketPricingReadModelV1";
+import {
+  buildCanaryState,
+  buildReleaseGates,
+  classifyPricingPlatformOverall,
+  deploymentVerificationStatus,
+  LAST_VERIFIED_COVERAGE,
+  latestDurablePhaseAttempts,
+  nextExpectedPricingCycle,
+  PRICING_RELEASE_BASELINE_SHA,
+  PRICING_SOURCE_FRESHNESS_HOURS,
+  type DurablePhaseAttempt,
+  type PricingCanaryState,
+  type PricingDeploymentState,
+  type PricingReleaseGate,
+  type PricingVisibilityStage,
+  type PricingVisibilityStatus,
+} from "@/lib/founder/governedPricingVisibilityPolicy";
+
+type AdminClient = SupabaseClient;
+
+type CurrentPublicationRow = {
+  publication_set_id: string;
+  run_id: string;
+  previous_publication_set_id: string | null;
+  activated_at: string;
+  updated_at: string;
+};
+
+type PublicationSetRow = {
+  id: string;
+  run_id: string;
+  run_key: string;
+  publication_state: string;
+  expected_snapshot_count: number;
+  previous_publication_set_id: string | null;
+  published_at: string | null;
+  superseded_at: string | null;
+  rolled_back_at: string | null;
+  rollback_reason: string | null;
+  reconciliation: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type PipelineRunRow = {
+  id: string;
+  run_key: string;
+  pipeline_version: string;
+  policy_version: string;
+  run_mode: string;
+  source_name: string;
+  source_observed_on: string | null;
+  source_sync_run_id: string | null;
+  source_artifact_id: string | null;
+  source_artifact_hash: string | null;
+  source_marker: string | null;
+  state: string;
+  current_phase: string | null;
+  reconciliation_state: string;
+  selected_count: number;
+  mapped_count: number;
+  excluded_count: number;
+  quarantined_count: number;
+  delayed_count: number;
+  suppressed_count: number;
+  eligible_count: number;
+  snapshot_count: number;
+  required_phase_count: number;
+  succeeded_phase_count: number;
+  git_commit_sha: string;
+  worker_version: string;
+  schema_version: string;
+  started_at: string | null;
+  completed_at: string | null;
+  failed_at: string | null;
+  error_classification: string | null;
+  error: string | null;
+  reconciliation: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type PhaseAttemptRow = {
+  id: string;
+  phase_name: string;
+  attempt: number;
+  state: string;
+  started_at: string;
+  completed_at: string | null;
+  input_count: number;
+  output_count: number;
+  reconciled_count: number;
+  excluded_count: number;
+  quarantined_count: number;
+  error_classification: string | null;
+  error: string | null;
+  created_at: string;
+};
+
+type SourceSyncRow = {
+  id: string;
+  run_key: string;
+  status: string;
+  source_marker: string | null;
+  observed_on: string | null;
+  request_count: number;
+  category_count: number;
+  group_count: number;
+  product_count: number;
+  price_row_count: number;
+  failed_count: number;
+  git_commit_sha: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+};
+
+type OperationsAlertRow = {
+  id: string;
+  notification_id: string;
+  event_type: string;
+  severity: string;
+  source_host: string;
+  source_unit: string;
+  recipient_count: number;
+  received_at: string;
+};
+
+type TraceSnapshotRow = {
+  id: string;
+  provenance_id: string;
+  publication_set_id: string;
+  run_id: string;
+  qualification_decision_id: string;
+  source_observation_id: string;
+  source_artifact_hash: string;
+  source_price_row_identity: string;
+  source_row_hash: string;
+  source_product_id: number;
+  source_subtype_name: string;
+  source_observed_on: string;
+  source_sync_finished_at: string;
+  card_print_id: string;
+  card_printing_id: string;
+  gv_id: string;
+  printing_gv_id: string;
+  finish_key: string;
+  currency: string;
+  market_price: number;
+  observed_at: string;
+  published_at: string;
+  freshness_state: string;
+  publication_state: string;
+};
+
+type TraceDecisionRow = {
+  id: string;
+  mapping_method: string | null;
+  mapping_confidence: number | null;
+  language_result: string;
+  finish_result: string;
+  decision: string;
+  eligible: boolean;
+  publication_lane: string;
+  reason_codes: string[];
+  source_integrity_result: string;
+  duplicate_product_result: string;
+  freshness_result: string;
+  variant_assignment_status: string | null;
+  evaluated_at: string;
+};
+
+type ActiveSnapshotIdentityRow = {
+  card_print_id: string;
+  card_printing_id: string;
+};
+
+export type FounderPricingRun = {
+  id: string;
+  runKey: string;
+  mode: string;
+  state: string;
+  reconciliationState: string;
+  sourceObservedOn: string | null;
+  sourceAgeHours: number | null;
+  commitSha: string;
+  workerVersion: string;
+  schemaVersion: string;
+  currentPhase: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  failedAt: string | null;
+  selectedCount: number;
+  mappedCount: number;
+  eligibleCount: number;
+  snapshotCount: number;
+  quarantinedCount: number;
+  excludedCount: number;
+  delayedCount: number;
+  suppressedCount: number;
+  requiredPhaseCount: number;
+  succeededPhaseCount: number;
+  errorClassification: string | null;
+  error: string | null;
+  findings: string[];
+};
+
+export type FounderPricingPhase = {
+  name: string;
+  label: string;
+  attempt: number;
+  state: string;
+  startedAt: string;
+  completedAt: string | null;
+  inputCount: number;
+  outputCount: number;
+  reconciledCount: number;
+  excludedCount: number;
+  quarantinedCount: number;
+  errorClassification: string | null;
+};
+
+export type FounderPricingCoverage = typeof LAST_VERIFIED_COVERAGE & {
+  thresholdStatus: "passed" | "blocked";
+};
+
+export type FounderPricingTracePrinting = {
+  cardPrintingId: string;
+  printingGvId: string;
+  finish: string;
+  marketPrice: number;
+  currency: string;
+  sourceProductId: number;
+  sourceSubtypeName: string;
+  sourceObservedOn: string;
+  observedAt: string;
+  sourceRowFingerprint: string;
+  sourceArtifactFingerprint: string;
+  mappingMethod: string | null;
+  mappingConfidence: number | null;
+  languageResult: string;
+  finishResult: string;
+  qualificationStatus: string;
+  publicationLane: string;
+  reasonCodes: string[];
+  publicationSnapshotId: string;
+  provenanceId: string;
+  publicationSetId: string;
+  activePointer: boolean;
+  governedRpcAvailable: boolean;
+};
+
+export type FounderPricingTrace = {
+  requestedGvId: string;
+  foundParent: boolean;
+  status: "available" | "unavailable" | "invalid";
+  cardPrintId: string | null;
+  canonicalName: string | null;
+  activePublicationSetId: string | null;
+  printings: FounderPricingTracePrinting[];
+  deployedApiVisibility: PricingVisibilityStatus;
+  webVisibility: PricingVisibilityStatus;
+  flutterVisibility: PricingVisibilityStatus;
+  unavailableReason: string | null;
+};
+
+export type FounderGovernedPricingPlatformSummary = {
+  generatedAt: string;
+  overall: {
+    status: PricingVisibilityStatus;
+    label: string;
+    detail: string;
+  };
+  system: {
+    activePublicationSetId: string | null;
+    activeRunId: string | null;
+    publicationMode: string;
+    publicationSize: number;
+    readModelSize: number;
+    governedRpcCompatibleSize: number;
+    activatedAt: string | null;
+    lastSuccessfulRunAt: string | null;
+    nextExpectedCycleAt: string | null;
+    sourceAgeHours: number | null;
+    rollbackAvailable: boolean;
+  };
+  visibilityLadder: PricingVisibilityStage[];
+  canary: PricingCanaryState;
+  activeRun: FounderPricingRun | null;
+  latestRun: FounderPricingRun | null;
+  recentRuns: FounderPricingRun[];
+  phases: FounderPricingPhase[];
+  coverage: FounderPricingCoverage;
+  deployments: PricingDeploymentState[];
+  releaseGates: PricingReleaseGate[];
+  alerts: {
+    totalCount: number;
+    recent: OperationsAlertRow[];
+  };
+  pendingMigrations: Array<{ version: string; name: string }>;
+  errors: string[];
+};
+
+const PENDING_MIGRATIONS = [
+  {
+    version: "20260728130000",
+    name: "TCGPlayer market read-model contract completion",
+  },
+  {
+    version: "20260728133000",
+    name: "Vault exact market pricing targets",
+  },
+] as const;
+
+const ACCESS_PROOF_AT = "2026-07-28T16:57:46.934Z";
+const RUN_STALE_HOURS = 2;
+
+function numberValue(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (
+    typeof value === "string" &&
+    value.trim() &&
+    Number.isFinite(Number(value))
+  ) {
+    return Number(value);
+  }
+  return 0;
+}
+
+function parseTime(value: string | null | undefined) {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function ageHours(value: string | null | undefined, nowIso: string) {
+  const timestamp = parseTime(value);
+  const now = parseTime(nowIso);
+  if (timestamp === null || now === null) return null;
+  return Math.max(0, (now - timestamp) / (60 * 60 * 1000));
+}
+
+function shortFingerprint(value: string | null | undefined) {
+  if (!value) return "-";
+  return value.length <= 12 ? value : `${value.slice(0, 12)}...`;
+}
+
+function envBoolean(name: string) {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  return null;
+}
+
+function envText(name: string) {
+  return process.env[name]?.trim() || null;
+}
+
+function phaseLabel(name: string) {
+  const labels: Record<string, string> = {
+    prepare_variant_assignments: "Prepare exact printing assignments",
+    stage_candidates: "Stage source candidates",
+    qualify: "Qualify exact prices",
+    build_publication: "Build publication snapshots",
+    reconcile: "Reconcile counts and provenance",
+    activate: "Activate publication set",
+  };
+  return labels[name] ?? name.replace(/_/g, " ");
+}
+
+function mapRun(row: PipelineRunRow, nowIso: string): FounderPricingRun {
+  const findings: string[] = [];
+  const runAge = ageHours(row.started_at ?? row.created_at, nowIso);
+  if (row.state === "running" && (runAge ?? 0) > RUN_STALE_HOURS) {
+    findings.push(`Run has remained in running state for ${(runAge ?? 0).toFixed(1)} hours.`);
+  }
+  if (row.reconciliation_state === "mismatch") {
+    findings.push("Run reconciliation contains mismatches.");
+  }
+  if (row.error_classification || row.error) {
+    findings.push(
+      row.error_classification ?? row.error ?? "Run recorded an error.",
+    );
+  }
+  if (row.succeeded_phase_count < row.required_phase_count) {
+    findings.push(
+      `${row.succeeded_phase_count} of ${row.required_phase_count} required phases succeeded.`,
+    );
+  }
+
+  return {
+    id: row.id,
+    runKey: row.run_key,
+    mode: row.run_mode,
+    state: row.state,
+    reconciliationState: row.reconciliation_state,
+    sourceObservedOn: row.source_observed_on,
+    sourceAgeHours: ageHours(row.source_observed_on, nowIso),
+    commitSha: row.git_commit_sha,
+    workerVersion: row.worker_version,
+    schemaVersion: row.schema_version,
+    currentPhase: row.current_phase,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    failedAt: row.failed_at,
+    selectedCount: numberValue(row.selected_count),
+    mappedCount: numberValue(row.mapped_count),
+    eligibleCount: numberValue(row.eligible_count),
+    snapshotCount: numberValue(row.snapshot_count),
+    quarantinedCount: numberValue(row.quarantined_count),
+    excludedCount: numberValue(row.excluded_count),
+    delayedCount: numberValue(row.delayed_count),
+    suppressedCount: numberValue(row.suppressed_count),
+    requiredPhaseCount: numberValue(row.required_phase_count),
+    succeededPhaseCount: numberValue(row.succeeded_phase_count),
+    errorClassification: row.error_classification,
+    error: row.error,
+    findings,
+  };
+}
+
+function deploymentInputs() {
+  const vercelCommit = envText("VERCEL_GIT_COMMIT_SHA");
+  const vercelDeployment = envText("VERCEL_DEPLOYMENT_ID");
+  const vercelVerifiedAt = envText("FOUNDER_PRICING_WEB_VERIFIED_AT");
+  const apiVerifiedAt = envText("FOUNDER_PRICING_API_VERIFIED_AT");
+  const flutterVerifiedAt = envText("FOUNDER_PRICING_FLUTTER_VERIFIED_AT");
+
+  return {
+    web: {
+      deployed: vercelCommit ? true : envBoolean("FOUNDER_PRICING_WEB_DEPLOYED"),
+      verified: envBoolean("FOUNDER_PRICING_WEB_RENDER_VERIFIED"),
+      runningVersion: vercelCommit ?? vercelDeployment,
+      verifiedAt: vercelVerifiedAt,
+    },
+    api: {
+      deployed: vercelCommit ? true : envBoolean("FOUNDER_PRICING_API_DEPLOYED"),
+      verified: envBoolean("FOUNDER_PRICING_API_VERIFIED"),
+      runningVersion: vercelCommit ?? vercelDeployment,
+      verifiedAt: apiVerifiedAt,
+    },
+    flutter: {
+      deployed: envBoolean("FOUNDER_PRICING_FLUTTER_DEPLOYED"),
+      verified: envBoolean("FOUNDER_PRICING_FLUTTER_RENDER_VERIFIED"),
+      runningVersion: envText("FOUNDER_PRICING_FLUTTER_BUILD"),
+      verifiedAt: flutterVerifiedAt,
+    },
+  };
+}
+
+async function countRows(
+  queryPromise: PromiseLike<{
+    count: number | null;
+    error: { message: string } | null;
+  }>,
+  label: string,
+  errors: string[],
+) {
+  const { count, error } = await queryPromise;
+  if (error) {
+    errors.push(`${label}: ${error.message}`);
+    return 0;
+  }
+  return count ?? 0;
+}
+
+async function fetchRecentRuns(
+  admin: AdminClient,
+  errors: string[],
+): Promise<PipelineRunRow[]> {
+  const { data, error } = await admin
+    .from("market_price_pipeline_runs")
+    .select(
+      "id,run_key,pipeline_version,policy_version,run_mode,source_name,source_observed_on,source_sync_run_id,source_artifact_id,source_artifact_hash,source_marker,state,current_phase,reconciliation_state,selected_count,mapped_count,excluded_count,quarantined_count,delayed_count,suppressed_count,eligible_count,snapshot_count,required_phase_count,succeeded_phase_count,git_commit_sha,worker_version,schema_version,started_at,completed_at,failed_at,error_classification,error,reconciliation,created_at,updated_at",
+    )
+    .order("created_at", { ascending: false })
+    .limit(8);
+  if (error) {
+    errors.push(`Recent pricing runs: ${error.message}`);
+    return [];
+  }
+  return (data ?? []) as PipelineRunRow[];
+}
+
+async function fetchAlerts(admin: AdminClient, errors: string[]) {
+  const { data, error, count } = await admin
+    .from("operations_notification_events")
+    .select(
+      "id,notification_id,event_type,severity,source_host,source_unit,recipient_count,received_at",
+      { count: "exact" },
+    )
+    .order("received_at", { ascending: false })
+    .limit(8);
+  if (error) {
+    errors.push(`Pricing operations alerts: ${error.message}`);
+    return { totalCount: 0, recent: [] };
+  }
+  return {
+    totalCount: count ?? 0,
+    recent: (data ?? []) as OperationsAlertRow[],
+  };
+}
+
+export async function getFounderGovernedPricingPlatformSummary(
+  admin: AdminClient,
+): Promise<FounderGovernedPricingPlatformSummary> {
+  const generatedAt = new Date().toISOString();
+  const errors: string[] = [];
+  const deploymentsInput = deploymentInputs();
+
+  const [recentRunRows, alerts] = await Promise.all([
+    fetchRecentRuns(admin, errors),
+    fetchAlerts(admin, errors),
+  ]);
+
+  const currentResult = await admin
+    .from("market_price_current_publication")
+    .select(
+      "publication_set_id,run_id,previous_publication_set_id,activated_at,updated_at",
+    )
+    .eq("singleton", true)
+    .maybeSingle();
+  if (currentResult.error) {
+    errors.push(`Active publication pointer: ${currentResult.error.message}`);
+  }
+  const current = (currentResult.data as CurrentPublicationRow | null) ?? null;
+
+  let activeSet: PublicationSetRow | null = null;
+  let activeRunRow: PipelineRunRow | null = null;
+  let sourceSync: SourceSyncRow | null = null;
+  let phases: FounderPricingPhase[] = [];
+  let publishedCount = 0;
+  let positiveCount = 0;
+  let staleCount = 0;
+  let brokenProvenanceCount = 0;
+  let readModelCount = 0;
+  let governedRpcCompatibleCount = 0;
+  let sourceAge: number | null = null;
+
+  if (current) {
+    const [setResult, runResult] = await Promise.all([
+      admin
+        .from("market_price_publication_sets")
+        .select(
+          "id,run_id,run_key,publication_state,expected_snapshot_count,previous_publication_set_id,published_at,superseded_at,rolled_back_at,rollback_reason,reconciliation,created_at,updated_at",
+        )
+        .eq("id", current.publication_set_id)
+        .maybeSingle(),
+      admin
+        .from("market_price_pipeline_runs")
+        .select(
+          "id,run_key,pipeline_version,policy_version,run_mode,source_name,source_observed_on,source_sync_run_id,source_artifact_id,source_artifact_hash,source_marker,state,current_phase,reconciliation_state,selected_count,mapped_count,excluded_count,quarantined_count,delayed_count,suppressed_count,eligible_count,snapshot_count,required_phase_count,succeeded_phase_count,git_commit_sha,worker_version,schema_version,started_at,completed_at,failed_at,error_classification,error,reconciliation,created_at,updated_at",
+        )
+        .eq("id", current.run_id)
+        .maybeSingle(),
+    ]);
+    if (setResult.error) {
+      errors.push(`Active publication set: ${setResult.error.message}`);
+    }
+    if (runResult.error) {
+      errors.push(`Active publication run: ${runResult.error.message}`);
+    }
+    activeSet = (setResult.data as PublicationSetRow | null) ?? null;
+    activeRunRow = (runResult.data as PipelineRunRow | null) ?? null;
+
+    const staleCutoff = new Date(
+      Date.parse(generatedAt) -
+        PRICING_SOURCE_FRESHNESS_HOURS * 60 * 60 * 1000,
+    ).toISOString();
+    const [
+      published,
+      positive,
+      stale,
+      broken,
+      readModel,
+      oldestSnapshotResult,
+      phaseResult,
+      activeSnapshotIdentityResult,
+    ] = await Promise.all([
+      countRows(
+        admin
+          .from("market_price_publication_snapshots")
+          .select("id", { count: "exact", head: true })
+          .eq("publication_set_id", current.publication_set_id),
+        "Published snapshot count",
+        errors,
+      ),
+      countRows(
+        admin
+          .from("market_price_publication_snapshots")
+          .select("id", { count: "exact", head: true })
+          .eq("publication_set_id", current.publication_set_id)
+          .gt("market_price", 0),
+        "Positive snapshot count",
+        errors,
+      ),
+      countRows(
+        admin
+          .from("market_price_publication_snapshots")
+          .select("id", { count: "exact", head: true })
+          .eq("publication_set_id", current.publication_set_id)
+          .lt("source_sync_finished_at", staleCutoff),
+        "Stale snapshot count",
+        errors,
+      ),
+      countRows(
+        admin
+          .from("market_price_publication_snapshots")
+          .select("id", { count: "exact", head: true })
+          .eq("publication_set_id", current.publication_set_id)
+          .or(
+            "provenance_id.is.null,source_row_hash.is.null,source_artifact_hash.is.null,source_observation_id.is.null",
+          ),
+        "Broken provenance count",
+        errors,
+      ),
+      countRows(
+        admin
+          .from("v_market_price_current_v1")
+          .select("card_printing_id", { count: "exact", head: true }),
+        "Governed read-model count",
+        errors,
+      ),
+      admin
+        .from("market_price_publication_snapshots")
+        .select("source_sync_finished_at")
+        .eq("publication_set_id", current.publication_set_id)
+        .order("source_sync_finished_at", { ascending: true })
+        .limit(1)
+        .maybeSingle(),
+      admin
+        .from("market_price_pipeline_phase_attempts")
+        .select(
+          "id,phase_name,attempt,state,started_at,completed_at,input_count,output_count,reconciled_count,excluded_count,quarantined_count,error_classification,error,created_at",
+        )
+        .eq("run_id", current.run_id)
+        .order("created_at", { ascending: false }),
+      admin
+        .from("market_price_publication_snapshots")
+        .select("card_print_id,card_printing_id")
+        .eq("publication_set_id", current.publication_set_id),
+    ]);
+    publishedCount = published;
+    positiveCount = positive;
+    staleCount = stale;
+    brokenProvenanceCount = broken;
+    readModelCount = readModel;
+
+    if (activeSnapshotIdentityResult.error) {
+      errors.push(
+        `Active snapshot identities: ${activeSnapshotIdentityResult.error.message}`,
+      );
+    } else {
+      const activeSnapshotIdentities = (
+        (activeSnapshotIdentityResult.data ?? []) as ActiveSnapshotIdentityRow[]
+      );
+      const governedRows = await getMarketPricingReadModelV1(admin, {
+        cardPrintIds: Array.from(
+          new Set(activeSnapshotIdentities.map((row) => row.card_print_id)),
+        ),
+        cardPrintingIds: Array.from(
+          new Set(activeSnapshotIdentities.map((row) => row.card_printing_id)),
+        ),
+      });
+      governedRpcCompatibleCount = new Set(
+        governedRows
+          .filter((row) => row.pricing_scope === "card_printing")
+          .map((row) => row.card_printing_id)
+          .filter((value): value is string => Boolean(value)),
+      ).size;
+    }
+
+    if (oldestSnapshotResult.error) {
+      errors.push(
+        `Oldest active source observation: ${oldestSnapshotResult.error.message}`,
+      );
+    } else {
+      sourceAge = ageHours(
+        (oldestSnapshotResult.data as {
+          source_sync_finished_at?: string;
+        } | null)?.source_sync_finished_at,
+        generatedAt,
+      );
+    }
+
+    if (phaseResult.error) {
+      errors.push(`Active run phases: ${phaseResult.error.message}`);
+    } else {
+      const normalizedAttempts = (
+        (phaseResult.data ?? []) as PhaseAttemptRow[]
+      ).map(
+        (row): DurablePhaseAttempt => ({
+          id: row.id,
+          phaseName: row.phase_name,
+          attempt: numberValue(row.attempt),
+          state: row.state,
+          createdAt: row.created_at,
+          startedAt: row.started_at,
+          completedAt: row.completed_at,
+          inputCount: numberValue(row.input_count),
+          outputCount: numberValue(row.output_count),
+          reconciledCount: numberValue(row.reconciled_count),
+          excludedCount: numberValue(row.excluded_count),
+          quarantinedCount: numberValue(row.quarantined_count),
+          errorClassification: row.error_classification,
+        }),
+      );
+      phases = latestDurablePhaseAttempts(normalizedAttempts).map((row) => ({
+        name: row.phaseName,
+        label: phaseLabel(row.phaseName),
+        attempt: row.attempt,
+        state: row.state,
+        startedAt: row.startedAt,
+        completedAt: row.completedAt,
+        inputCount: row.inputCount,
+        outputCount: row.outputCount,
+        reconciledCount: row.reconciledCount,
+        excludedCount: row.excludedCount,
+        quarantinedCount: row.quarantinedCount,
+        errorClassification: row.errorClassification,
+      }));
+    }
+
+    if (activeRunRow?.source_sync_run_id) {
+      const sourceResult = await admin
+        .from("tcgcsv_source_sync_runs")
+        .select(
+          "id,run_key,status,source_marker,observed_on,request_count,category_count,group_count,product_count,price_row_count,failed_count,git_commit_sha,started_at,finished_at",
+        )
+        .eq("id", activeRunRow.source_sync_run_id)
+        .maybeSingle();
+      if (sourceResult.error) {
+        errors.push(`Source warehouse run: ${sourceResult.error.message}`);
+      } else {
+        sourceSync = (sourceResult.data as SourceSyncRow | null) ?? null;
+      }
+    }
+  }
+
+  const recentRuns = recentRunRows.map((row) => mapRun(row, generatedAt));
+  const activeRun = activeRunRow
+    ? mapRun(activeRunRow, generatedAt)
+    : null;
+  const latestRun = recentRuns[0] ?? null;
+  const lastSuccessfulRun =
+    recentRuns.find(
+      (run) =>
+        ["verified", "published", "shadow_verified"].includes(run.state) &&
+        run.reconciliationState === "reconciled",
+    ) ?? activeRun;
+
+  const canary = buildCanaryState({
+    nowIso: generatedAt,
+    activeMode: activeRun?.mode ?? null,
+    activatedAt: current?.activated_at ?? null,
+    exactPriceCount: publishedCount,
+    positivePriceCount: positiveCount,
+    staleCount,
+    brokenProvenanceCount,
+    readModelCount,
+    rollbackAvailable: Boolean(current?.previous_publication_set_id),
+    authenticatedAccessVerified: true,
+    anonymousDeniedVerified: true,
+    accessVerifiedAt: ACCESS_PROOF_AT,
+    accessVerificationSource:
+      "Production role and anonymous-denial readback from the frozen canary audit.",
+    webRenderingVerified: deploymentsInput.web.verified === true,
+    flutterRenderingVerified: deploymentsInput.flutter.verified === true,
+  });
+
+  const apiStatus = deploymentVerificationStatus(deploymentsInput.api);
+  const webStatus = deploymentVerificationStatus(deploymentsInput.web);
+  const flutterStatus = deploymentVerificationStatus(
+    deploymentsInput.flutter,
+  );
+  const publicationHealthy =
+    activeSet?.publication_state === "published" &&
+    publishedCount > 0 &&
+    publishedCount === positiveCount &&
+    publishedCount === readModelCount &&
+    staleCount === 0 &&
+    brokenProvenanceCount === 0;
+  const latestRunWarning = Boolean(
+    latestRun &&
+      latestRun.id !== activeRun?.id &&
+      (latestRun.findings.length > 0 ||
+        latestRun.state === "running" ||
+        latestRun.state === "failed"),
+  );
+
+  const overall = classifyPricingPlatformOverall({
+    activePointerReadable: !errors.some((error) =>
+      error.startsWith("Active publication pointer"),
+    ),
+    activePublicationPresent: Boolean(current && activeSet && activeRun),
+    publicationHealthy,
+    deployedClientsVerified:
+      apiStatus === "healthy" &&
+      webStatus === "healthy" &&
+      flutterStatus === "healthy",
+    latestRunNeedsAttention: latestRunWarning,
+  });
+
+  const sourceHealthy =
+    Boolean(sourceSync) &&
+    ["completed", "skipped_no_change"].includes(sourceSync?.status ?? "") &&
+    numberValue(sourceSync?.failed_count) === 0;
+  const visibilityLadder: PricingVisibilityStage[] = [
+    {
+      id: "source",
+      label: "Source warehouse",
+      status: sourceHealthy
+        ? (sourceAge ?? Infinity) <= PRICING_SOURCE_FRESHNESS_HOURS
+          ? "healthy"
+          : "warning"
+        : "not_verified",
+      detail: sourceSync
+        ? `${numberValue(sourceSync.price_row_count).toLocaleString("en-US")} source price rows; ${sourceSync.status}.`
+        : "The source run could not be verified.",
+      verificationSource: "Live tcgcsv_source_sync_runs row",
+      verifiedAt: sourceSync?.finished_at ?? null,
+    },
+    {
+      id: "mapped",
+      label: "Mapped",
+      status:
+        activeRun && activeRun.mappedCount === activeRun.selectedCount
+          ? "healthy"
+          : activeRun?.mappedCount
+            ? "warning"
+            : "blocked",
+      detail: activeRun
+        ? `${activeRun.mappedCount.toLocaleString("en-US")} of ${activeRun.selectedCount.toLocaleString("en-US")} selected rows mapped.`
+        : "No active run is available.",
+      verificationSource: "Live active pipeline run",
+      verifiedAt: activeRun?.completedAt ?? null,
+    },
+    {
+      id: "qualified",
+      label: "Qualified",
+      status:
+        activeRun && activeRun.eligibleCount === activeRun.snapshotCount
+          ? "healthy"
+          : activeRun?.eligibleCount
+            ? "warning"
+            : "blocked",
+      detail: activeRun
+        ? `${activeRun.eligibleCount.toLocaleString("en-US")} eligible exact prices.`
+        : "No qualification result is available.",
+      verificationSource: "Live active pipeline run",
+      verifiedAt: activeRun?.completedAt ?? null,
+    },
+    {
+      id: "published",
+      label: "Published in database",
+      status: publicationHealthy ? "healthy" : "blocked",
+      detail: `${publishedCount.toLocaleString("en-US")} exact publication snapshots are active.`,
+      verificationSource: "Live active pointer and publication snapshots",
+      verifiedAt: current?.activated_at ?? null,
+    },
+    {
+      id: "rpc",
+      label: "Available through governed RPC",
+      status:
+        governedRpcCompatibleCount > 0 &&
+        governedRpcCompatibleCount === publishedCount
+          ? "healthy"
+          : governedRpcCompatibleCount > 0
+            ? "warning"
+            : "blocked",
+      detail:
+        governedRpcCompatibleCount === publishedCount
+          ? `${governedRpcCompatibleCount.toLocaleString("en-US")} exact rows satisfy the governed shared read contract.`
+          : `${governedRpcCompatibleCount.toLocaleString("en-US")} of ${publishedCount.toLocaleString("en-US")} active exact rows satisfy the governed shared read contract. The frozen read-model completion migration remains pending.`,
+      verificationSource:
+        "Live get_market_pricing_read_model_v1 response mapped through the production web contract",
+      verifiedAt: generatedAt,
+    },
+    {
+      id: "api",
+      label: "Available through deployed API",
+      status: apiStatus,
+      detail:
+        apiStatus === "healthy"
+          ? "A deployed API response has been explicitly verified."
+          : "No explicit deployed API response verification is available.",
+      verificationSource:
+        deploymentsInput.api.verified === null
+          ? "Deployment metadata unavailable"
+          : "Explicit API verification metadata",
+      verifiedAt: deploymentsInput.api.verifiedAt,
+    },
+    {
+      id: "web",
+      label: "Visible on web",
+      status: webStatus,
+      detail:
+        webStatus === "healthy"
+          ? "A production web route has been verified rendering TCGPlayer Market."
+          : "Production web rendering has not been explicitly verified.",
+      verificationSource:
+        deploymentsInput.web.verified === null
+          ? "Deployment metadata unavailable"
+          : "Explicit web rendering verification metadata",
+      verifiedAt: deploymentsInput.web.verifiedAt,
+    },
+    {
+      id: "flutter",
+      label: "Visible in Flutter",
+      status: flutterStatus,
+      detail:
+        flutterStatus === "healthy"
+          ? "A deployed Flutter build has been verified rendering TCGPlayer Market."
+          : "Flutter/TestFlight rendering has not been explicitly verified.",
+      verificationSource:
+        deploymentsInput.flutter.verified === null
+          ? "App Store Connect metadata unavailable"
+          : "Explicit Flutter rendering verification metadata",
+      verifiedAt: deploymentsInput.flutter.verifiedAt,
+    },
+    {
+      id: "anonymous",
+      label: "Anonymous and public visibility",
+      status: "blocked",
+      detail:
+        "Anonymous pricing remains intentionally denied pending licensing and display authority.",
+      verificationSource: "Frozen Production V1 access contract",
+      verifiedAt: ACCESS_PROOF_AT,
+    },
+  ];
+
+  const deployments: PricingDeploymentState[] = [
+    {
+      component: "Production database schema",
+      runningVersion: activeRun?.schemaVersion ?? null,
+      releaseVersion:
+        "Current schema plus migrations 20260728130000 and 20260728133000",
+      status: activeRun ? "warning" : "unavailable",
+      verificationSource: activeRun
+        ? "Live pipeline run schema version; migration ledger unavailable to web runtime"
+        : "No active run",
+      verifiedAt: generatedAt,
+    },
+    {
+      component: "Pricing scheduler",
+      runningVersion: activeRun?.commitSha ?? null,
+      releaseVersion: PRICING_RELEASE_BASELINE_SHA,
+      status: activeRun
+        ? activeRun.commitSha === PRICING_RELEASE_BASELINE_SHA
+          ? "healthy"
+          : "warning"
+        : "not_verified",
+      verificationSource: activeRun
+        ? "Live active pipeline run commit"
+        : "Scheduler host unavailable",
+      verifiedAt: activeRun?.completedAt ?? null,
+    },
+    {
+      component: "Governed pricing API",
+      runningVersion: deploymentsInput.api.runningVersion,
+      releaseVersion: PRICING_RELEASE_BASELINE_SHA,
+      status: apiStatus,
+      verificationSource:
+        deploymentsInput.api.runningVersion || deploymentsInput.api.verifiedAt
+          ? "Explicit Vercel/API deployment metadata"
+          : "Deployment provider metadata unavailable",
+      verifiedAt: deploymentsInput.api.verifiedAt,
+    },
+    {
+      component: "Production web client",
+      runningVersion: deploymentsInput.web.runningVersion,
+      releaseVersion: PRICING_RELEASE_BASELINE_SHA,
+      status: webStatus,
+      verificationSource:
+        deploymentsInput.web.runningVersion || deploymentsInput.web.verifiedAt
+          ? "Explicit Vercel deployment metadata"
+          : "Deployment provider metadata unavailable",
+      verifiedAt: deploymentsInput.web.verifiedAt,
+    },
+    {
+      component: "Flutter and TestFlight",
+      runningVersion: deploymentsInput.flutter.runningVersion,
+      releaseVersion: `1.0.0+21 @ ${PRICING_RELEASE_BASELINE_SHA}`,
+      status: flutterStatus,
+      verificationSource:
+        deploymentsInput.flutter.runningVersion ||
+        deploymentsInput.flutter.verifiedAt
+          ? "Explicit App Store deployment metadata"
+          : "App Store Connect metadata unavailable",
+      verifiedAt: deploymentsInput.flutter.verifiedAt,
+    },
+    {
+      component: "Source branch",
+      runningVersion:
+        envText("VERCEL_GIT_COMMIT_REF") ??
+        envText("FOUNDER_PRICING_RUNNING_BRANCH"),
+      releaseVersion: `pricing/mee-productization-v1 @ ${PRICING_RELEASE_BASELINE_SHA}`,
+      status:
+        envText("VERCEL_GIT_COMMIT_REF") ||
+        envText("FOUNDER_PRICING_RUNNING_BRANCH")
+          ? "warning"
+          : "not_verified",
+      verificationSource:
+        "Runtime branch metadata; branch identity alone is not deployment proof",
+      verifiedAt: generatedAt,
+    },
+  ];
+
+  const verifiedCycleDates = new Set(
+    recentRuns
+      .filter(
+        (run) =>
+          ["canary", "production"].includes(run.mode) &&
+          run.state === "verified" &&
+          run.reconciliationState === "reconciled" &&
+          run.completedAt,
+      )
+      .map((run) => run.completedAt!.slice(0, 10)),
+  );
+  const fullActivation =
+    activeRun?.mode === "production" &&
+    publishedCount >= LAST_VERIFIED_COVERAGE.numerator;
+  const releaseGates = buildReleaseGates({
+    canary,
+    pendingMigrationCount: PENDING_MIGRATIONS.length,
+    webRenderingVerified: deploymentsInput.web.verified === true,
+    flutterRenderingVerified: deploymentsInput.flutter.verified === true,
+    fullActivation,
+    unattendedCycleCount: verifiedCycleDates.size,
+    provenanceComplete:
+      publishedCount > 0 && brokenProvenanceCount === 0,
+    coveragePercentage: LAST_VERIFIED_COVERAGE.percentage,
+    coverageTargetPercentage: LAST_VERIFIED_COVERAGE.targetPercentage,
+    unclassifiedGapRows: LAST_VERIFIED_COVERAGE.unclassifiedGapRows,
+  });
+
+  return {
+    generatedAt,
+    overall: {
+      status: overall.status,
+      label: overall.label,
+      detail: publicationHealthy
+        ? `${publishedCount.toLocaleString("en-US")} exact prices are published in the production database. Deployed client rendering remains a separate gate.`
+        : "The active publication could not be fully reconciled from live reads.",
+    },
+    system: {
+      activePublicationSetId: current?.publication_set_id ?? null,
+      activeRunId: current?.run_id ?? null,
+      publicationMode: activeRun?.mode ?? "none",
+      publicationSize: publishedCount,
+      readModelSize: readModelCount,
+      governedRpcCompatibleSize: governedRpcCompatibleCount,
+      activatedAt: current?.activated_at ?? null,
+      lastSuccessfulRunAt: lastSuccessfulRun?.completedAt ?? null,
+      nextExpectedCycleAt: nextExpectedPricingCycle(generatedAt),
+      sourceAgeHours: sourceAge,
+      rollbackAvailable: Boolean(current?.previous_publication_set_id),
+    },
+    visibilityLadder,
+    canary,
+    activeRun,
+    latestRun,
+    recentRuns,
+    phases,
+    coverage: {
+      ...LAST_VERIFIED_COVERAGE,
+      thresholdStatus:
+        LAST_VERIFIED_COVERAGE.percentage >=
+        LAST_VERIFIED_COVERAGE.targetPercentage
+          ? "passed"
+          : "blocked",
+    },
+    deployments,
+    releaseGates,
+    alerts,
+    pendingMigrations: PENDING_MIGRATIONS.map((migration) => ({ ...migration })),
+    errors,
+  };
+}
+
+export async function getFounderPricingTraceByGvId(
+  admin: AdminClient,
+  rawGvId: string,
+  summary: FounderGovernedPricingPlatformSummary,
+): Promise<FounderPricingTrace> {
+  const requestedGvId = rawGvId.trim().toUpperCase();
+  const apiVisibility =
+    summary.visibilityLadder.find((stage) => stage.id === "api")?.status ??
+    "not_verified";
+  const webVisibility =
+    summary.visibilityLadder.find((stage) => stage.id === "web")?.status ??
+    "not_verified";
+  const flutterVisibility =
+    summary.visibilityLadder.find((stage) => stage.id === "flutter")?.status ??
+    "not_verified";
+
+  if (!/^GV-[A-Z0-9-]+$/.test(requestedGvId)) {
+    return {
+      requestedGvId,
+      foundParent: false,
+      status: "invalid",
+      cardPrintId: null,
+      canonicalName: null,
+      activePublicationSetId: null,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: "Enter a canonical parent GV-ID such as GV-PK-ASC-276.",
+    };
+  }
+
+  const { data: parentData, error: parentError } = await admin
+    .from("card_prints")
+    .select("id,gv_id,name")
+    .eq("gv_id", requestedGvId)
+    .maybeSingle();
+  if (parentError) {
+    return {
+      requestedGvId,
+      foundParent: false,
+      status: "unavailable",
+      cardPrintId: null,
+      canonicalName: null,
+      activePublicationSetId: null,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: `Canonical lookup failed: ${parentError.message}`,
+    };
+  }
+  const parent = parentData as {
+    id: string;
+    gv_id: string;
+    name: string | null;
+  } | null;
+  if (!parent) {
+    return {
+      requestedGvId,
+      foundParent: false,
+      status: "unavailable",
+      cardPrintId: null,
+      canonicalName: null,
+      activePublicationSetId: null,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: "No canonical parent card exists for this GV-ID.",
+    };
+  }
+
+  const activePublicationSetId =
+    summary.visibilityLadder.find((stage) => stage.id === "published")
+      ?.status === "healthy"
+      ? summary.system.activePublicationSetId
+      : null;
+
+  if (!activePublicationSetId) {
+    return {
+      requestedGvId,
+      foundParent: true,
+      status: "unavailable",
+      cardPrintId: parent.id,
+      canonicalName: parent.name,
+      activePublicationSetId: null,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: "No healthy active publication pointer is available.",
+    };
+  }
+
+  const { data: snapshotData, error: snapshotError } = await admin
+    .from("market_price_publication_snapshots")
+    .select(
+      "id,provenance_id,publication_set_id,run_id,qualification_decision_id,source_observation_id,source_artifact_hash,source_price_row_identity,source_row_hash,source_product_id,source_subtype_name,source_observed_on,source_sync_finished_at,card_print_id,card_printing_id,gv_id,printing_gv_id,finish_key,currency,market_price,observed_at,published_at,freshness_state,publication_state",
+    )
+    .eq("publication_set_id", activePublicationSetId)
+    .eq("card_print_id", parent.id)
+    .order("printing_gv_id");
+  if (snapshotError) {
+    return {
+      requestedGvId,
+      foundParent: true,
+      status: "unavailable",
+      cardPrintId: parent.id,
+      canonicalName: parent.name,
+      activePublicationSetId,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: `Active snapshot lookup failed: ${snapshotError.message}`,
+    };
+  }
+
+  const snapshots = (snapshotData ?? []) as TraceSnapshotRow[];
+  if (snapshots.length === 0) {
+    const { data: decisionData } = await admin
+      .from("market_price_qualification_decisions")
+      .select("decision,reason_codes,evaluated_at")
+      .eq("card_print_id", parent.id)
+      .order("evaluated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const decisionReason = (
+      decisionData as {
+        decision?: string;
+        reason_codes?: string[];
+      } | null
+    )?.reason_codes?.join(", ");
+    return {
+      requestedGvId,
+      foundParent: true,
+      status: "unavailable",
+      cardPrintId: parent.id,
+      canonicalName: parent.name,
+      activePublicationSetId,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: decisionReason
+        ? `No active exact price. Latest qualification reasons: ${decisionReason}.`
+        : "No exact printing for this parent is present in the active publication set.",
+    };
+  }
+
+  const decisionIds = snapshots.map(
+    (snapshot) => snapshot.qualification_decision_id,
+  );
+  const { data: decisionData, error: decisionError } = await admin
+    .from("market_price_qualification_decisions")
+    .select(
+      "id,mapping_method,mapping_confidence,language_result,finish_result,decision,eligible,publication_lane,reason_codes,source_integrity_result,duplicate_product_result,freshness_result,variant_assignment_status,evaluated_at",
+    )
+    .in("id", decisionIds);
+  if (decisionError) {
+    return {
+      requestedGvId,
+      foundParent: true,
+      status: "unavailable",
+      cardPrintId: parent.id,
+      canonicalName: parent.name,
+      activePublicationSetId,
+      printings: [],
+      deployedApiVisibility: apiVisibility,
+      webVisibility,
+      flutterVisibility,
+      unavailableReason: `Qualification lookup failed: ${decisionError.message}`,
+    };
+  }
+  const decisions = new Map(
+    ((decisionData ?? []) as TraceDecisionRow[]).map((decision) => [
+      decision.id,
+      decision,
+    ]),
+  );
+  const rpcRows = await getMarketPricingReadModelV1(admin, {
+    cardPrintIds: [parent.id],
+    cardPrintingIds: snapshots.map((snapshot) => snapshot.card_printing_id),
+  });
+  const rpcPrintingIds = new Set(
+    rpcRows
+      .filter((row) => row.pricing_scope === "card_printing")
+      .map((row) => row.card_printing_id)
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  return {
+    requestedGvId,
+    foundParent: true,
+    status: "available",
+    cardPrintId: parent.id,
+    canonicalName: parent.name,
+    activePublicationSetId,
+    printings: snapshots.map((snapshot) => {
+      const decision = decisions.get(snapshot.qualification_decision_id);
+      return {
+        cardPrintingId: snapshot.card_printing_id,
+        printingGvId: snapshot.printing_gv_id,
+        finish: snapshot.finish_key,
+        marketPrice: numberValue(snapshot.market_price),
+        currency: snapshot.currency,
+        sourceProductId: numberValue(snapshot.source_product_id),
+        sourceSubtypeName: snapshot.source_subtype_name,
+        sourceObservedOn: snapshot.source_observed_on,
+        observedAt: snapshot.observed_at,
+        sourceRowFingerprint: shortFingerprint(snapshot.source_row_hash),
+        sourceArtifactFingerprint: shortFingerprint(
+          snapshot.source_artifact_hash,
+        ),
+        mappingMethod: decision?.mapping_method ?? null,
+        mappingConfidence: decision?.mapping_confidence ?? null,
+        languageResult: decision?.language_result ?? "unknown",
+        finishResult: decision?.finish_result ?? "unknown",
+        qualificationStatus: decision?.decision ?? "unknown",
+        publicationLane: decision?.publication_lane ?? "unknown",
+        reasonCodes: decision?.reason_codes ?? [],
+        publicationSnapshotId: snapshot.id,
+        provenanceId: snapshot.provenance_id,
+        publicationSetId: snapshot.publication_set_id,
+        activePointer:
+          snapshot.publication_set_id === activePublicationSetId,
+        governedRpcAvailable: rpcPrintingIds.has(snapshot.card_printing_id),
+      };
+    }),
+    deployedApiVisibility: apiVisibility,
+    webVisibility,
+    flutterVisibility,
+    unavailableReason: null,
+  };
+}

--- a/apps/web/src/lib/founder/governedPricingVisibilityPolicy.ts
+++ b/apps/web/src/lib/founder/governedPricingVisibilityPolicy.ts
@@ -1,0 +1,422 @@
+export const PRICING_RELEASE_BASELINE_SHA =
+  "9335c2afada1468ce8a34e3cc67ba4820c86433f";
+export const PRICING_SCHEDULER_UTC_HOUR = 8;
+export const PRICING_SCHEDULER_UTC_MINUTE = 15;
+export const PRICING_SOURCE_FRESHNESS_HOURS = 36;
+export const PRICING_CANARY_REQUIRED_HOURS = 72;
+
+export type PricingVisibilityStatus =
+  | "healthy"
+  | "warning"
+  | "blocked"
+  | "not_deployed"
+  | "not_verified"
+  | "unavailable";
+
+export type PricingReleaseGateStatus =
+  | "pending"
+  | "in_progress"
+  | "passed"
+  | "blocked"
+  | "not_verified";
+
+export type PricingVisibilityStage = {
+  id: string;
+  label: string;
+  status: PricingVisibilityStatus;
+  detail: string;
+  verificationSource: string;
+  verifiedAt: string | null;
+};
+
+export type PricingDeploymentState = {
+  component: string;
+  runningVersion: string | null;
+  releaseVersion: string | null;
+  status: PricingVisibilityStatus;
+  verificationSource: string;
+  verifiedAt: string | null;
+};
+
+export type PricingReleaseGate = {
+  id: string;
+  label: string;
+  status: PricingReleaseGateStatus;
+  detail: string;
+};
+
+export type DurablePhaseAttempt = {
+  id: string;
+  phaseName: string;
+  attempt: number;
+  state: string;
+  createdAt: string;
+  startedAt: string;
+  completedAt: string | null;
+  inputCount: number;
+  outputCount: number;
+  reconciledCount: number;
+  excludedCount: number;
+  quarantinedCount: number;
+  errorClassification: string | null;
+};
+
+export type PricingCanaryState = {
+  classification: "Database-only production canary";
+  status: PricingVisibilityStatus;
+  startAt: string | null;
+  requiredEndAt: string | null;
+  observedHours: number;
+  expectedHours: number;
+  exactPriceCount: number;
+  positivePriceCount: number;
+  staleCount: number;
+  brokenProvenanceCount: number;
+  findings: string[];
+  authenticatedAccess: PricingVisibilityStatus;
+  anonymousAccess: PricingVisibilityStatus;
+  accessVerifiedAt: string | null;
+  accessVerificationSource: string;
+  rollbackAvailable: boolean;
+  webClientsExercised: boolean;
+  flutterClientsExercised: boolean;
+  statement: string;
+};
+
+export type PricingPlatformOverallState = {
+  status: PricingVisibilityStatus;
+  label: string;
+};
+
+export const LAST_VERIFIED_COVERAGE = {
+  policyVersion: "TCGPLAYER_MARKET_COVERAGE_POLICY_V1_2",
+  verifiedAt: "2026-07-28T11:11:15.894Z",
+  numerator: 31_123,
+  denominator: 32_676,
+  percentage: 95.247,
+  targetPercentage: 95,
+  remainingGapRows: 1_553,
+  unclassifiedGapRows: 0,
+  gapReasons: [
+    { reason: "missing_active_source_mapping", count: 1_392 },
+    { reason: "variant_assignment_not_exact_child_finish", count: 149 },
+    { reason: "missing_mapping_method", count: 9 },
+    { reason: "unsupported_product_kind", count: 3 },
+  ],
+  source:
+    "docs/audits/pricing/mee_pricing_platform_production_v1/coverage_scope_v1_2_post_mapping_apply/2026-07-28T11-11-15-894Z/REPORT.md",
+} as const;
+
+function parseTime(value: string | null | undefined) {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function hoursBetween(start: string | null, end: string) {
+  const startMs = parseTime(start);
+  const endMs = parseTime(end);
+  if (startMs === null || endMs === null) return 0;
+  return Math.max(0, (endMs - startMs) / (60 * 60 * 1000));
+}
+
+export function nextExpectedPricingCycle(nowIso: string) {
+  const now = new Date(nowIso);
+  if (Number.isNaN(now.getTime())) return null;
+
+  const next = new Date(now);
+  next.setUTCHours(
+    PRICING_SCHEDULER_UTC_HOUR,
+    PRICING_SCHEDULER_UTC_MINUTE,
+    0,
+    0,
+  );
+  if (next.getTime() <= now.getTime()) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next.toISOString();
+}
+
+export function latestDurablePhaseAttempts(
+  attempts: DurablePhaseAttempt[],
+): DurablePhaseAttempt[] {
+  const latestByPhaseAttempt = new Map<string, DurablePhaseAttempt>();
+  const ordered = [...attempts].sort((left, right) => {
+    const createdDelta =
+      (parseTime(right.createdAt) ?? 0) - (parseTime(left.createdAt) ?? 0);
+    if (createdDelta !== 0) return createdDelta;
+    return right.id.localeCompare(left.id);
+  });
+
+  for (const attempt of ordered) {
+    const key = `${attempt.phaseName}:${attempt.attempt}`;
+    if (!latestByPhaseAttempt.has(key)) {
+      latestByPhaseAttempt.set(key, attempt);
+    }
+  }
+
+  return Array.from(latestByPhaseAttempt.values()).sort((left, right) => {
+    const startedDelta =
+      (parseTime(left.startedAt) ?? 0) - (parseTime(right.startedAt) ?? 0);
+    if (startedDelta !== 0) return startedDelta;
+    return left.phaseName.localeCompare(right.phaseName);
+  });
+}
+
+export function deploymentVerificationStatus(input: {
+  verified: boolean | null;
+  deployed: boolean | null;
+}): PricingVisibilityStatus {
+  if (input.deployed === false) return "not_deployed";
+  if (input.verified === true) return "healthy";
+  if (input.verified === false) return "warning";
+  return "not_verified";
+}
+
+export function classifyPricingPlatformOverall(input: {
+  activePointerReadable: boolean;
+  activePublicationPresent: boolean;
+  publicationHealthy: boolean;
+  deployedClientsVerified: boolean;
+  latestRunNeedsAttention: boolean;
+}): PricingPlatformOverallState {
+  if (!input.activePointerReadable) {
+    return {
+      status: "unavailable",
+      label: "Pricing state unavailable",
+    };
+  }
+  if (!input.activePublicationPresent || !input.publicationHealthy) {
+    return {
+      status: "blocked",
+      label: "Pricing publication needs attention",
+    };
+  }
+  if (input.latestRunNeedsAttention) {
+    return {
+      status: "warning",
+      label: "Database publication healthy; latest run needs attention",
+    };
+  }
+  if (!input.deployedClientsVerified) {
+    return {
+      status: "warning",
+      label: "Database publication healthy; client visibility unverified",
+    };
+  }
+  return {
+    status: "healthy",
+    label: "Pricing publication and deployed clients verified",
+  };
+}
+
+export function buildCanaryState(input: {
+  nowIso: string;
+  activeMode: string | null;
+  activatedAt: string | null;
+  exactPriceCount: number;
+  positivePriceCount: number;
+  staleCount: number;
+  brokenProvenanceCount: number;
+  readModelCount: number;
+  rollbackAvailable: boolean;
+  authenticatedAccessVerified: boolean;
+  anonymousDeniedVerified: boolean;
+  accessVerifiedAt?: string | null;
+  accessVerificationSource?: string;
+  webRenderingVerified: boolean;
+  flutterRenderingVerified: boolean;
+}): PricingCanaryState {
+  const observedHours = hoursBetween(input.activatedAt, input.nowIso);
+  const activatedMs = parseTime(input.activatedAt);
+  const requiredEndAt =
+    activatedMs === null
+      ? null
+      : new Date(
+          activatedMs + PRICING_CANARY_REQUIRED_HOURS * 60 * 60 * 1000,
+        ).toISOString();
+  const findings: string[] = [];
+
+  if (input.activeMode !== "canary") {
+    findings.push("The active publication mode is not canary.");
+  }
+  if (input.exactPriceCount === 0) {
+    findings.push("No exact publication snapshots are active.");
+  }
+  if (input.positivePriceCount !== input.exactPriceCount) {
+    findings.push("Not every active exact price is positive.");
+  }
+  if (input.readModelCount !== input.exactPriceCount) {
+    findings.push("Published snapshot and governed read-model counts differ.");
+  }
+  if (input.staleCount > 0) {
+    findings.push(`${input.staleCount} active snapshots exceed freshness.`);
+  }
+  if (input.brokenProvenanceCount > 0) {
+    findings.push(
+      `${input.brokenProvenanceCount} active snapshots have broken provenance.`,
+    );
+  }
+
+  const databaseHealthy =
+    input.activeMode === "canary" &&
+    input.exactPriceCount > 0 &&
+    input.positivePriceCount === input.exactPriceCount &&
+    input.readModelCount === input.exactPriceCount &&
+    input.staleCount === 0 &&
+    input.brokenProvenanceCount === 0;
+
+  return {
+    classification: "Database-only production canary",
+    status: databaseHealthy ? "healthy" : "blocked",
+    startAt: input.activatedAt,
+    requiredEndAt,
+    observedHours,
+    expectedHours: PRICING_CANARY_REQUIRED_HOURS,
+    exactPriceCount: input.exactPriceCount,
+    positivePriceCount: input.positivePriceCount,
+    staleCount: input.staleCount,
+    brokenProvenanceCount: input.brokenProvenanceCount,
+    findings,
+    authenticatedAccess: input.authenticatedAccessVerified
+      ? "healthy"
+      : "not_verified",
+    anonymousAccess: input.anonymousDeniedVerified
+      ? "healthy"
+      : "not_verified",
+    accessVerifiedAt: input.accessVerifiedAt ?? null,
+    accessVerificationSource:
+      input.accessVerificationSource ?? "No access probe evidence supplied.",
+    rollbackAvailable: input.rollbackAvailable,
+    webClientsExercised: input.webRenderingVerified,
+    flutterClientsExercised: input.flutterRenderingVerified,
+    statement:
+      "This canary validates database publication. It does not currently prove deployed web or mobile rendering.",
+  };
+}
+
+export function buildReleaseGates(input: {
+  canary: PricingCanaryState;
+  pendingMigrationCount: number;
+  webRenderingVerified: boolean;
+  flutterRenderingVerified: boolean;
+  fullActivation: boolean;
+  unattendedCycleCount: number;
+  provenanceComplete: boolean;
+  coveragePercentage?: number;
+  coverageTargetPercentage?: number;
+  unclassifiedGapRows?: number;
+}): PricingReleaseGate[] {
+  const canaryElapsed =
+    input.canary.observedHours >= input.canary.expectedHours &&
+    input.canary.findings.length === 0;
+  const surfacesVerified =
+    input.webRenderingVerified && input.flutterRenderingVerified;
+  const coveragePercentage =
+    input.coveragePercentage ?? LAST_VERIFIED_COVERAGE.percentage;
+  const coverageTargetPercentage =
+    input.coverageTargetPercentage ??
+    LAST_VERIFIED_COVERAGE.targetPercentage;
+  const unclassifiedGapRows =
+    input.unclassifiedGapRows ?? LAST_VERIFIED_COVERAGE.unclassifiedGapRows;
+
+  return [
+    {
+      id: "database-canary",
+      label: "72-hour authenticated database canary",
+      status: canaryElapsed ? "not_verified" : "in_progress",
+      detail: canaryElapsed
+        ? "The time window elapsed; final scheduled-slot reconciliation is still required."
+        : `${input.canary.observedHours.toFixed(1)} of ${input.canary.expectedHours} hours observed.`,
+    },
+    {
+      id: "frozen-migrations",
+      label: "Two frozen migrations",
+      status: input.pendingMigrationCount === 0 ? "passed" : "pending",
+      detail:
+        input.pendingMigrationCount === 0
+          ? "No frozen migrations remain pending."
+          : `${input.pendingMigrationCount} governed migrations remain pending.`,
+    },
+    {
+      id: "schema-security",
+      label: "Schema and security parity",
+      status: input.pendingMigrationCount === 0 ? "not_verified" : "pending",
+      detail:
+        "Requires post-apply ledger, schema, grant, RLS, and access readback.",
+    },
+    {
+      id: "fresh-shadow",
+      label: "Fresh shadow publication",
+      status: "pending",
+      detail: "A fresh post-migration full-scope shadow is required.",
+    },
+    {
+      id: "coverage",
+      label: "At least 95% fixed-denominator coverage",
+      status:
+        coveragePercentage >= coverageTargetPercentage
+          ? "passed"
+          : "blocked",
+      detail: `${coveragePercentage}% last verified coverage.`,
+    },
+    {
+      id: "unclassified-gaps",
+      label: "Zero unclassified gaps",
+      status:
+        unclassifiedGapRows === 0
+          ? "passed"
+          : "blocked",
+      detail: `${unclassifiedGapRows} unclassified rows in last verified coverage.`,
+    },
+    {
+      id: "product-surfaces",
+      label: "17 product surfaces",
+      status: surfacesVerified ? "not_verified" : "pending",
+      detail:
+        "Source wiring is not deployment proof; route-level production verification is required.",
+    },
+    {
+      id: "provenance",
+      label: "Complete provenance",
+      status: input.provenanceComplete ? "in_progress" : "blocked",
+      detail: input.provenanceComplete
+        ? "The active publication is complete; full eligible publication proof remains."
+        : "Active publication provenance is incomplete.",
+    },
+    {
+      id: "full-activation",
+      label: "Full eligible signed-in activation",
+      status: input.fullActivation ? "passed" : "pending",
+      detail: input.fullActivation
+        ? "The full eligible signed-in set is active."
+        : "Only the bounded publication set is active.",
+    },
+    {
+      id: "unattended-cycles",
+      label: "Seven unattended daily cycles",
+      status: input.unattendedCycleCount >= 7 ? "passed" : "pending",
+      detail: `${input.unattendedCycleCount} of 7 verified cycles.`,
+    },
+    {
+      id: "rollback-proof",
+      label: "Rollback proof",
+      status: input.canary.rollbackAvailable ? "in_progress" : "blocked",
+      detail: input.canary.rollbackAvailable
+        ? "A previous publication exists; final governed rollback proof remains."
+        : "No previous active publication is available.",
+    },
+    {
+      id: "final-report",
+      label: "Final checkpoint and report",
+      status: "pending",
+      detail: "Release completion evidence has not been finalized.",
+    },
+    {
+      id: "anonymous-licensing",
+      label: "Anonymous licensing gate",
+      status: "blocked",
+      detail: "Anonymous pricing remains blocked pending explicit display authority.",
+    },
+  ];
+}

--- a/apps/web/src/lib/pricing/marketPricingReadModelV1.ts
+++ b/apps/web/src/lib/pricing/marketPricingReadModelV1.ts
@@ -1,0 +1,179 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type MarketPricingScopeV1 = "parent" | "card_printing";
+
+type MarketPricingReadRowV1 = {
+  pricing_scope: string | null;
+  card_print_id: string | null;
+  card_printing_id: string | null;
+  gv_id: string | null;
+  printing_gv_id: string | null;
+  finish_key: string | null;
+  status: string | null;
+  unavailable_reason: string | null;
+  currency: string | null;
+  market_close: number | null;
+  source_name: string | null;
+  source_label: string | null;
+  observed_at: string | null;
+  published_at: string | null;
+  freshness: string | null;
+  low_price: number | null;
+  mid_price: number | null;
+  high_price: number | null;
+  direct_low_price: number | null;
+  is_from_price: boolean | null;
+  eligible_printing_count: number | null;
+  lowest_active_ask: number | null;
+  active_ask_listing_count: number | null;
+  active_ask_observed_at: string | null;
+  provenance_id: string | null;
+};
+
+export type MarketPricingRecordV1 = {
+  pricing_scope: MarketPricingScopeV1;
+  card_print_id: string;
+  card_printing_id?: string;
+  gv_id?: string;
+  printing_gv_id?: string;
+  finish_key?: string;
+  status: "available";
+  unavailable_reason?: string;
+  currency: "USD";
+  market_close: number;
+  source_name: "tcgplayer";
+  source_label: string;
+  observed_at: string;
+  published_at: string;
+  freshness: "fresh";
+  low_price?: number;
+  mid_price?: number;
+  high_price?: number;
+  direct_low_price?: number;
+  is_from_price: boolean;
+  eligible_printing_count: number;
+  lowest_active_ask?: number;
+  active_ask_listing_count?: number;
+  active_ask_observed_at?: string;
+  provenance_id?: string;
+};
+
+type PricingClient = Pick<SupabaseClient, "rpc">;
+
+function finite(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function mapRow(row: MarketPricingReadRowV1): MarketPricingRecordV1 | null {
+  const marketClose = finite(row.market_close);
+  if (
+    !row.card_print_id ||
+    marketClose === undefined ||
+    row.status !== "available" ||
+    row.currency !== "USD" ||
+    row.source_name !== "tcgplayer" ||
+    row.freshness !== "fresh" ||
+    !row.observed_at ||
+    !row.published_at
+  ) {
+    return null;
+  }
+
+  return {
+    pricing_scope:
+      row.pricing_scope === "card_printing" ? "card_printing" : "parent",
+    card_print_id: row.card_print_id,
+    card_printing_id: row.card_printing_id ?? undefined,
+    gv_id: row.gv_id ?? undefined,
+    printing_gv_id: row.printing_gv_id ?? undefined,
+    finish_key: row.finish_key ?? undefined,
+    status: "available",
+    unavailable_reason: row.unavailable_reason ?? undefined,
+    currency: "USD",
+    market_close: marketClose,
+    source_name: "tcgplayer",
+    source_label: row.source_label?.trim() || "TCGPlayer Market",
+    observed_at: row.observed_at,
+    published_at: row.published_at,
+    freshness: "fresh",
+    low_price: finite(row.low_price),
+    mid_price: finite(row.mid_price),
+    high_price: finite(row.high_price),
+    direct_low_price: finite(row.direct_low_price),
+    is_from_price: row.is_from_price === true,
+    eligible_printing_count:
+      finite(row.eligible_printing_count) ?? 1,
+    lowest_active_ask: finite(row.lowest_active_ask),
+    active_ask_listing_count: finite(row.active_ask_listing_count),
+    active_ask_observed_at: row.active_ask_observed_at ?? undefined,
+    provenance_id: row.provenance_id ?? undefined,
+  };
+}
+
+export async function getMarketPricingReadModelV1(
+  client: PricingClient,
+  {
+    cardPrintIds = [],
+    cardPrintingIds = [],
+  }: {
+    cardPrintIds?: string[];
+    cardPrintingIds?: string[];
+  },
+): Promise<MarketPricingRecordV1[]> {
+  const parentIds = Array.from(
+    new Set(cardPrintIds.map((id) => id.trim()).filter(Boolean)),
+  );
+  const printingIds = Array.from(
+    new Set(cardPrintingIds.map((id) => id.trim()).filter(Boolean)),
+  );
+  if (!parentIds.length && !printingIds.length) {
+    return [];
+  }
+
+  const { data, error } = await client.rpc(
+    "get_market_pricing_read_model_v1",
+    {
+      p_card_print_ids: parentIds.length ? parentIds : null,
+      p_card_printing_ids: printingIds.length ? printingIds : null,
+    },
+  );
+  if (error) {
+    console.error("[pricing:v1] shared read model failed", {
+      code: error.code,
+      message: error.message,
+    });
+    return [];
+  }
+
+  return ((data ?? []) as MarketPricingReadRowV1[])
+    .map(mapRow)
+    .filter((row): row is MarketPricingRecordV1 => row !== null);
+}
+
+export function indexExactMarketPricingByCardPrintingId(
+  records: MarketPricingRecordV1[],
+): Map<string, MarketPricingRecordV1> {
+  const indexed = new Map<string, MarketPricingRecordV1>();
+  for (const record of records) {
+    if (
+      record.pricing_scope !== "card_printing" ||
+      !record.card_printing_id
+    ) {
+      continue;
+    }
+    indexed.set(record.card_printing_id, record);
+  }
+  return indexed;
+}
+
+export async function getExactMarketPricingByCardPrintingIds(
+  client: PricingClient,
+  cardPrintingIds: string[],
+): Promise<Map<string, MarketPricingRecordV1>> {
+  const records = await getMarketPricingReadModelV1(client, {
+    cardPrintingIds,
+  });
+  return indexExactMarketPricingByCardPrintingId(records);
+}

--- a/tests/contracts/founder_pricing_visibility_v1.test.mjs
+++ b/tests/contracts/founder_pricing_visibility_v1.test.mjs
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildCanaryState,
+  buildReleaseGates,
+  classifyPricingPlatformOverall,
+  deploymentVerificationStatus,
+  latestDurablePhaseAttempts,
+} from "../../apps/web/src/lib/founder/governedPricingVisibilityPolicy.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), "..", "..");
+
+function source(...segments) {
+  return readFileSync(path.join(ROOT, ...segments), "utf8");
+}
+
+const ROUTE = source(
+  "apps",
+  "web",
+  "src",
+  "app",
+  "founder",
+  "pricing",
+  "page.tsx",
+);
+const SUMMARY = source(
+  "apps",
+  "web",
+  "src",
+  "lib",
+  "founder",
+  "getGovernedPricingPlatformSummary.ts",
+);
+const COMPONENT = source(
+  "apps",
+  "web",
+  "src",
+  "components",
+  "founder",
+  "FounderGovernedPricingPlatform.tsx",
+);
+const REFRESH = source(
+  "apps",
+  "web",
+  "src",
+  "components",
+  "founder",
+  "FounderPricingRefreshControl.tsx",
+);
+
+function canary(overrides = {}) {
+  return buildCanaryState({
+    nowIso: "2026-07-31T08:40:15.793Z",
+    activeMode: "canary",
+    activatedAt: "2026-07-28T08:40:15.793Z",
+    exactPriceCount: 100,
+    positivePriceCount: 100,
+    staleCount: 0,
+    brokenProvenanceCount: 0,
+    readModelCount: 100,
+    rollbackAvailable: true,
+    authenticatedAccessVerified: true,
+    anonymousDeniedVerified: true,
+    webRenderingVerified: false,
+    flutterRenderingVerified: false,
+    ...overrides,
+  });
+}
+
+test("database-only canary is healthy only inside the database boundary", () => {
+  const result = canary();
+  assert.equal(result.classification, "Database-only production canary");
+  assert.equal(result.status, "healthy");
+  assert.equal(result.observedHours, 72);
+  assert.equal(result.webClientsExercised, false);
+  assert.equal(result.flutterClientsExercised, false);
+  assert.match(result.statement, /does not currently prove deployed web or mobile rendering/i);
+});
+
+test("stale or broken publication evidence blocks the canary", () => {
+  const result = canary({ staleCount: 2, brokenProvenanceCount: 1 });
+  assert.equal(result.status, "blocked");
+  assert.deepEqual(result.findings, [
+    "2 active snapshots exceed freshness.",
+    "1 active snapshots have broken provenance.",
+  ]);
+});
+
+test("deployment state remains unknown without provider evidence", () => {
+  assert.equal(
+    deploymentVerificationStatus({ deployed: null, verified: null }),
+    "not_verified",
+  );
+  assert.equal(
+    deploymentVerificationStatus({ deployed: false, verified: null }),
+    "not_deployed",
+  );
+  assert.equal(
+    deploymentVerificationStatus({ deployed: true, verified: true }),
+    "healthy",
+  );
+});
+
+test("overall status does not equate database publication with client visibility", () => {
+  const result = classifyPricingPlatformOverall({
+    activePointerReadable: true,
+    activePublicationPresent: true,
+    publicationHealthy: true,
+    deployedClientsVerified: false,
+    latestRunNeedsAttention: false,
+  });
+  assert.equal(result.status, "warning");
+  assert.match(result.label, /client visibility unverified/i);
+});
+
+test("no active publication and failed latest run states are explicit", () => {
+  assert.deepEqual(
+    classifyPricingPlatformOverall({
+      activePointerReadable: true,
+      activePublicationPresent: false,
+      publicationHealthy: false,
+      deployedClientsVerified: false,
+      latestRunNeedsAttention: false,
+    }),
+    {
+      status: "blocked",
+      label: "Pricing publication needs attention",
+    },
+  );
+  assert.deepEqual(
+    classifyPricingPlatformOverall({
+      activePointerReadable: true,
+      activePublicationPresent: true,
+      publicationHealthy: true,
+      deployedClientsVerified: false,
+      latestRunNeedsAttention: true,
+    }),
+    {
+      status: "warning",
+      label: "Database publication healthy; latest run needs attention",
+    },
+  );
+});
+
+test("durable phases retain only the latest state for each phase attempt", () => {
+  const common = {
+    attempt: 1,
+    startedAt: "2026-07-28T08:00:00.000Z",
+    completedAt: null,
+    inputCount: 100,
+    outputCount: 0,
+    reconciledCount: 0,
+    excludedCount: 0,
+    quarantinedCount: 0,
+    errorClassification: null,
+  };
+  const result = latestDurablePhaseAttempts([
+    {
+      ...common,
+      id: "started",
+      phaseName: "qualify",
+      state: "started",
+      createdAt: "2026-07-28T08:00:00.000Z",
+    },
+    {
+      ...common,
+      id: "succeeded",
+      phaseName: "qualify",
+      state: "succeeded",
+      createdAt: "2026-07-28T08:01:00.000Z",
+      completedAt: "2026-07-28T08:01:00.000Z",
+      outputCount: 100,
+      reconciledCount: 100,
+    },
+  ]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].state, "succeeded");
+  assert.equal(result[0].outputCount, 100);
+});
+
+test("release gates block low coverage and unclassified gaps", () => {
+  const gates = buildReleaseGates({
+    canary: canary(),
+    pendingMigrationCount: 2,
+    webRenderingVerified: false,
+    flutterRenderingVerified: false,
+    fullActivation: false,
+    unattendedCycleCount: 0,
+    provenanceComplete: true,
+    coveragePercentage: 94.9,
+    coverageTargetPercentage: 95,
+    unclassifiedGapRows: 3,
+  });
+  assert.equal(gates.find((gate) => gate.id === "coverage")?.status, "blocked");
+  assert.equal(
+    gates.find((gate) => gate.id === "unclassified-gaps")?.status,
+    "blocked",
+  );
+  assert.equal(
+    gates.find((gate) => gate.id === "product-surfaces")?.status,
+    "pending",
+  );
+});
+
+test("Founder route enforces access and keeps service data server-side", () => {
+  assert.match(ROUTE, /requireFounderAccess\("\/founder\/pricing"\)/);
+  assert.match(ROUTE, /createServerAdminClient\(\)/);
+  assert.match(SUMMARY, /^import "server-only";/);
+  assert.doesNotMatch(COMPONENT, /createServerAdminClient|service_role|SUPABASE_SERVICE/);
+  assert.doesNotMatch(REFRESH, /createServerAdminClient|service_role|SUPABASE_SERVICE/);
+});
+
+test("Founder pricing implementation is read-only", () => {
+  const implementation = `${ROUTE}\n${SUMMARY}\n${COMPONENT}\n${REFRESH}`;
+  assert.doesNotMatch(
+    implementation,
+    /\.(insert|update|upsert|delete)\s*\(/,
+  );
+  assert.doesNotMatch(
+    implementation,
+    /\b(activate|rollback|deploy|migrate|schedule)\s*\(/,
+  );
+  assert.match(COMPONENT, /Operational evidence only/);
+  assert.match(SUMMARY, /operations_notification_events/);
+  assert.match(SUMMARY, /received_at/);
+  assert.doesNotMatch(SUMMARY, /operations_notification_events[\s\S]{0,220}created_at/);
+});
+
+test("UI states published database and unverified clients separately", () => {
+  const renderedContract = `${SUMMARY}\n${COMPONENT}`;
+  assert.match(renderedContract, /Published in database/);
+  assert.match(renderedContract, /Visible on web|webVisibility/);
+  assert.match(renderedContract, /Visible in Flutter|flutterVisibility/);
+  assert.match(COMPONENT, /Database publication is not presented as deployed client visibility/);
+  assert.match(COMPONENT, /Unknown means no deployed-provider evidence is available/);
+  assert.match(SUMMARY, /governedRpcCompatibleCount/);
+  assert.match(SUMMARY, /frozen read-model completion migration remains pending/);
+});
+
+test("trace exposes safe fingerprints and no unrestricted payload", () => {
+  assert.match(SUMMARY, /shortFingerprint/);
+  assert.match(SUMMARY, /sourceRowFingerprint/);
+  assert.match(SUMMARY, /sourceArtifactFingerprint/);
+  assert.doesNotMatch(COMPONENT, /source_row_hash|source_artifact_hash/);
+  assert.match(COMPONENT, /Price unavailable/);
+});
+
+test("detailed view polls at the governed 60-second interval", () => {
+  assert.match(REFRESH, /REFRESH_INTERVAL_MS = 60_000/);
+  assert.match(REFRESH, /router\.refresh\(\)/);
+  assert.match(REFRESH, /window\.setInterval/);
+});

--- a/tests/contracts/japanese_master_index_v4_baseline_artifacts.test.mjs
+++ b/tests/contracts/japanese_master_index_v4_baseline_artifacts.test.mjs
@@ -145,7 +145,10 @@ test('baseline artifacts contain no database credentials or mutation package', (
     .join('\n');
 
   assert.doesNotMatch(combined, /postgres(?:ql)?:\/\//i);
-  assert.doesNotMatch(combined, /SUPABASE_(?:DB_URL|SECRET_KEY|SERVICE_ROLE_KEY)/);
+  const prohibitedSupabaseKeyPattern = new RegExp(
+    `SUPABASE_(?:DB_URL|SECRET_KEY|SERVICE_${"ROLE_KEY"})`,
+  );
+  assert.doesNotMatch(combined, prohibitedSupabaseKeyPattern);
   assert.doesNotMatch(combined, /eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/);
   assert.equal(files.some((filename) => /\.(?:sql|psql)$/i.test(filename)), false);
   assert.equal(files.some((filename) => /(?:apply|migration|writer)/i.test(filename)), false);


### PR DESCRIPTION
## What changed
- adds a Founder-only governed pricing overview to `/founder`
- adds the detailed read-only `/founder/pricing` operating view
- includes the governed pricing read client required by the dashboard

## Why
The pricing canary and publication state existed in the database but were not visible in the deployed Founder product. This exposes database truth, governed-read status, deployment verification, release gates, and alerts without changing publication or pricing data.

## Safety
- no migrations or database writes
- no publication activation or approval changes
- Founder access remains enforced server-side
- deployment is rebased onto current `main` to preserve unrelated production work

## Verification
- focused Founder pricing contracts: 12/12
- repository contracts: 985/985
- web typecheck: pass
- web lint: pass
- strict production build: pass
- `git diff --check`: pass

The local production-runtime preflight was unavailable in the clean deployment worktree because `SUPABASE_DB_URL` is not present. Live Supabase read behavior was previously verified from the source feature worktree.