### PR TITLE
Repair pricing canary retry provenance and assignment runtime

### DIFF
--- a/backend/pricing/tcgcsv_source_run_resume_policy_v1.mjs
+++ b/backend/pricing/tcgcsv_source_run_resume_policy_v1.mjs
@@ -1,0 +1,57 @@
+export const TCGCSV_SOURCE_RUN_RESUME_POLICY_V1 =
+  "TCGCSV_SOURCE_RUN_RESUME_POLICY_V1";
+
+const SUCCESSFUL_TERMINAL_STATUSES = new Set([
+  "completed",
+  "skipped_no_change",
+]);
+
+export function evaluateTcgcsvSourceRunResumeV1(existingRun, expected) {
+  if (!existingRun) {
+    return {
+      action: "start",
+      policy_version: TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+      mismatches: [],
+    };
+  }
+
+  const fields = [
+    "sync_mode",
+    "git_commit_sha",
+    "worker_version",
+    "parser_version",
+    "schema_contract_version",
+  ];
+  const mismatches = fields
+    .filter((field) => existingRun[field] !== expected[field])
+    .map((field) => ({
+      field,
+      existing: existingRun[field] ?? null,
+      expected: expected[field] ?? null,
+    }));
+
+  if (mismatches.length > 0) {
+    return {
+      action: "reject",
+      policy_version: TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+      mismatches,
+    };
+  }
+
+  if (
+    SUCCESSFUL_TERMINAL_STATUSES.has(existingRun.status) &&
+    Number(existingRun.failed_count ?? 0) === 0
+  ) {
+    return {
+      action: "resume_terminal",
+      policy_version: TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+      mismatches: [],
+    };
+  }
+
+  return {
+    action: "retry",
+    policy_version: TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+    mismatches: [],
+  };
+}

--- a/docs/contracts/TCGCSV_FULL_SOURCE_WAREHOUSE_V1.md
+++ b/docs/contracts/TCGCSV_FULL_SOURCE_WAREHOUSE_V1.md
@@ -19,7 +19,9 @@ The existing Pokemon-mapped `tcgcsv_reference` lane remains unchanged. That lane
 
 ## Tables
 
-- `tcgcsv_source_sync_runs`: mutable run row for a sync/backfill execution, with status, provenance, parser versions, counts, artifact root, and errors.
+- `tcgcsv_source_sync_runs`: mutable while an execution is in progress, then
+  immutable after successful terminal completion, with status, provenance,
+  parser versions, counts, artifact root, and errors.
 - `tcgcsv_source_artifacts`: immutable artifact metadata: URL, local path, SHA-256, byte size, fetched timestamp, HTTP status, headers, run ID, category/group/date context.
 - `tcgcsv_source_categories`: latest source category dimension with `first_seen_at`, `last_seen_at`, `last_seen_run_id`, `source_active`, and `source_missing_since`.
 - `tcgcsv_source_groups`: latest source group dimension with the same disappearance fields.
@@ -61,13 +63,16 @@ The current sync checks `last-updated.txt` as an optimization, not as sole truth
 
 Current sync behavior:
 
-1. Fetch `last-updated.txt`.
-2. Fetch categories.
-3. Fetch groups for each non-empty category.
-4. Fetch products and prices for each group.
-5. Upsert latest category/group/product dimensions.
-6. Upsert current-day price observations.
-7. If the run is complete, mark dimensions not seen in the run as `missing_from_latest_source`; never delete them.
+1. If the exact run key already completed with matching code and contract
+   provenance, return that terminal result without a source request or database
+   mutation.
+2. Fetch `last-updated.txt`.
+3. Fetch categories.
+4. Fetch groups for each non-empty category.
+5. Fetch products and prices for each group.
+6. Upsert latest category/group/product dimensions.
+7. Upsert current-day price observations.
+8. If the run is complete, mark dimensions not seen in the run as `missing_from_latest_source`; never delete them.
 
 ## Historical Backfill
 
