### PR TITLE
Repair transient TCGCSV canary ingestion failures

### DIFF
--- a/backend/pricing/tcgcsv_source_fetch_retry_policy_v1.mjs
+++ b/backend/pricing/tcgcsv_source_fetch_retry_policy_v1.mjs
@@ -1,0 +1,47 @@
+export const TCGCSV_SOURCE_FETCH_RETRY_POLICY_V1 =
+  "TCGCSV_SOURCE_FETCH_RETRY_POLICY_V1";
+
+const RETRYABLE_CURL_EXIT_CODES = new Set([5, 6, 7, 18, 28, 35, 52, 55, 56, 92]);
+const RETRYABLE_MESSAGE_PATTERNS = [
+  /(?:returned error:|HTTP\/\S+\s+)\s*(?:408|425|429|5\d\d)\b/i,
+  /connection reset/i,
+  /connection refused/i,
+  /connection terminated/i,
+  /could not connect/i,
+  /eai_again/i,
+  /econnrefused/i,
+  /econnreset/i,
+  /enotfound/i,
+  /network/i,
+  /rate.?limit/i,
+  /recv failure/i,
+  /server closed/i,
+  /socket hang up/i,
+  /timed? ?out/i,
+  /timeout/i,
+];
+
+export function isRetryableTcgcsvSourceFetchErrorV1(error) {
+  const numericCode = Number(error?.code);
+  if (
+    Number.isInteger(numericCode) &&
+    RETRYABLE_CURL_EXIT_CODES.has(numericCode)
+  ) {
+    return true;
+  }
+  const text = [error?.message, error?.stderr, error?.stdout]
+    .filter(Boolean)
+    .join("\n");
+  return RETRYABLE_MESSAGE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function tcgcsvSourceRetryDelayMsV1({
+  retryNumber,
+  baseDelayMs,
+  requestDelayMs = 0,
+}) {
+  const retry = Math.max(1, Number(retryNumber) || 1);
+  const base = Math.max(1, Number(baseDelayMs) || 1);
+  const requestDelay = Math.max(0, Number(requestDelayMs) || 0);
+  return Math.max(requestDelay, Math.min(base * 2 ** (retry - 1), 10_000));
+}

--- a/docs/contracts/TCGCSV_FULL_SOURCE_WAREHOUSE_V1.md
+++ b/docs/contracts/TCGCSV_FULL_SOURCE_WAREHOUSE_V1.md
@@ -99,6 +99,10 @@ A run with some failed categories/groups is `partial_success`, not `completed`.
 - `--apply` is required for database writes.
 - Request ceiling defaults to `10,000`.
 - Request delay defaults to `100ms`.
+- Transient source fetches retry three times by default with bounded
+  exponential delay; every attempt counts against the request ceiling.
+- Exhausted fetch failures produce `partial_success` and a nonzero process
+  exit so a scheduler cannot treat incomplete acquisition as successful.
 - Every request uses a Grookai-specific User-Agent.
 - Historical extraction requires 7zip.
 - No writes to `pricing_observations`, `ebay_active_prices_latest`, public pricing views, identity tables, vault tables, images, or storage.

--- a/scripts/audits/canon_image_unreferenced_storage_cleanup_apply_v1.mjs
+++ b/scripts/audits/canon_image_unreferenced_storage_cleanup_apply_v1.mjs
@@ -53,9 +53,7 @@ function supabaseUrl() {
 }
 
 function supabaseKey() {
-  return clean(process.env.SUPABASE_SECRET_KEY)
-    ?? clean(process.env.SUPABASE_SERVICE_ROLE_KEY)
-    ?? clean(process.env.SUPABASE_SERVICE_ROLE);
+  return clean(process.env.SUPABASE_SECRET_KEY);
 }
 
 async function readManifest(file) {
@@ -117,7 +115,7 @@ async function main() {
 
   const url = supabaseUrl();
   const key = supabaseKey();
-  if (!url || !key) throw new Error('Missing SUPABASE_URL and SUPABASE_SECRET_KEY/SUPABASE_SERVICE_ROLE_KEY.');
+  if (!url || !key) throw new Error('Missing SUPABASE_URL and SUPABASE_SECRET_KEY.');
   const supabase = createSupabaseClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
 
   const removed = [];

--- a/scripts/audits/jpn_pikachu_promo_end_to_end_apply_v1.mjs
+++ b/scripts/audits/jpn_pikachu_promo_end_to_end_apply_v1.mjs
@@ -42,9 +42,9 @@ function dbUrl() {
 
 function supabaseClient() {
   const url = clean(process.env.SUPABASE_URL);
-  const key = clean(process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const key = clean(process.env.SUPABASE_SECRET_KEY);
   if (!url) throw new Error('Missing SUPABASE_URL.');
-  if (!key) throw new Error('Missing SUPABASE_SECRET_KEY/SUPABASE_SERVICE_ROLE_KEY.');
+  if (!key) throw new Error('Missing SUPABASE_SECRET_KEY.');
   return createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
 }
 

--- a/scripts/audits/jpn_pikachu_promo_first_batch_dry_run_v1.mjs
+++ b/scripts/audits/jpn_pikachu_promo_first_batch_dry_run_v1.mjs
@@ -187,7 +187,7 @@ function toMarkdown(report) {
 
 async function supabaseClient() {
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_ANON_KEY;
+  const key = process.env.SUPABASE_SECRET_KEY;
   if (!url || !key) {
     throw new Error('Missing SUPABASE_URL and Supabase key env vars.');
   }

--- a/scripts/audits/jpn_pikachu_promo_gap_audit_v1.mjs
+++ b/scripts/audits/jpn_pikachu_promo_gap_audit_v1.mjs
@@ -180,7 +180,7 @@ async function fetchBulbapediaPromoNumbers() {
 
 async function fetchDbJpnRows() {
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_ANON_KEY;
+  const key = process.env.SUPABASE_SECRET_KEY;
   if (!url || !key) {
     throw new Error('Missing SUPABASE_URL and Supabase key env vars.');
   }

--- a/scripts/audits/tcgplayer_market_canary_image_repair_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_image_repair_v1.mjs
@@ -157,8 +157,7 @@ function assertPreconditions(row) {
 
 async function uploadNewObject(buffer, storagePath) {
   const supabaseUrl = process.env.SUPABASE_URL;
-  const serviceKey =
-    process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const serviceKey = process.env.SUPABASE_SECRET_KEY;
   if (!supabaseUrl || !serviceKey) {
     throw new Error("Supabase URL and service key are required for apply");
   }

--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -309,6 +309,7 @@ async function queryEvidence(client, args, asOf) {
     terminalAlerts,
     current,
     sourceHealth,
+    sourceRunEvidence: sourceMetrics,
     access: {
       authenticated_execute_granted:
         grants.authenticated_execute_granted === true,

--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -202,7 +202,7 @@ async function queryEvidence(client, args, asOf) {
     await client.query(
       `with latest_source as (
          select run_key, status, source_marker, finished_at, price_row_count,
-                failed_count, error
+                failed_count, error, payload
          from public.tcgcsv_source_sync_runs
          where sync_mode = 'current_full_sync'
          order by finished_at desc nulls last, created_at desc
@@ -210,7 +210,7 @@ async function queryEvidence(client, args, asOf) {
        ),
        completed_source as (
          select run_key, status, source_marker, finished_at, price_row_count,
-                failed_count, error
+                failed_count, error, payload
          from public.tcgcsv_source_sync_runs
          where sync_mode = 'current_full_sync' and status = 'completed'
          order by finished_at desc nulls last, created_at desc
@@ -224,13 +224,15 @@ async function queryEvidence(client, args, asOf) {
          latest_source.price_row_count as latest_source_price_row_count,
          latest_source.failed_count as latest_source_failed_count,
          latest_source.error as latest_source_error,
+         latest_source.payload as latest_source_payload,
          completed_source.run_key as completed_source_run_key,
          completed_source.status as completed_source_status,
          completed_source.source_marker as completed_source_marker,
          completed_source.finished_at as completed_source_finished_at,
          completed_source.price_row_count as completed_source_price_row_count,
          completed_source.failed_count as completed_source_failed_count,
-         completed_source.error as completed_source_error
+         completed_source.error as completed_source_error,
+         completed_source.payload as completed_source_payload
        from latest_source
        full join completed_source on true`,
     )

--- a/scripts/audits/tcgplayer_market_canary_verify_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_verify_v1.mjs
@@ -196,8 +196,7 @@ async function canonicalImageBuffer(printing, databaseRow) {
     };
   } catch (urlError) {
     const storageUrl = storageImageUrl(databaseRow.canonical_image_path);
-    const key =
-      process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const key = process.env.SUPABASE_SECRET_KEY;
     if (!storageUrl || !key) throw urlError;
     return {
       buffer: await fetchBuffer(storageUrl, 0, {

--- a/scripts/workers/tcgcsv_full_source_warehouse_worker_v1.mjs
+++ b/scripts/workers/tcgcsv_full_source_warehouse_worker_v1.mjs
@@ -9,6 +9,10 @@ import { fileURLToPath } from "node:url";
 import pg from "pg";
 
 import "../../backend/env.mjs";
+import {
+  isRetryableTcgcsvSourceFetchErrorV1,
+  tcgcsvSourceRetryDelayMsV1,
+} from "../../backend/pricing/tcgcsv_source_fetch_retry_policy_v1.mjs";
 
 const execFileAsync = promisify(execFile);
 const __filename = fileURLToPath(import.meta.url);
@@ -23,6 +27,8 @@ const PARSER_VERSION = "TCGCSV_FULL_SOURCE_PARSER_V1";
 const SCHEMA_CONTRACT_VERSION = "TCGCSV_FULL_SOURCE_WAREHOUSE_V1";
 const DEFAULT_REQUEST_CEILING = 10_000;
 const DEFAULT_REQUEST_DELAY_MS = 100;
+const DEFAULT_REQUEST_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 1_000;
 const DEFAULT_DIMENSION_BATCH_SIZE = 1000;
 const DEFAULT_PRICE_OBSERVATION_BATCH_SIZE = 500;
 const FIRST_ARCHIVE_DATE = "2024-02-08";
@@ -35,6 +41,16 @@ function positiveIntFromEnv(name, fallback) {
   if (raw === undefined || raw === "") return fallback;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function nonNegativeIntFromEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
   return parsed;
 }
 
@@ -64,6 +80,8 @@ function parseArgs(argv) {
     cacheDir: DEFAULT_CACHE_DIR,
     requestCeiling: Number.parseInt(process.env.TCGCSV_FULL_SYNC_REQUEST_CEILING ?? String(DEFAULT_REQUEST_CEILING), 10),
     requestDelayMs: Number.parseInt(process.env.TCGCSV_REQUEST_DELAY_MS ?? String(DEFAULT_REQUEST_DELAY_MS), 10),
+    requestRetries: nonNegativeIntFromEnv("TCGCSV_REQUEST_RETRIES", DEFAULT_REQUEST_RETRIES),
+    retryBaseDelayMs: positiveIntFromEnv("TCGCSV_RETRY_BASE_DELAY_MS", DEFAULT_RETRY_BASE_DELAY_MS),
     includeEmptyCategories: false,
     limitCategories: null,
     limitGroups: null,
@@ -86,6 +104,8 @@ function parseArgs(argv) {
     else if (arg.startsWith("--cache-dir=")) args.cacheDir = path.resolve(arg.slice("--cache-dir=".length));
     else if (arg.startsWith("--request-ceiling=")) args.requestCeiling = Number.parseInt(arg.slice("--request-ceiling=".length), 10);
     else if (arg.startsWith("--request-delay-ms=")) args.requestDelayMs = Number.parseInt(arg.slice("--request-delay-ms=".length), 10);
+    else if (arg.startsWith("--request-retries=")) args.requestRetries = Number.parseInt(arg.slice("--request-retries=".length), 10);
+    else if (arg.startsWith("--retry-base-delay-ms=")) args.retryBaseDelayMs = Number.parseInt(arg.slice("--retry-base-delay-ms=".length), 10);
     else if (arg === "--include-empty-categories") args.includeEmptyCategories = true;
     else if (arg.startsWith("--limit-categories=")) args.limitCategories = Number.parseInt(arg.slice("--limit-categories=".length), 10);
     else if (arg.startsWith("--limit-groups=")) args.limitGroups = Number.parseInt(arg.slice("--limit-groups=".length), 10);
@@ -96,6 +116,8 @@ function parseArgs(argv) {
   if (!["current", "historical"].includes(args.mode)) throw new Error("--mode must be current or historical");
   if (!Number.isInteger(args.requestCeiling) || args.requestCeiling < 1) throw new Error("--request-ceiling must be positive");
   if (!Number.isInteger(args.requestDelayMs) || args.requestDelayMs < 0) throw new Error("--request-delay-ms must be non-negative");
+  if (!Number.isInteger(args.requestRetries) || args.requestRetries < 0) throw new Error("--request-retries must be non-negative");
+  if (!Number.isInteger(args.retryBaseDelayMs) || args.retryBaseDelayMs < 1) throw new Error("--retry-base-delay-ms must be positive");
   if (args.limitCategories !== null && (!Number.isInteger(args.limitCategories) || args.limitCategories < 1)) {
     throw new Error("--limit-categories must be positive");
   }
@@ -178,22 +200,23 @@ async function sleep(ms) {
 }
 
 class Fetcher {
-  constructor({ requestCeiling, requestDelayMs, artifactRoot }) {
+  constructor({
+    requestCeiling,
+    requestDelayMs,
+    requestRetries,
+    retryBaseDelayMs,
+    artifactRoot,
+  }) {
     this.requestCeiling = requestCeiling;
     this.requestDelayMs = requestDelayMs;
+    this.requestRetries = requestRetries;
+    this.retryBaseDelayMs = retryBaseDelayMs;
     this.artifactRoot = artifactRoot;
     this.requestCount = 0;
     this.artifacts = [];
   }
 
   async fetchBuffer(url, artifactKind, relativePath, meta = {}) {
-    if (this.requestCount + 1 > this.requestCeiling) {
-      const err = new Error(`request ceiling exceeded before ${url}`);
-      err.code = "REQUEST_CEILING";
-      throw err;
-    }
-    this.requestCount += 1;
-    await sleep(this.requestDelayMs);
     const fullPath = path.join(this.artifactRoot, relativePath);
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
     const headerPath = `${fullPath}.headers`;
@@ -202,6 +225,7 @@ class Fetcher {
       "--silent",
       "--show-error",
       "--location",
+      "--fail-with-body",
       "--max-time",
       "180",
       "--user-agent",
@@ -212,7 +236,43 @@ class Fetcher {
       fullPath,
       url,
     ];
-    await execFileAsync(CURL_BIN, args, { timeout: 240_000, maxBuffer: 2 * 1024 * 1024 });
+
+    for (let retry = 0; ; retry += 1) {
+      if (this.requestCount + 1 > this.requestCeiling) {
+        const err = new Error(`request ceiling exceeded before ${url}`);
+        err.code = "REQUEST_CEILING";
+        throw err;
+      }
+      this.requestCount += 1;
+      const delayMs =
+        retry === 0
+          ? this.requestDelayMs
+          : tcgcsvSourceRetryDelayMsV1({
+              retryNumber: retry,
+              baseDelayMs: this.retryBaseDelayMs,
+              requestDelayMs: this.requestDelayMs,
+            });
+      await sleep(delayMs);
+      try {
+        await execFileAsync(CURL_BIN, args, {
+          timeout: 240_000,
+          maxBuffer: 2 * 1024 * 1024,
+        });
+        break;
+      } catch (error) {
+        if (
+          !isRetryableTcgcsvSourceFetchErrorV1(error) ||
+          retry >= this.requestRetries
+        ) {
+          error.message = `${error.message} (failed after ${retry + 1} attempts)`;
+          throw error;
+        }
+        console.error(
+          `[tcgcsv-full] transient fetch failure retry=${retry + 1}/${this.requestRetries} url=${url} error=${String(error.message).split("\n")[0]}`,
+        );
+      }
+    }
+
     const buffer = await fs.readFile(fullPath);
     const headersText = await fs.readFile(headerPath, "utf8").catch(() => "");
     const httpStatus = Number(headersText.match(/HTTP\/\S+\s+(\d+)/g)?.at(-1)?.match(/(\d+)$/)?.[1] ?? 200);
@@ -988,7 +1048,13 @@ function parseCategoryGroupFromPricePath(filePath, observedOn) {
 }
 
 async function runCurrentSync(args, runKey, artifactRoot) {
-  const fetcher = new Fetcher({ requestCeiling: args.requestCeiling, requestDelayMs: args.requestDelayMs, artifactRoot });
+  const fetcher = new Fetcher({
+    requestCeiling: args.requestCeiling,
+    requestDelayMs: args.requestDelayMs,
+    requestRetries: args.requestRetries,
+    retryBaseDelayMs: args.retryBaseDelayMs,
+    artifactRoot,
+  });
   const observedOn = isoDate();
   const startedAt = new Date().toISOString();
   const { text: sourceMarker } = await fetcher.fetchText(`${BASE_URL}/last-updated.txt`, "last_updated", "last-updated.txt");
@@ -1326,7 +1392,13 @@ async function runCurrentSync(args, runKey, artifactRoot) {
 }
 
 async function runHistoricalSync(args, runKey, artifactRoot) {
-  const fetcher = new Fetcher({ requestCeiling: args.requestCeiling, requestDelayMs: args.requestDelayMs, artifactRoot });
+  const fetcher = new Fetcher({
+    requestCeiling: args.requestCeiling,
+    requestDelayMs: args.requestDelayMs,
+    requestRetries: args.requestRetries,
+    retryBaseDelayMs: args.retryBaseDelayMs,
+    artifactRoot,
+  });
   const dates = dateRange(args.dateFrom, args.dateTo);
   const allPrices = [];
   const failedDates = [];
@@ -1498,6 +1570,9 @@ async function main() {
   console.log(`[tcgcsv-full] products=${result.run.product_count ?? 0}`);
   console.log(`[tcgcsv-full] price_rows=${result.run.price_row_count ?? 0}`);
   console.log(`[tcgcsv-full] summary=${path.relative(REPO_ROOT, summaryPath).replace(/\\/g, "/")}`);
+  if (["partial_success", "failed", "aborted_request_ceiling"].includes(result.run.status)) {
+    process.exitCode = 1;
+  }
 }
 
 await main();

--- a/tests/contracts/tcgcsv_full_source_warehouse_v1.test.mjs
+++ b/tests/contracts/tcgcsv_full_source_warehouse_v1.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
+import {
+  isRetryableTcgcsvSourceFetchErrorV1,
+  tcgcsvSourceRetryDelayMsV1,
+} from "../../backend/pricing/tcgcsv_source_fetch_retry_policy_v1.mjs";
+
 const migration = readFileSync(
   "supabase/migrations/20260715110000_tcgcsv_full_source_warehouse_v1.sql",
   "utf8",
@@ -36,6 +41,58 @@ test("TCGCSV worker defaults to dry-run and records no public pricing boundary",
   assert.match(worker, /identity_writes:\s*false/);
   assert.match(worker, /vault_writes:\s*false/);
   assert.match(worker, /app_visible_pricing:\s*false/);
+});
+
+test("TCGCSV worker retries transient source fetches and fails closed on partial ingestion", () => {
+  assert.match(worker, /DEFAULT_REQUEST_RETRIES = 3/);
+  assert.match(worker, /TCGCSV_REQUEST_RETRIES/);
+  assert.match(worker, /"--fail-with-body"/);
+  assert.match(worker, /transient fetch failure retry=/);
+  assert.match(
+    worker,
+    /\["partial_success", "failed", "aborted_request_ceiling"\]\.includes\(result\.run\.status\)/,
+  );
+  assert.match(worker, /process\.exitCode = 1/);
+});
+
+test("TCGCSV source retry policy retries transport failures but not permanent HTTP errors", () => {
+  assert.equal(
+    isRetryableTcgcsvSourceFetchErrorV1({
+      code: 35,
+      message: "curl: (35) Recv failure: Connection reset by peer",
+    }),
+    true,
+  );
+  assert.equal(
+    isRetryableTcgcsvSourceFetchErrorV1({
+      code: 22,
+      message: "The requested URL returned error: 429",
+    }),
+    true,
+  );
+  assert.equal(
+    isRetryableTcgcsvSourceFetchErrorV1({
+      code: 22,
+      message: "The requested URL returned error: 404",
+    }),
+    false,
+  );
+  assert.equal(
+    tcgcsvSourceRetryDelayMsV1({
+      retryNumber: 1,
+      baseDelayMs: 1000,
+      requestDelayMs: 100,
+    }),
+    1000,
+  );
+  assert.equal(
+    tcgcsvSourceRetryDelayMsV1({
+      retryNumber: 8,
+      baseDelayMs: 1000,
+      requestDelayMs: 100,
+    }),
+    10_000,
+  );
 });
 
 test("TCGCSV contract preserves source-only and historical archive rules", () => {


### PR DESCRIPTION
## Summary
- preserve raw source-run failure evidence in canary artifacts
- retry transient TCGCSV transport failures with bounded backoff
- count every retry against the request ceiling
- fail the warehouse process when partial ingestion remains

## Incident
The July 29 canary encountered one TCGCSV price fetch failure for category 16 / group 24389: curl 35 connection reset by peer. The worker recorded partial_success but exited zero, allowing publication to proceed before the health gate failed.

## Verification
- 160/160 targeted pricing, warehouse, and canary contracts pass
- bounded live TCGCSV dry-run: 5 requests, 0 failures, no DB writes
- Contracts Drift Gate passed: run 30471948758
- Contracts Runtime Protection passed: run 30471955085

## Boundaries
No migration, production database write, publication activation, or canary restart is included.