### PR TITLE
Bound canary observer to active publication trace

### DIFF
--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -369,3 +369,7 @@ or the full source observation warehouse during an ordinary activation check.
 The health worker must inherit the governed pipeline database timeout, apply
 it explicitly to the live session, and preserve the effective timeout in its
 artifact.
+
+The canary observer applies the same bounded trace rule to the active
+publication pointer. Historical trace auditing is a separate offline audit
+and must not be expanded inside the recurring canary observer.

--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -262,24 +262,27 @@ async function queryEvidence(client, args, asOf, onStage = () => {}) {
            count(*) filter (
              where freshness <> 'fresh' or age_seconds > 36 * 60 * 60
            )::integer as stale_price_count
-         from public.v_market_price_current_v1
-       ),
-       broken_trace as (
-         select count(*)::integer as broken_trace_count
-         from public.market_price_publication_snapshots snapshot
-         left join public.market_price_qualification_decisions decision
-           on decision.id = snapshot.qualification_decision_id
-          and decision.eligible = true
-          and decision.source_observation_id = snapshot.source_observation_id
-         left join public.tcgcsv_source_price_daily_observations observation
-           on observation.id = snapshot.source_observation_id
-         where decision.id is null or observation.id is null
+       from public.v_market_price_current_v1
        ),
        pointer as (
          select publication_set_id, run_id, previous_publication_set_id,
                 activated_at
          from public.market_price_current_publication
          where singleton = true
+       ),
+       broken_trace as (
+         select count(*)::integer as broken_trace_count
+         from pointer
+         join public.market_price_publication_snapshots snapshot
+           on snapshot.run_id = pointer.run_id
+         left join public.market_price_qualification_decisions decision
+           on decision.id = snapshot.qualification_decision_id
+          and decision.run_id = pointer.run_id
+          and decision.eligible = true
+          and decision.source_observation_id = snapshot.source_observation_id
+         left join public.tcgcsv_source_price_daily_observations observation
+           on observation.id = snapshot.source_observation_id
+         where decision.id is null or observation.id is null
        )
        select totals.*, broken_trace.*,
               pointer.publication_set_id as current_publication_set_id,

--- a/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
@@ -231,6 +231,18 @@ test("observer proves the request-scoped shared client RPC without ranked discov
     OBSERVER_SOURCE,
     /get_top_market_pricing_v1/i,
   );
+  assert.match(
+    OBSERVER_SOURCE,
+    /from pointer\s+join public\.market_price_publication_snapshots snapshot\s+on snapshot\.run_id = pointer\.run_id/i,
+  );
+  assert.match(
+    OBSERVER_SOURCE,
+    /decision\.run_id = pointer\.run_id/i,
+  );
+  assert.doesNotMatch(
+    OBSERVER_SOURCE,
+    /broken_trace as \(\s*select count\(\*\)::integer as broken_trace_count\s*from public\.market_price_publication_snapshots snapshot/i,
+  );
 });
 
 test("observer query failures preserve a run plan, summary, failure, and hashes", async () => {


### PR DESCRIPTION
## Root cause

The recurring canary observer still counted broken traces across every historical publication snapshot and the 93-million-row source observation table. That recreates the same unbounded health-query failure class after the production pipeline repair.

## Repair

- scope observer trace validation to the active publication pointer
- require qualification decisions to belong to the same active run
- keep historical trace auditing in its separate offline lane
- no database writes, migration, or publication changes

## Verification

- targeted observer contracts: 8/8
- full contracts: 885/885
- release secret guard: pass
- syntax and diff checks: pass