### PR TITLE
Observe pricing canary through shared client RPC

### DIFF
--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -193,6 +193,11 @@ must prove:
 - authenticated runtime reads succeed and anonymous runtime reads remain denied
 - rollback authority and a prior publication generation remain available
 
+Runtime access proof must call the request-scoped
+`get_market_pricing_read_model_v1` contract with the current exact-printing
+identities. The canary does not depend on the separately governed ranked
+discovery endpoint.
+
 An incomplete time window is `observing`, not passed. A missing elapsed schedule
 slot, broken trace, stale value, access-boundary regression, terminal alert, or
 run mismatch fails the gate.

--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -249,6 +249,10 @@ async function queryEvidence(client, args, asOf, onStage = () => {}) {
       `with totals as (
          select
            count(*)::integer as exact_price_count,
+           array_agg(
+             card_printing_id
+             order by card_printing_id
+           ) as current_printing_ids,
            count(*) filter (
              where currency = 'USD' and market_price > 0
            )::integer as positive_usd_count,
@@ -349,12 +353,12 @@ async function queryEvidence(client, args, asOf, onStage = () => {}) {
       `select
          has_function_privilege(
            'authenticated',
-           'public.get_top_market_pricing_v1(integer)',
+           'public.get_market_pricing_read_model_v1(uuid[],uuid[])',
            'EXECUTE'
          ) as authenticated_execute_granted,
          has_function_privilege(
            'anon',
-           'public.get_top_market_pricing_v1(integer)',
+           'public.get_market_pricing_read_model_v1(uuid[],uuid[])',
            'EXECUTE'
          ) as anonymous_execute_granted,
          has_function_privilege(
@@ -373,8 +377,13 @@ async function queryEvidence(client, args, asOf, onStage = () => {}) {
       (
         await client.query(
           `select count(*)::integer as row_count
-           from public.get_top_market_pricing_v1($1)`,
-          [args.expectedCount],
+           from public.get_market_pricing_read_model_v1(
+             '{}'::uuid[],
+             $1::uuid[]
+           )
+           where pricing_scope = 'card_printing'
+             and status = 'available'`,
+          [current.current_printing_ids ?? []],
         )
       ).rows[0]?.row_count ?? 0,
     );
@@ -389,8 +398,11 @@ async function queryEvidence(client, args, asOf, onStage = () => {}) {
   try {
     await client.query(
       `select count(*)::integer
-       from public.get_top_market_pricing_v1($1)`,
-      [1],
+       from public.get_market_pricing_read_model_v1(
+         '{}'::uuid[],
+         $1::uuid[]
+       )`,
+      [[current.current_printing_ids?.[0]].filter(Boolean)],
     );
   } catch (error) {
     anonymousRuntimeCode = error.code ?? null;

--- a/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
@@ -17,6 +17,13 @@ import {
 
 const WINDOW_START = "2026-07-28T08:40:15.793Z";
 const COMMIT = "c0cdce5500c96cdc5b1d689e5178d9fa4e117e1d";
+const OBSERVER_SOURCE = await fs.readFile(
+  new URL(
+    "../../scripts/audits/tcgplayer_market_canary_observation_v1.mjs",
+    import.meta.url,
+  ),
+  "utf8",
+);
 
 function exactRun({
   id,
@@ -205,6 +212,25 @@ test("stale prices, broken access, and unavailable rollback fail closed", () => 
     result.findings.includes("anonymous_pricing_execute_unexpectedly_granted"),
   );
   assert.ok(result.findings.includes("publication_rollback_not_available"));
+});
+
+test("observer proves the request-scoped shared client RPC without ranked discovery", () => {
+  assert.match(
+    OBSERVER_SOURCE,
+    /array_agg\(\s*card_printing_id\s*order by card_printing_id\s*\) as current_printing_ids/i,
+  );
+  assert.match(
+    OBSERVER_SOURCE,
+    /get_market_pricing_read_model_v1\(\s*'\{\}'::uuid\[\],\s*\$1::uuid\[\]\s*\)/i,
+  );
+  assert.match(
+    OBSERVER_SOURCE,
+    /where pricing_scope = 'card_printing'\s+and status = 'available'/i,
+  );
+  assert.doesNotMatch(
+    OBSERVER_SOURCE,
+    /get_top_market_pricing_v1/i,
+  );
 });
 
 test("observer query failures preserve a run plan, summary, failure, and hashes", async () => {


### PR DESCRIPTION
## Summary
- collect the 100 active exact-printing IDs from the governed current publication
- prove authenticated access through get_market_pricing_read_model_v1 instead of the separately governed ranked-discovery endpoint
- retain anonymous denial and durable observer failure artifacts

## Live read-only proof
- current publication: 100 printing IDs in 463 ms
- shared RPC: 100/100 available exact rows in 227 ms
- no database writes

## Validation
- focused observer/runtime contracts: 12/12
- full contract suite: 885/885
- node syntax and diff checks: pass

## Release boundary
The pending migration package remains unapplied until the 72-hour canary passes. This change unblocks the observer without weakening that gate.