### PR TITLE
Repair pricing canary governed read runtime

### DIFF
--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -197,6 +197,13 @@ An incomplete time window is `observing`, not passed. A missing elapsed schedule
 slot, broken trace, stale value, access-boundary regression, terminal alert, or
 run mismatch fails the gate.
 
+The observer must create and hash its frozen run plan before connecting to the
+database. A connection or query failure must still preserve a machine-readable
+`summary.json`, exact `failure.json`, human-readable report, failure stage, safe
+database error metadata, and artifact hashes. Observer failures remain
+read-only and must not be reported as pipeline publication failures without
+separate pipeline evidence.
+
 ## Health Gates
 
 Production health is critical when:
@@ -337,6 +344,10 @@ but they must not be described as end-user JWT measurements. A separate direct
 database proof must execute the same RPC under the `authenticated` role.
 
 The shared customer RPC must never aggregate the raw active-listing warehouse.
+Parent-summary reads must materialize the governed current publication once and
+reuse that bounded row set for deterministic parent ranking and active-ask
+aggregation; they must not independently expand the historical current-price
+view for each calculation.
 Exact-printing eBay active asks are maintained in
 `mv_market_listing_active_ask_current_v1` by a separately governed refresh
 phase. Refresh failures fail the activation pipeline closed, while shadow and

--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -117,7 +117,94 @@ function sha256(buffer) {
   return createHash("sha256").update(buffer).digest("hex");
 }
 