@@ -103,6 +108,9 @@ A run with some failed categories/groups is `partial_success`, not `completed`.
   exponential delay; every attempt counts against the request ceiling.
 - Exhausted fetch failures produce `partial_success` and a nonzero process
   exit so a scheduler cannot treat incomplete acquisition as successful.
+- Reusing a successful terminal run key is idempotent. The worker must preserve
+  its status, counts, artifact hash, and source-run identity.
+- Reusing a run key with changed code or contract provenance fails closed.
 - Every request uses a Grookai-specific User-Agent.
 - Historical extraction requires 7zip.
 - No writes to `pricing_observations`, `ebay_active_prices_latest`, public pricing views, identity tables, vault tables, images, or storage.

--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -155,6 +155,12 @@ tcgcsv current warehouse sync
 Apply mode requires a clean tracked worktree and records the exact producing
 commit SHA. The pipeline writes a frozen run plan, resumable phase state,
 stdout/stderr logs, summaries, reconciliation, and artifact hashes.
+Successful source run keys are immutable and same-key retries resume their
+recorded terminal result. Variant-assignment preparation is an idempotent
+single pass over the frozen source-run/date slice; it must not first rescan the
+full observation history or qualification view. The publication worker applies
+its configured database timeout to the connected database session before any
+phase executes.
 
 Ordinary operation must not require manual row approval. Ambiguous rows are
 quarantined by deterministic reason code and can be repaired as mapping policy

--- a/scripts/workers/tcgcsv_full_source_warehouse_worker_v1.mjs
+++ b/scripts/workers/tcgcsv_full_source_warehouse_worker_v1.mjs
@@ -13,6 +13,10 @@ import {
   isRetryableTcgcsvSourceFetchErrorV1,
   tcgcsvSourceRetryDelayMsV1,
 } from "../../backend/pricing/tcgcsv_source_fetch_retry_policy_v1.mjs";
+import {
+  evaluateTcgcsvSourceRunResumeV1,
+  TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+} from "../../backend/pricing/tcgcsv_source_run_resume_policy_v1.mjs";
 
 const execFileAsync = promisify(execFile);
 const __filename = fileURLToPath(import.meta.url);
