### PR TITLE
Fix production active-ask refresh timeout

### DIFF
--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -356,4 +356,9 @@ view for each calculation.
 Exact-printing eBay active asks are maintained in
 `mv_market_listing_active_ask_current_v1` by a separately governed refresh
 phase. Refresh failures fail the activation pipeline closed, while shadow and
-dry-run modes inspect the cache without changing it.
+dry-run modes inspect the cache without changing it. The refresh worker must
+set its database statement timeout explicitly on the live session and use the
+hash-plan path (`enable_nestloop = off`) so production-scale evidence joins do
+not inherit the platform's shorter default timeout or regress to pathological
+random index lookups. The effective session settings must be preserved in the
+refresh artifact.

--- a/scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs
+++ b/scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs
@@ -97,6 +97,23 @@ async function readback(client) {
   ).rows[0];
 }
 
+async function configureRefreshSession(client, timeoutMinutes) {
+  await client.query(
+    "select set_config('statement_timeout', $1, false)",
+    [`${timeoutMinutes}min`],
+  );
+  await client.query(
+    "select set_config('enable_nestloop', 'off', false)",
+  );
+  return (
+    await client.query(
+      `select
+         current_setting('statement_timeout') as statement_timeout,
+         current_setting('enable_nestloop') as enable_nestloop`,
+    )
+  ).rows[0];
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const url = databaseUrl();
@@ -121,6 +138,10 @@ async function main() {
     created_at: new Date().toISOString(),
     materialized_view: MATERIALIZED_VIEW,
     timeout_minutes: args.timeoutMinutes,
+    database_session_policy: {
+      statement_timeout: `${args.timeoutMinutes}min`,
+      enable_nestloop: "off",
+    },
     boundaries: {
       canonical_identity_writes: false,
       price_publication_writes: false,
@@ -140,6 +161,10 @@ async function main() {
   });
   await client.connect();
   try {
+    const databaseSession = await configureRefreshSession(
+      client,
+      args.timeoutMinutes,
+    );
     const before = await readback(client);
     const startedAt = new Date().toISOString();
     if (args.apply) {
@@ -158,6 +183,7 @@ async function main() {
       mode: runPlan.mode,
       started_at: startedAt,
       finished_at: new Date().toISOString(),
+      database_session: databaseSession,
       before,
       after,
       findings: [

--- a/tests/contracts/tcgplayer_market_read_model_performance_migration_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_read_model_performance_migration_v1.test.mjs
@@ -115,6 +115,30 @@ test("active asks refresh in the background and not inside product reads", () =>
   );
   assert.match(REFRESH_WORKER, /active-ask refresh apply requires a clean tracked working tree/i);
   assert.match(REFRESH_WORKER, /active_ask_cache_write:\s*args\.apply/i);
+  assert.match(
+    REFRESH_WORKER,
+    /select set_config\('statement_timeout', \$1, false\)/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /select set_config\('enable_nestloop', 'off', false\)/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /current_setting\('statement_timeout'\) as statement_timeout/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /current_setting\('enable_nestloop'\) as enable_nestloop/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /database_session_policy:\s*\{[\s\S]*statement_timeout:[\s\S]*enable_nestloop:\s*"off"/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /database_session:\s*databaseSession/i,
+  );
   assert.doesNotMatch(REFRESH_WORKER, /\b(insert|update|delete)\s+(?:into|from|public\.)/i);
   assert.match(PIPELINE, /phase:\s*"active_ask_refresh"/);
   assert.match(PIPELINE, /activationMode \? "--apply" : "--dry-run"/);


### PR DESCRIPTION
## Root cause

The 2026-07-30 unattended canary cycle completed the 9,202-request TCGCSV warehouse sync, then failed before publication because the active-ask materialized-view refresh inherited the production database's 2-minute statement timeout and selected a pathological nested-loop plan over the production-scale listing evidence tables.

Read-only production proof:
- default plan exceeded the two-minute boundary
- nable_nestloop = off completed the equivalent aggregate in about 76 seconds
- the current active-ask result is empty, which is valid for the separate optional eBay availability lane

## Repair

- explicitly set the configured statement timeout on the live database session
- force the hash-plan path for the refresh session
- record effective session settings in refresh artifacts
- document and contract-test the runtime policy
- no migration or schema change

## Verification

- focused contract: 6/6
- full contracts: 885/885
- runtime health: pass
- release secret guard: pass
- syntax and diff checks: pass

The local global shipcheck hook could not run its database preflight because SUPABASE_DB_URL is not available in the isolated worktree; the relevant suites and production read-only proof were run explicitly.