### PR TITLE
Automate pricing canary observation

### DIFF
--- a/.github/workflows/tcgplayer-market-canary-observation.yml
+++ b/.github/workflows/tcgplayer-market-canary-observation.yml
@@ -1,0 +1,99 @@
+name: TCGPlayer Market Canary Observation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tcgplayer-market-canary-observation
+  cancel-in-progress: false
+
+jobs:
+  observe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CANARY_WINDOW_START: "2026-07-28T08:40:15.793Z"
+      CANARY_REQUIRED_END: "2026-07-31T08:40:15.793Z"
+      CANARY_ACTIVATION_RUN_ID: "87b13fc1-3639-47cb-843f-2f5d8b29d3b0"
+      CANARY_EXPECTED_COMMIT_SHA: "c0cdce5500c96cdc5b1d689e5178d9fa4e117e1d"
+      CANARY_EXPECTED_COUNT: "100"
+      OBSERVER_SOURCE_SHA: "9335c2afada1468ce8a34e3cc67ba4820c86433f"
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+
+    steps:
+      - name: Check out frozen pricing release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.OBSERVER_SOURCE_SHA }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Observe frozen canary
+        id: observe
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          now_epoch="$(date -u +%s)"
+          required_end_epoch="$(date -u -d "${CANARY_REQUIRED_END}" +%s)"
+          final_observation_deadline="$((required_end_epoch + 21600))"
+
+          if (( now_epoch > final_observation_deadline )); then
+            echo "The frozen canary observation window is complete; no further scheduled reads are required."
+            echo "skipped_after_final_window=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          require_pass=()
+          if (( now_epoch >= required_end_epoch )); then
+            require_pass=(--require-pass)
+          fi
+
+          node scripts/audits/tcgplayer_market_canary_observation_v1.mjs \
+            "--window-start=${CANARY_WINDOW_START}" \
+            "--activation-run-id=${CANARY_ACTIVATION_RUN_ID}" \
+            "--expected-commit-sha=${CANARY_EXPECTED_COMMIT_SHA}" \
+            --required-hours=72 \
+            "--expected-count=${CANARY_EXPECTED_COUNT}" \
+            --schedule-tolerance-minutes=90 \
+            --out-root="$RUNNER_TEMP/tcgplayer-market-canary-observation" \
+            "${require_pass[@]}"
+
+          latest_summary="$(
+            find "$RUNNER_TEMP/tcgplayer-market-canary-observation" \
+              -type f \
+              -name summary.json \
+              -print \
+              | sort \
+              | tail -1
+          )"
+          test -n "$latest_summary"
+
+          {
+            echo "## TCGPlayer Market canary"
+            echo
+            echo '```json'
+            cat "$latest_summary"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload observation evidence
+        if: ${{ always() && steps.observe.outputs.skipped_after_final_window != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcgplayer-market-canary-observation-${{ github.run_id }}
+          path: ${{ runner.temp }}/tcgplayer-market-canary-observation
+          if-no-files-found: error
+          retention-days: 30

--- a/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+const WORKFLOW_PATH = path.join(
+  ROOT,
+  ".github",
+  "workflows",
+  "tcgplayer-market-canary-observation.yml",
+);
+const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+test("scheduled canary observer is pinned to the reviewed source and canary", () => {
+  assert.match(
+    workflow,
+    /OBSERVER_SOURCE_SHA: "9335c2afada1468ce8a34e3cc67ba4820c86433f"/,
+  );
+  assert.match(
+    workflow,
+    /CANARY_EXPECTED_COMMIT_SHA: "c0cdce5500c96cdc5b1d689e5178d9fa4e117e1d"/,
+  );
+  assert.match(
+    workflow,
+    /CANARY_ACTIVATION_RUN_ID: "87b13fc1-3639-47cb-843f-2f5d8b29d3b0"/,
+  );
+  assert.match(workflow, /CANARY_EXPECTED_COUNT: "100"/);
+  assert.match(workflow, /ref: \$\{\{ env\.OBSERVER_SOURCE_SHA \}\}/);
+});
+
+test("scheduled canary observer requires the terminal pass after 72 hours", () => {
+  assert.match(workflow, /CANARY_REQUIRED_END: "2026-07-31T08:40:15\.793Z"/);
+  assert.match(workflow, /--required-hours=72/);
+  assert.match(workflow, /require_pass=\(--require-pass\)/);
+  assert.match(workflow, /"\$\{require_pass\[@\]\}"/);
+});
+
+test("scheduled canary observer is read-only and cannot apply migrations", () => {
+  assert.match(
+    workflow,
+    /node scripts\/audits\/tcgplayer_market_canary_observation_v1\.mjs/,
+  );
+  assert.match(workflow, /SUPABASE_DB_URL: \$\{\{ secrets\.SUPABASE_DB_URL \}\}/);
+  assert.doesNotMatch(workflow, /supabase\s+db\s+push/i);
+  assert.doesNotMatch(workflow, /pricing:market:[^\s]*apply/i);
+  assert.doesNotMatch(workflow, /tcgplayer_market_publication_worker_v1/i);
+  assert.doesNotMatch(workflow, /tcgplayer_market_pipeline_v1/i);
+});


### PR DESCRIPTION
## What changed
- observes the frozen 100-printing TCGPlayer Market canary every six hours
- pins observer execution to reviewed source SHA `9335c2afada1468ce8a34e3cc67ba4820c86433f`
- requires a passing observer result once the 72-hour window ends
- uploads read-only evidence without committing generated artifacts

## Boundaries
- no database writes
- no migration apply
- no publication activation
- no automatic rollout
- stops scheduled reads after the final observation window

## Verification
- workflow boundary contracts: 3/3
- legacy-key guard: pass
- `git diff --check`: pass