-async function queryEvidence(client, args, asOf) {
+function serializeError(error) {
+  return {
+    name: error?.name ?? "Error",
+    code: error?.code ?? null,
+    message: error?.message ?? String(error),
+  };
+}
+
+export function buildTcgplayerMarketCanaryRunPlanV1(args, asOf) {
+  return {
+    audit_version: AUDIT_VERSION,
+    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V1,
+    window_start: args.windowStart,
+    activation_run_id: args.activationRunId,
+    expected_commit_sha: args.expectedCommitSha,
+    as_of: asOf,
+    required_hours: args.requiredHours,
+    expected_count: args.expectedCount,
+    schedule_tolerance_minutes: args.scheduleToleranceMinutes,
+    boundaries: {
+      database_reads_only: true,
+      database_writes: false,
+      publication_activation: false,
+      grant_changes: false,
+    },
+  };
+}
+
+export async function writeTcgplayerMarketCanaryArtifactsV1(
+  runDir,
+  files,
+  existingHashes = {},
+) {
+  await fs.mkdir(runDir, { recursive: true });
+  const hashes = { ...existingHashes };
+  for (const [name, contents] of Object.entries(files)) {
+    await fs.writeFile(path.join(runDir, name), contents);
+    hashes[name] = sha256(Buffer.from(contents));
+  }
+  await fs.writeFile(
+    path.join(runDir, "artifact_hashes.json"),
+    `${JSON.stringify(hashes, null, 2)}\n`,
+  );
+  return hashes;
+}
+
+export function buildTcgplayerMarketCanaryFailureArtifactsV1({
+  runPlan,
+  stage,
+  error,
+  failedAt = new Date().toISOString(),
+}) {
+  const failure = {
+    audit_version: AUDIT_VERSION,
+    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V1,
+    status: "observer_error",
+    failed_at: failedAt,
+    stage,
+    error: serializeError(error),
+    window: {
+      started_at: runPlan.window_start,
+      as_of: runPlan.as_of,
+    },
+    boundaries: runPlan.boundaries,
+  };
+  const report = [
+    "# TCGPlayer Market Canary Observation Failure",
+    "",
+    `- Status: \`${failure.status}\``,
+    `- Stage: \`${failure.stage}\``,
+    `- Error code: \`${failure.error.code ?? "unavailable"}\``,
+    `- Error: ${failure.error.message}`,
+    `- Failed at: \`${failure.failed_at}\``,
+    "",
+    "The observer failed closed. No database writes, publication activation,",
+    "or grant changes were attempted.",
+    "",
+  ].join("\n");
+  const serialized = `${JSON.stringify(failure, null, 2)}\n`;
+  return {
+    "failure.json": serialized,
+    "summary.json": serialized,
+    "REPORT.md": `${report}\n`,
+  };
+}
+
+async function queryEvidence(client, args, asOf, onStage = () => {}) {
+  onStage("activation_run_read");
   const activationRun = (
     await client.query(
       `select *
@@ -127,6 +214,7 @@ async function queryEvidence(client, args, asOf) {
     )
   ).rows[0] ?? null;
 
+  onStage("scheduled_runs_read");
   const scheduledRuns = (
     await client.query(
       `select *
@@ -140,6 +228,7 @@ async function queryEvidence(client, args, asOf) {
     )
   ).rows;
 
+  onStage("terminal_alerts_read");
   const terminalAlerts = (
     await client.query(
       `select notification_id, event_type, severity, source_unit,
@@ -154,6 +243,7 @@ async function queryEvidence(client, args, asOf) {
     )
   ).rows;
 
+  onStage("current_read_model_read");
   const current = (
     await client.query(
       `with totals as (
@@ -198,6 +288,7 @@ async function queryEvidence(client, args, asOf) {
     )
   ).rows[0];
 
+  onStage("source_health_read");
   const sourceMetrics = (
     await client.query(
       `with latest_source as (
@@ -252,6 +343,7 @@ async function queryEvidence(client, args, asOf) {
     findings: sourceEvaluation.findings,
   };
 
+  onStage("access_grants_read");
   const grants = (
     await client.query(
       `select
@@ -274,6 +366,7 @@ async function queryEvidence(client, args, asOf) {
   ).rows[0];
 
   let authenticatedReadCount = 0;
+  onStage("authenticated_governed_read");
   await client.query("set role authenticated");
   try {
     authenticatedReadCount = Number(
@@ -291,6 +384,7 @@ async function queryEvidence(client, args, asOf) {
 
   let anonymousRuntimeDenied = false;
   let anonymousRuntimeCode = null;
+  onStage("anonymous_governed_read");
   await client.query("set role anon");
   try {
     await client.query(
@@ -385,16 +479,32 @@ async function main() {
   const asOf = args.asOf
     ? new Date(args.asOf).toISOString()
     : new Date().toISOString();
-  const client = new Client({
-    connectionString: url,
-    ssl: sslConfig(url),
-    connectionTimeoutMillis: 15_000,
-    statement_timeout: 120_000,
-    query_timeout: 120_000,
-  });
-  await client.connect();
+  const runDir = path.join(args.outRoot, stamp());
+  const runPlan = buildTcgplayerMarketCanaryRunPlanV1(args, asOf);
+  let artifactHashes = await writeTcgplayerMarketCanaryArtifactsV1(
+    runDir,
+    { "run_plan.json": `${JSON.stringify(runPlan, null, 2)}\n` },
+  );
+  let stage = "database_connect";
+  let client = null;
   try {
-    const evidence = await queryEvidence(client, args, asOf);
+    client = new Client({
+      connectionString: url,
+      ssl: sslConfig(url),
+      connectionTimeoutMillis: 15_000,
+      statement_timeout: 120_000,
+      query_timeout: 120_000,
+    });
+    await client.connect();
+    const evidence = await queryEvidence(
+      client,
+      args,
+      asOf,
+      (nextStage) => {
+        stage = nextStage;
+      },
+    );
+    stage = "policy_evaluation";
     const report = evaluateTcgplayerMarketCanaryObservationV1({
       windowStart: args.windowStart,
       asOf,
@@ -405,40 +515,16 @@ async function main() {
       ...evidence,
     });
 
-    const runDir = path.join(args.outRoot, stamp());
-    await fs.mkdir(runDir, { recursive: true });
-    const runPlan = {
-      audit_version: AUDIT_VERSION,
-      policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V1,
-      window_start: args.windowStart,
-      activation_run_id: args.activationRunId,
-      expected_commit_sha: args.expectedCommitSha,
-      as_of: asOf,
-      required_hours: args.requiredHours,
-      expected_count: args.expectedCount,
-      schedule_tolerance_minutes: args.scheduleToleranceMinutes,
-      boundaries: {
-        database_reads_only: true,
-        database_writes: false,
-        publication_activation: false,
-        grant_changes: false,
-      },
-    };
+    stage = "artifact_write";
     const files = {
-      "run_plan.json": `${JSON.stringify(runPlan, null, 2)}\n`,
       "evidence.json": `${JSON.stringify(evidence, null, 2)}\n`,
       "summary.json": `${JSON.stringify(report, null, 2)}\n`,
       "REPORT.md": markdown(report),
     };
-    const hashes = {};
-    for (const [name, contents] of Object.entries(files)) {
-      const filePath = path.join(runDir, name);
-      await fs.writeFile(filePath, contents);
-      hashes[name] = sha256(Buffer.from(contents));
-    }
-    await fs.writeFile(
-      path.join(runDir, "artifact_hashes.json"),
-      `${JSON.stringify(hashes, null, 2)}\n`,
+    artifactHashes = await writeTcgplayerMarketCanaryArtifactsV1(
+      runDir,
+      files,
+      artifactHashes,
     );
 
     process.stdout.write(
@@ -455,12 +541,36 @@ async function main() {
     );
     if (report.status === "failed") process.exitCode = 1;
     if (args.requirePass && report.status !== "passed") process.exitCode = 1;
+  } catch (error) {
+    const failureFiles = buildTcgplayerMarketCanaryFailureArtifactsV1({
+      runPlan,
+      stage,
+      error,
+    });
+    await writeTcgplayerMarketCanaryArtifactsV1(
+      runDir,
+      failureFiles,
+      artifactHashes,
+    );
+    error.artifactRoot = path
+      .relative(REPO_ROOT, runDir)
+      .replace(/\\/g, "/");
+    throw error;
   } finally {
-    await client.end().catch(() => {});
+    await client?.end().catch(() => {});
   }
 }
 
-main().catch((error) => {
-  console.error(`[market-canary-observation] ${error.stack || error.message}`);
-  process.exitCode = 1;
-});
+if (path.resolve(process.argv[1] ?? "") === __filename) {
+  main().catch((error) => {
+    console.error(
+      `[market-canary-observation] ${error.stack || error.message}`,
+    );
+    if (error.artifactRoot) {
+      console.error(
+        `[market-canary-observation] failure artifacts: ${error.artifactRoot}`,
+      );
+    }
+    process.exitCode = 1;
+  });
+}

--- a/supabase/migrations/20260730180000_tcgplayer_market_parent_summary_runtime_repair_v1.sql
+++ b/supabase/migrations/20260730180000_tcgplayer_market_parent_summary_runtime_repair_v1.sql
@@ -1,0 +1,69 @@
+-- TCGPlayer Market Product V1 parent-summary runtime repair.
+--
+-- The parent summary expanded v_market_price_current_v1 twice: once for the
+-- deterministic parent-price rank and once for active-ask aggregation. On the
+-- production history volume, PostgreSQL selected a plan that exceeded both the
+-- product and canary-observer statement timeouts. Materialize the already
+-- governed current publication once and reuse that bounded row set.
+
+create or replace view public.v_market_price_parent_summary_v1 as
+with current_prices as materialized (
+  select *
+  from public.v_market_price_current_v1
+),
+ranked_parent_prices as materialized (
+  select
+    current_price.*,
+    count(*) over (
+      partition by current_price.card_print_id
+    )::integer as eligible_printing_count,
+    row_number() over (
+      partition by current_price.card_print_id
+      order by
+        current_price.market_price asc,
+        current_price.published_at desc,
+        current_price.observed_at desc,
+        current_price.card_printing_id asc
+    ) as parent_price_rank
+  from current_prices current_price
+),
+parent_active_asks as materialized (
+  select
+    current_price.card_print_id,
+    min(active_ask.lowest_active_ask)::numeric as lowest_active_ask,
+    sum(coalesce(active_ask.listing_count, 0))::integer
+      as active_ask_listing_count,
+    max(active_ask.observed_at) as active_ask_observed_at
+  from current_prices current_price
+  left join public.mv_market_listing_active_ask_current_v1 active_ask
+    on active_ask.card_printing_id = current_price.card_printing_id
+  group by current_price.card_print_id
+)
+select
+  selected.card_print_id,
+  selected.gv_id,
+  selected.currency,
+  selected.market_price::numeric as market_close,
+  selected.eligible_printing_count,
+  (selected.eligible_printing_count > 1) as is_from_price,
+  selected.observed_at,
+  selected.freshness,
+  selected.provenance_id,
+  active_ask.lowest_active_ask,
+  active_ask.active_ask_listing_count,
+  active_ask.active_ask_observed_at,
+  selected.card_printing_id,
+  selected.printing_gv_id,
+  selected.finish_key,
+  selected.published_at
+from ranked_parent_prices selected
+left join parent_active_asks active_ask
+  on active_ask.card_print_id = selected.card_print_id
+where selected.parent_price_rank = 1;
+
+revoke all on public.v_market_price_parent_summary_v1
+  from public, anon, authenticated;
+grant select on public.v_market_price_parent_summary_v1 to service_role;
+
+comment on view public.v_market_price_parent_summary_v1 is
+  'Service-role parent summary grounded in one materialized current-publication read. Parent price is the deterministic minimum eligible exact printing; active asks come from the background-refreshed exact-printing materialized view.';

--- a/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -6,6 +9,11 @@ import {
   expectedTcgplayerMarketScheduleSlotsV1,
   TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V1,
 } from "../../backend/pricing/tcgplayer_market_canary_observation_policy_v1.mjs";
+import {
+  buildTcgplayerMarketCanaryFailureArtifactsV1,
+  buildTcgplayerMarketCanaryRunPlanV1,
+  writeTcgplayerMarketCanaryArtifactsV1,
+} from "../../scripts/audits/tcgplayer_market_canary_observation_v1.mjs";
 
 const WINDOW_START = "2026-07-28T08:40:15.793Z";
 const COMMIT = "c0cdce5500c96cdc5b1d689e5178d9fa4e117e1d";
@@ -197,4 +205,66 @@ test("stale prices, broken access, and unavailable rollback fail closed", () => 
     result.findings.includes("anonymous_pricing_execute_unexpectedly_granted"),
   );
   assert.ok(result.findings.includes("publication_rollback_not_available"));
+});
+
+test("observer query failures preserve a run plan, summary, failure, and hashes", async () => {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), "market-canary-observer-failure-"),
+  );
+  try {
+    const runPlan = buildTcgplayerMarketCanaryRunPlanV1(
+      {
+        windowStart: WINDOW_START,
+        activationRunId: "activation",
+        expectedCommitSha: COMMIT,
+        requiredHours: 72,
+        expectedCount: 100,
+        scheduleToleranceMinutes: 90,
+      },
+      "2026-07-30T14:34:51.000Z",
+    );
+    let hashes = await writeTcgplayerMarketCanaryArtifactsV1(root, {
+      "run_plan.json": `${JSON.stringify(runPlan, null, 2)}\n`,
+    });
+    const error = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    hashes = await writeTcgplayerMarketCanaryArtifactsV1(
+      root,
+      buildTcgplayerMarketCanaryFailureArtifactsV1({
+        runPlan,
+        stage: "authenticated_governed_read",
+        error,
+        failedAt: "2026-07-30T14:34:51.000Z",
+      }),
+      hashes,
+    );
+
+    const summary = JSON.parse(
+      await fs.readFile(path.join(root, "summary.json"), "utf8"),
+    );
+    const failure = JSON.parse(
+      await fs.readFile(path.join(root, "failure.json"), "utf8"),
+    );
+    const storedHashes = JSON.parse(
+      await fs.readFile(path.join(root, "artifact_hashes.json"), "utf8"),
+    );
+
+    assert.equal(summary.status, "observer_error");
+    assert.equal(summary.stage, "authenticated_governed_read");
+    assert.equal(summary.error.code, "57014");
+    assert.deepEqual(summary, failure);
+    assert.deepEqual(storedHashes, hashes);
+    assert.deepEqual(Object.keys(storedHashes).sort(), [
+      "REPORT.md",
+      "failure.json",
+      "run_plan.json",
+      "summary.json",
+    ]);
+    assert.equal(runPlan.boundaries.database_reads_only, true);
+    assert.equal(runPlan.boundaries.database_writes, false);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });

--- a/tests/contracts/tcgplayer_market_parent_summary_runtime_repair_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_parent_summary_runtime_repair_v1.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "..", "..");
+const MIGRATION = readFileSync(
+  path.join(
+    ROOT,
+    "supabase/migrations/20260730180000_tcgplayer_market_parent_summary_runtime_repair_v1.sql",
+  ),
+  "utf8",
+);
+
+test("parent summary materializes the governed current publication once", () => {
+  assert.match(
+    MIGRATION,
+    /current_prices as materialized\s*\(\s*select \*\s*from public\.v_market_price_current_v1\s*\)/i,
+  );
+  assert.equal(
+    (
+      MIGRATION.match(
+        /from public\.v_market_price_current_v1/gi,
+      ) ?? []
+    ).length,
+    1,
+  );
+  assert.match(
+    MIGRATION,
+    /ranked_parent_prices as materialized[\s\S]*from current_prices current_price/i,
+  );
+  assert.match(
+    MIGRATION,
+    /parent_active_asks as materialized[\s\S]*from current_prices current_price/i,
+  );
+});
+
+test("runtime repair preserves deterministic parent-price semantics", () => {
+  assert.match(
+    MIGRATION,
+    /count\(\*\) over \(\s*partition by current_price\.card_print_id\s*\)::integer as eligible_printing_count/i,
+  );
+  assert.match(
+    MIGRATION,
+    /row_number\(\) over \(\s*partition by current_price\.card_print_id\s*order by\s*current_price\.market_price asc,\s*current_price\.published_at desc,\s*current_price\.observed_at desc,\s*current_price\.card_printing_id asc\s*\) as parent_price_rank/i,
+  );
+  assert.match(MIGRATION, /where selected\.parent_price_rank = 1/i);
+  assert.match(
+    MIGRATION,
+    /selected\.market_price::numeric as market_close/i,
+  );
+  assert.doesNotMatch(
+    MIGRATION,
+    /\b(?:avg|max)\s*\(\s*current_price\.market_price/i,
+  );
+});
+
+test("runtime repair preserves traced exact identity and active-ask source", () => {
+  assert.match(
+    MIGRATION,
+    /selected\.provenance_id,[\s\S]*selected\.card_printing_id,[\s\S]*selected\.printing_gv_id,[\s\S]*selected\.finish_key,[\s\S]*selected\.published_at/i,
+  );
+  assert.match(
+    MIGRATION,
+    /left join public\.mv_market_listing_active_ask_current_v1 active_ask/i,
+  );
+  assert.doesNotMatch(
+    MIGRATION,
+    /v_market_listing_variant_active_ask_exact_v1/i,
+  );
+});
+
+test("runtime repair retains service-only parent-summary access", () => {
+  assert.match(
+    MIGRATION,
+    /revoke all on public\.v_market_price_parent_summary_v1\s+from public, anon, authenticated/i,
+  );
+  assert.match(
+    MIGRATION,
+    /grant select on public\.v_market_price_parent_summary_v1 to service_role/i,
+  );
+  assert.doesNotMatch(
+    MIGRATION,
+    /grant select on public\.v_market_price_parent_summary_v1 to (?:public|anon|authenticated)/i,
+  );
+});


### PR DESCRIPTION
## Summary
- materialize the governed current-price publication once inside the parent summary instead of expanding the historical view twice
- preserve the existing parent-price ranking, exact-printing provenance, active-ask source, RPC signature, and access grants
- make the canary observer write its frozen run plan before database reads and preserve summary/failure/report/hash artifacts on query errors

## Production incident evidence
- `v_market_price_current_v1` returned all 100 active rows in 382 ms through the production REST interface
- `v_market_price_parent_summary_v1?limit=1` failed with PostgreSQL `57014` after 8.4 seconds
- `get_top_market_pricing_v1(1)` failed with the same `57014` after 8.6 seconds
- scheduled Actions runs `30528232819` and `30552137442` both timed out at the authenticated governed RPC read

## Validation
- focused pricing and observer contracts: 22/22
- full contract suite: 884/884
- runtime protection: pass
- release secret guard: pass
- migration compile and RPC resolution: pass in a rollback-only local PostgreSQL transaction
- `node --check`: pass
- `git diff --check`: pass

The global local shipcheck reached web typechecking but this isolated worktree did not have the web workspace dependencies, producing missing JSX type declarations. No web or Flutter files are changed by this PR.

## Boundaries
- no production migration applied
- no publication or pricing rows written
- no grant broadening
- no canary rerun
