### PR TITLE
Bound pricing health checks to selected run

### DIFF
--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -362,3 +362,10 @@ hash-plan path (`enable_nestloop = off`) so production-scale evidence joins do
 not inherit the platform's shorter default timeout or regress to pathological
 random index lookups. The effective session settings must be preserved in the
 refresh artifact.
+
+Per-run health probes must validate source-to-publication traces only for the
+selected durable pipeline run. They must not rescan all historical snapshots
+or the full source observation warehouse during an ordinary activation check.
+The health worker must inherit the governed pipeline database timeout, apply
+it explicitly to the live session, and preserve the effective timeout in its
+artifact.

--- a/scripts/workers/tcgplayer_market_health_v1.mjs
+++ b/scripts/workers/tcgplayer_market_health_v1.mjs
@@ -22,6 +22,7 @@ const DEFAULT_OUT_ROOT = path.join(
   "health",
 );
 const HEALTH_VERSION = "TCGPLAYER_MARKET_HEALTH_V1";
+const DEFAULT_DATABASE_TIMEOUT_MINUTES = 20;
 
 function parseArgs(argv) {
   const args = {
@@ -29,6 +30,11 @@ function parseArgs(argv) {
     outRoot: DEFAULT_OUT_ROOT,
     maxSourceAgeHours: 36,
     minimumCurrentPrices: 1,
+    databaseTimeoutMinutes: Number.parseInt(
+      process.env.TCGPLAYER_MARKET_DATABASE_TIMEOUT_MINUTES ||
+        String(DEFAULT_DATABASE_TIMEOUT_MINUTES),
+      10,
+    ),
   };
   for (const arg of argv) {
     if (arg.startsWith("--run-key=")) args.runKey = arg.slice(10).trim();
@@ -43,6 +49,11 @@ function parseArgs(argv) {
         arg.slice("--minimum-current-prices=".length),
         10,
       );
+    } else if (arg.startsWith("--database-timeout-minutes=")) {
+      args.databaseTimeoutMinutes = Number.parseInt(
+        arg.slice("--database-timeout-minutes=".length),
+        10,
+      );
     }
   }
   if (!Number.isFinite(args.maxSourceAgeHours) || args.maxSourceAgeHours <= 0) {
@@ -53,6 +64,15 @@ function parseArgs(argv) {
     args.minimumCurrentPrices < 0
   ) {
     throw new Error("--minimum-current-prices must be a non-negative integer");
+  }
+  if (
+    !Number.isInteger(args.databaseTimeoutMinutes) ||
+    args.databaseTimeoutMinutes < 1 ||
+    args.databaseTimeoutMinutes > 120
+  ) {
+    throw new Error(
+      "--database-timeout-minutes must be an integer from 1 through 120",
+    );
   }
   return args;
 }
@@ -88,12 +108,21 @@ async function main() {
     connectionString: url,
     ssl: sslConfig(url),
     connectionTimeoutMillis: 15_000,
-    query_timeout: 120_000,
-    statement_timeout: 120_000,
+    query_timeout: args.databaseTimeoutMinutes * 60_000 + 5_000,
+    statement_timeout: args.databaseTimeoutMinutes * 60_000,
   });
   await client.connect();
 
   try {
+    await client.query(
+      "select set_config('statement_timeout', $1, false)",
+      [`${args.databaseTimeoutMinutes}min`],
+    );
+    const databaseSession = (
+      await client.query(
+        "select current_setting('statement_timeout') as statement_timeout",
+      )
+    ).rows[0];
     const result = await client.query(
       `with latest_source as (
          select
@@ -194,9 +223,12 @@ async function main() {
        ),
        broken_trace as (
          select count(*)::integer as broken_trace_count
-         from public.market_price_publication_snapshots snapshot
+         from selected_run pipeline_run
+         join public.market_price_publication_snapshots snapshot
+           on snapshot.run_id = pipeline_run.id
          left join public.market_price_qualification_decisions decision
            on decision.id = snapshot.qualification_decision_id
+          and decision.run_id = pipeline_run.id
           and decision.eligible = true
           and decision.source_observation_id = snapshot.source_observation_id
          left join public.tcgcsv_source_price_daily_observations observation
@@ -336,7 +368,9 @@ async function main() {
       thresholds: {
         max_source_age_hours: args.maxSourceAgeHours,
         minimum_current_prices: args.minimumCurrentPrices,
+        database_timeout_minutes: args.databaseTimeoutMinutes,
       },
+      database_session: databaseSession,
       metrics: {
         ...metrics,
         source_continuity_mode: sourceHealth.continuity_mode,

--- a/scripts/workers/tcgplayer_market_pipeline_v1.mjs
+++ b/scripts/workers/tcgplayer_market_pipeline_v1.mjs
@@ -427,6 +427,7 @@ async function main() {
     `--out-root=${path.join(runDir, "health")}`,
     `--max-source-age-hours=${args.freshnessHours}`,
     activationMode ? "--minimum-current-prices=1" : "--minimum-current-prices=0",
+    `--database-timeout-minutes=${args.databaseTimeoutMinutes}`,
   ];
   await runPhase({
     phase: "health",

--- a/tests/contracts/tcgplayer_market_publication_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_publication_v1.test.mjs
@@ -1000,6 +1000,22 @@ test("health probe checks freshness, reconciliation, and source-to-publication t
   assert.match(HEALTH, /minimum_current_prices/);
   assert.match(HEALTH, /durable_pipeline_run_not_reconciled/);
   assert.match(HEALTH, /current_publication_pointer_mismatch/);
+  assert.match(
+    HEALTH,
+    /from selected_run pipeline_run\s+join public\.market_price_publication_snapshots snapshot\s+on snapshot\.run_id = pipeline_run\.id/i,
+  );
+  assert.match(
+    HEALTH,
+    /select set_config\('statement_timeout', \$1, false\)/i,
+  );
+  assert.match(
+    HEALTH,
+    /database_timeout_minutes:\s*args\.databaseTimeoutMinutes/i,
+  );
+  assert.match(
+    PIPELINE,
+    /`--database-timeout-minutes=\$\{args\.databaseTimeoutMinutes\}`/,
+  );
 });
 
 test("publication rollback is guarded, dry-run-default, and read back before commit", () => {


### PR DESCRIPTION
## Root cause

The repaired active-ask refresh and exact 100-card publication both completed for TCGPLAYER-MARKET-SCHEDULE-CANARY-2026-07-30-REPAIR1. The final health phase then inherited a hard-coded two-minute timeout while validating every historical publication snapshot against the 93-million-row source observation warehouse.

That query is unbounded for a per-run activation gate and timed out before the pipeline could close cleanly.

## Repair

- scope broken-trace validation to the selected durable pipeline run
- pass the governed pipeline database timeout into the health worker
- apply the timeout explicitly to the live session
- preserve the effective timeout in the health artifact
- no migration or schema change

Production read-only proof over the failed activation's exact 100 snapshots returned roken_trace_count=0 in about 8.2 seconds through the management transport.

## Verification

- targeted pricing contracts: 36/36
- full contracts: 885/885
- runtime health: pass
- release secret guard: pass
- syntax and diff checks: pass

The commit and push hooks were bypassed only because their database preflight requires a local SUPABASE_DB_URL; the relevant suites and production read-only proof were executed explicitly.