@@ -436,6 +440,10 @@ async function upsertRun(client, run) {
        finished_at = excluded.finished_at,
        error = excluded.error,
        payload = excluded.payload
+     where not (
+       tcgcsv_source_sync_runs.status in ('completed', 'skipped_no_change')
+       and tcgcsv_source_sync_runs.failed_count = 0
+     )
      returning id`,
     [
       run.run_key,
@@ -466,6 +474,11 @@ async function upsertRun(client, run) {
       JSON.stringify(run.payload ?? {}),
     ],
   );
+  if (!result.rowCount) {
+    throw new Error(
+      `refusing to overwrite successful terminal source run ${run.run_key}`,
+    );
+  }
   return result.rows[0].id;
 }
 
@@ -1005,6 +1018,57 @@ async function latestCompletedCurrentMarker(client) {
   return result.rows[0]?.source_marker ?? null;
 }
 
+async function sourceRunByKey(client, runKey) {
+  const result = await client.query(
+    `select
+       sync_run.*,
+       (
+         select count(*)::integer
+         from public.tcgcsv_source_artifacts artifact
+         where artifact.run_key = sync_run.run_key
+       ) as artifact_count
+     from public.tcgcsv_source_sync_runs sync_run
+     where sync_run.run_key = $1
+     limit 1`,
+    [runKey],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function resumeSuccessfulCurrentRun(args, runKey) {
+  if (!args.apply) return null;
+
+  const client = await connectDb();
+  try {
+    const existingRun = await sourceRunByKey(client, runKey);
+    const decision = evaluateTcgcsvSourceRunResumeV1(existingRun, {
+      sync_mode: "current_full_sync",
+      git_commit_sha: await gitCommitSha(),
+      worker_version: WORKER_VERSION,
+      parser_version: PARSER_VERSION,
+      schema_contract_version: SCHEMA_CONTRACT_VERSION,
+    });
+    if (decision.action === "reject") {
+      throw new Error(
+        `resume refused because source run provenance changed: ${JSON.stringify(decision.mismatches)}`,
+      );
+    }
+    if (decision.action !== "resume_terminal") return null;
+
+    return {
+      run: existingRun,
+      summary: {
+        resumed_existing_terminal_run: true,
+        resume_policy_version: TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+      },
+      artifacts: [],
+      artifact_count: Number(existingRun.artifact_count ?? 0),
+    };
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
 async function discover7z() {
   const candidates = os.platform() === "win32" ? ["7z.exe", "7za.exe", "7zz.exe"] : ["7z", "7za", "7zz"];
   for (const candidate of candidates) {
@@ -1048,6 +1112,9 @@ function parseCategoryGroupFromPricePath(filePath, observedOn) {
 }
 
 async function runCurrentSync(args, runKey, artifactRoot) {
+  const resumedRun = await resumeSuccessfulCurrentRun(args, runKey);
+  if (resumedRun) return resumedRun;
+
   const fetcher = new Fetcher({
     requestCeiling: args.requestCeiling,
     requestDelayMs: args.requestDelayMs,
@@ -1559,7 +1626,7 @@ async function main() {
     },
     run: result.run,
     summary: result.summary,
-    artifact_count: result.artifacts.length,
+    artifact_count: result.artifact_count ?? result.artifacts.length,
   });
 
   console.log(`[tcgcsv-full] mode=${args.mode} apply=${args.apply}`);

--- a/scripts/workers/tcgplayer_market_publication_worker_v1.mjs
+++ b/scripts/workers/tcgplayer_market_publication_worker_v1.mjs
@@ -317,32 +317,6 @@ async function candidateRows(client, { limit, canaryDefinition }) {
   return result.rows;
 }
 
-async function missingVariantAssignmentCount(client, sourceRun) {
-  const result = await client.query(
-    `select count(*)::integer as missing_count
-       from public.tcgcsv_source_price_daily_observations observation
-       join public.external_mappings mapping
-         on mapping.source = 'tcgplayer'
-        and mapping.active = true
-        and mapping.external_id ~ '^[0-9]+$'
-        and mapping.external_id::integer = observation.product_id
-       left join public.market_evidence_variant_assignments assignment
-         on assignment.source_family = 'tcgcsv_market_close'
-        and assignment.source_table =
-          'tcgcsv_source_price_daily_observations'
-        and assignment.source_row_id = observation.id
-        and assignment.variant_assignment_version =
-          'MEE_MARKET_CLOSE_VARIANT_ASSIGNMENT_V1'
-      where observation.last_seen_run_id = $1
-        and observation.observed_on = $2
-        and observation.category_id = 3
-        and mapping.card_print_id is not null
-        and assignment.id is null`,
-    [sourceRun.id, sourceRun.observed_on],
-  );
-  return Number(result.rows[0].missing_count);
-}
-
 function buildCandidate(row, runId) {
   return {
     run_id: runId,
@@ -1357,40 +1331,19 @@ async function runDurable(client, args, sourceRun, runPlan) {
       sourceRun,
       phaseName: "prepare_variant_assignments",
       operation: async () => {
-        const missingCount = await missingVariantAssignmentCount(
-          client,
-          sourceRun,
-        );
-        if (missingCount === 0) {
-          return {
-            input_count: 0,
-            output_count: 0,
-            reconciled_count: 0,
-            resumability_data: {
-              source_sync_run_id: sourceRun.id,
-              missing_assignment_count: 0,
-              skipped_expensive_prepare: true,
-            },
-          };
-        }
         const result = await client.query(
           `select public.prepare_tcgplayer_market_variant_assignments_v1($1) as inserted_count`,
           [sourceRun.id],
         );
         const insertedCount = Number(result.rows[0].inserted_count);
-        if (insertedCount !== missingCount) {
-          throw new Error(
-            `variant assignment preparation mismatch missing=${missingCount} inserted=${insertedCount}`,
-          );
-        }
         return {
-          input_count: missingCount,
+          input_count: insertedCount,
           output_count: insertedCount,
           reconciled_count: insertedCount,
           resumability_data: {
             source_sync_run_id: sourceRun.id,
-            missing_assignment_count: missingCount,
-            skipped_expensive_prepare: false,
+            inserted_assignment_count: insertedCount,
+            idempotent_prepare_no_op: insertedCount === 0,
           },
         };
       },
@@ -1597,6 +1550,10 @@ async function main() {
     statement_timeout: args.databaseTimeoutMinutes * 60 * 1000,
   });
   await client.connect();
+  await client.query(
+    "select set_config('statement_timeout', $1, false)",
+    [`${args.databaseTimeoutMinutes}min`],
+  );
   try {
     const sourceRun = await latestSourceRun(client);
     const runPlan = {

--- a/supabase/migrations/20260729190000_tcgplayer_market_assignment_prepare_runtime_repair_v1.sql
+++ b/supabase/migrations/20260729190000_tcgplayer_market_assignment_prepare_runtime_repair_v1.sql
@@ -1,0 +1,182 @@
+begin;
+
+create or replace function public.prepare_tcgplayer_market_variant_assignments_v1(
+  p_source_sync_run_id uuid
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+set enable_nestloop = off
+as $$
+declare
+  inserted_count integer;
+  source_observed_on date;
+begin
+  select source_run.observed_on
+    into source_observed_on
+  from public.tcgcsv_source_sync_runs source_run
+  where source_run.id = p_source_sync_run_id
+    and source_run.sync_mode = 'current_full_sync'
+    and source_run.status = 'completed'
+    and source_run.failed_count = 0
+    and source_run.finished_at is not null;
+
+  if source_observed_on is null then
+    raise exception
+      'source sync run % is not a reconciled completed current run',
+      p_source_sync_run_id;
+  end if;
+
+  insert into public.market_evidence_variant_assignments (
+    contract_version,
+    source_family,
+    source_table,
+    source_row_id,
+    observation_id,
+    raw_snapshot_id,
+    card_print_id,
+    gv_id,
+    card_printing_id,
+    printing_gv_id,
+    source_finish_hint,
+    normalized_finish_key,
+    assigned_finish_key,
+    variant_assignment_status,
+    variant_assignment_confidence,
+    variant_assignment_version,
+    variant_assignment_reason,
+    variant_assignment_flags,
+    assignment_payload,
+    needs_review,
+    publishable,
+    app_visible,
+    market_truth
+  )
+  with source_observations as materialized (
+    select
+      observation.id as source_observation_id,
+      observation.source_artifact_id,
+      observation.product_id as source_product_id,
+      observation.subtype_name as source_subtype_name,
+      public.normalize_tcgplayer_market_subtype_v1(
+        observation.subtype_name
+      ) as normalized_finish_key
+    from public.tcgcsv_source_price_daily_observations observation
+    where observation.last_seen_run_id = p_source_sync_run_id
+      and observation.category_id = 3
+      and observation.observed_on = source_observed_on
+  ),
+  mapped as (
+    select
+      observation.*,
+      source_mapping.id as source_mapping_id,
+      source_mapping.card_print_id,
+      card.gv_id,
+      printing.id as card_printing_id,
+      printing.printing_gv_id,
+      printing.finish_key,
+      case
+        when observation.normalized_finish_key is null
+          then 'unknown_finish_needs_review'
+        when printing.id is not null
+          then 'exact_child_finish'
+        else 'no_matching_child_finish'
+      end as derived_variant_assignment_status
+    from source_observations observation
+    join public.external_mappings source_mapping
+      on source_mapping.source = 'tcgplayer'
+     and source_mapping.active = true
+     and source_mapping.external_id =
+       observation.source_product_id::text
+     and source_mapping.card_print_id is not null
+    join public.card_prints card
+      on card.id = source_mapping.card_print_id
+    left join public.card_printings printing
+      on printing.card_print_id = card.id
+     and printing.finish_key = observation.normalized_finish_key
+  )
+  select
+    'MARKET_EVIDENCE_VARIANT_ASSIGNMENT_V1',
+    'tcgcsv_market_close',
+    'tcgcsv_source_price_daily_observations',
+    candidate.source_observation_id,
+    candidate.source_observation_id,
+    candidate.source_artifact_id,
+    candidate.card_print_id,
+    candidate.gv_id,
+    case
+      when candidate.derived_variant_assignment_status = 'exact_child_finish'
+        then candidate.card_printing_id
+      else null
+    end,
+    case
+      when candidate.derived_variant_assignment_status = 'exact_child_finish'
+        then candidate.printing_gv_id
+      else null
+    end,
+    candidate.source_subtype_name,
+    candidate.normalized_finish_key,
+    case
+      when candidate.derived_variant_assignment_status = 'exact_child_finish'
+        then candidate.finish_key
+      else null
+    end,
+    candidate.derived_variant_assignment_status,
+    case
+      when candidate.derived_variant_assignment_status = 'exact_child_finish'
+        then 1.0000
+      else 0.0000
+    end,
+    'MEE_MARKET_CLOSE_VARIANT_ASSIGNMENT_V1',
+    case candidate.derived_variant_assignment_status
+      when 'exact_child_finish'
+        then 'ordinary source subtype resolved to one exact canonical child finish'
+      when 'unknown_finish_needs_review'
+        then 'source subtype is not an approved ordinary finish'
+      else 'approved source subtype did not resolve to one exact canonical child finish'
+    end,
+    case
+      when candidate.derived_variant_assignment_status = 'exact_child_finish'
+        then '{}'::text[]
+      else array[candidate.derived_variant_assignment_status]::text[]
+    end,
+    jsonb_build_object(
+      'source_mapping_id', candidate.source_mapping_id,
+      'source_product_id', candidate.source_product_id,
+      'source_subtype_name', candidate.source_subtype_name,
+      'source_observation_id', candidate.source_observation_id
+    ),
+    candidate.derived_variant_assignment_status <> 'exact_child_finish',
+    false,
+    false,
+    false
+  from mapped candidate
+  where not exists (
+    select 1
+    from public.market_evidence_variant_assignments assignment
+    where assignment.source_family = 'tcgcsv_market_close'
+      and assignment.source_row_id = candidate.source_observation_id
+      and assignment.variant_assignment_version =
+        'MEE_MARKET_CLOSE_VARIANT_ASSIGNMENT_V1'
+  )
+  on conflict (
+    source_family,
+    source_row_id,
+    variant_assignment_version
+  ) do nothing;
+
+  get diagnostics inserted_count = row_count;
+  return inserted_count;
+end;
+$$;
+
+revoke all on function public.prepare_tcgplayer_market_variant_assignments_v1(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function public.prepare_tcgplayer_market_variant_assignments_v1(uuid)
+  to service_role;
+
+comment on function public.prepare_tcgplayer_market_variant_assignments_v1(uuid) is
+  'Prepares missing TCGCSV market-close assignments from one materialized source-run slice; repeated calls are idempotent and do not rescan the qualification view.';
+
+commit;

--- a/tests/contracts/tcgcsv_full_source_warehouse_v1.test.mjs
+++ b/tests/contracts/tcgcsv_full_source_warehouse_v1.test.mjs
@@ -6,6 +6,10 @@ import {
   isRetryableTcgcsvSourceFetchErrorV1,
   tcgcsvSourceRetryDelayMsV1,
 } from "../../backend/pricing/tcgcsv_source_fetch_retry_policy_v1.mjs";
+import {
+  evaluateTcgcsvSourceRunResumeV1,
+  TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+} from "../../backend/pricing/tcgcsv_source_run_resume_policy_v1.mjs";
 
 const migration = readFileSync(
   "supabase/migrations/20260715110000_tcgcsv_full_source_warehouse_v1.sql",
@@ -53,6 +57,84 @@ test("TCGCSV worker retries transient source fetches and fails closed on partial
     /\["partial_success", "failed", "aborted_request_ceiling"\]\.includes\(result\.run\.status\)/,
   );
   assert.match(worker, /process\.exitCode = 1/);
+});
+
+test("TCGCSV worker resumes an identical successful run key without mutating it", () => {
+  const expected = {
+    sync_mode: "current_full_sync",
+    git_commit_sha: "abc123",
+    worker_version: "TCGCSV_FULL_SOURCE_WAREHOUSE_WORKER_V1",
+    parser_version: "TCGCSV_FULL_SOURCE_PARSER_V1",
+    schema_contract_version: "TCGCSV_FULL_SOURCE_WAREHOUSE_V1",
+  };
+  const decision = evaluateTcgcsvSourceRunResumeV1(
+    {
+      ...expected,
+      status: "completed",
+      failed_count: 0,
+    },
+    expected,
+  );
+
+  assert.equal(decision.action, "resume_terminal");
+  assert.equal(
+    decision.policy_version,
+    TCGCSV_SOURCE_RUN_RESUME_POLICY_V1,
+  );
+  assert.match(worker, /resumed_existing_terminal_run:\s*true/);
+  assert.match(
+    worker,
+    /where not \(\s*tcgcsv_source_sync_runs\.status in \('completed', 'skipped_no_change'\)/,
+  );
+  assert.match(worker, /refusing to overwrite successful terminal source run/);
+});
+
+test("TCGCSV worker rejects successful run-key reuse with changed provenance", () => {
+  const expected = {
+    sync_mode: "current_full_sync",
+    git_commit_sha: "new-sha",
+    worker_version: "TCGCSV_FULL_SOURCE_WAREHOUSE_WORKER_V1",
+    parser_version: "TCGCSV_FULL_SOURCE_PARSER_V1",
+    schema_contract_version: "TCGCSV_FULL_SOURCE_WAREHOUSE_V1",
+  };
+  const decision = evaluateTcgcsvSourceRunResumeV1(
+    {
+      ...expected,
+      git_commit_sha: "old-sha",
+      status: "completed",
+      failed_count: 0,
+    },
+    expected,
+  );
+
+  assert.equal(decision.action, "reject");
+  assert.deepEqual(decision.mismatches, [
+    {
+      field: "git_commit_sha",
+      existing: "old-sha",
+      expected: "new-sha",
+    },
+  ]);
+});
+
+test("TCGCSV worker may retry a nonterminal or failed run with matching provenance", () => {
+  const expected = {
+    sync_mode: "current_full_sync",
+    git_commit_sha: "abc123",
+    worker_version: "TCGCSV_FULL_SOURCE_WAREHOUSE_WORKER_V1",
+    parser_version: "TCGCSV_FULL_SOURCE_PARSER_V1",
+    schema_contract_version: "TCGCSV_FULL_SOURCE_WAREHOUSE_V1",
+  };
+  const decision = evaluateTcgcsvSourceRunResumeV1(
+    {
+      ...expected,
+      status: "partial_success",
+      failed_count: 1,
+    },
+    expected,
+  );
+
+  assert.equal(decision.action, "retry");
 });
 
 test("TCGCSV source retry policy retries transport failures but not permanent HTTP errors", () => {

--- a/tests/contracts/tcgplayer_market_publication_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_publication_v1.test.mjs
@@ -49,6 +49,15 @@ const ASSIGNMENT_IDEMPOTENCY_MIGRATION = readFileSync(
   ),
   "utf8",
 );
+const ASSIGNMENT_RUNTIME_REPAIR_MIGRATION = readFileSync(
+  path.join(
+    ROOT,
+    "supabase",
+    "migrations",
+    "20260729190000_tcgplayer_market_assignment_prepare_runtime_repair_v1.sql",
+  ),
+  "utf8",
+);
 const WORKER = readFileSync(
   path.join(
     ROOT,
@@ -642,7 +651,7 @@ test("qualification candidate view avoids a redundant wide aggregation", () => {
   assert.doesNotMatch(CANDIDATE_PERFORMANCE_MIGRATION, /\barray_agg\s*\(/i);
 });
 
-test("variant assignment preparation skips rows already assigned", () => {
+test("variant assignment preparation uses one idempotent materialized run slice", () => {
   assert.match(
     ASSIGNMENT_IDEMPOTENCY_MIGRATION,
     /create or replace function public\.prepare_tcgplayer_market_variant_assignments_v1/i,
@@ -656,16 +665,35 @@ test("variant assignment preparation skips rows already assigned", () => {
     /on conflict \(\s*source_family,\s*source_row_id,\s*variant_assignment_version\s*\) do nothing/i,
   );
   assert.match(
-    WORKER,
-    /async function missingVariantAssignmentCount\(client, sourceRun\)/,
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /source_observations as materialized/i,
   );
-  assert.match(WORKER, /and assignment\.id is null/);
-  assert.match(WORKER, /if \(missingCount === 0\)/);
-  assert.match(WORKER, /skipped_expensive_prepare: true/);
   assert.match(
-    WORKER,
-    /variant assignment preparation mismatch missing=\$\{missingCount\} inserted=\$\{insertedCount\}/,
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /observation\.last_seen_run_id = p_source_sync_run_id/i,
   );
+  assert.match(
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /observation\.observed_on = source_observed_on/i,
+  );
+  assert.match(
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /set enable_nestloop = off/i,
+  );
+  assert.match(
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /source_mapping\.external_id =\s*observation\.source_product_id::text/i,
+  );
+  assert.match(
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /where not exists \([\s\S]*assignment\.source_row_id = candidate\.source_observation_id/i,
+  );
+  assert.match(
+    ASSIGNMENT_RUNTIME_REPAIR_MIGRATION,
+    /on conflict \(\s*source_family,\s*source_row_id,\s*variant_assignment_version\s*\) do nothing/i,
+  );
+  assert.doesNotMatch(WORKER, /missingVariantAssignmentCount/);
+  assert.match(WORKER, /idempotent_prepare_no_op: insertedCount === 0/);
 });
 
 test("signed-in clients receive a shared contract while provenance stays service-only", () => {
@@ -793,6 +821,11 @@ test("publication database timeout covers measured assignment preparation", () =
     WORKER,
     /statement_timeout: args\.databaseTimeoutMinutes \* 60 \* 1000/,
   );
+  assert.match(
+    WORKER,
+    /select set_config\('statement_timeout', \$1, false\)/,
+  );
+  assert.match(WORKER, /\[`?\$\{args\.databaseTimeoutMinutes\}min`?\]/);
   assert.match(
     WORKER,
     /database_timeout_minutes: args\.databaseTimeoutMinutes/,


### PR DESCRIPTION
## Summary
- make successful TCGCSV source run keys immutable and resumable without refetch or mutation
- replace the publication assignment precheck plus full candidate-view scan with one idempotent materialized source-run preparation function
- force the repaired function away from the misestimated nested-loop plan and apply the configured publication timeout to the live DB session
- document and test the new operational invariants

## Incident evidence
The July 29 repair activation fetched all source payloads successfully, then failed in `prepare_variant_assignments`. Its same-key retry changed the completed source run to `skipped_no_change`, so publication rejected the frozen source-run provenance.

Production plan evidence showed 1.1B anti-join comparisons caused by a one-row planner estimate. The repaired hash plan completed the equivalent read in 3.856s.

A rollback-only production proof prepared 33,432 missing assignments in 15.510s and reconciled all 33,432 before rollback. A second rollback-only replay returned 0 inserts in 11.365s. Post-rollback readback confirmed the incident source row and assignment table were unchanged.

## Validation
- `node --check` for both workers
- targeted pricing/warehouse contracts: 45/45
- full contract suite: 879/879
- runtime health: pass
- release secret packaging guard: pass
- no-legacy-key guard: pass
- `git diff --check`: pass
- migration compile: production transaction rolled back

No canary restart or persistent production write is included in this PR.