### PR TITLE
Restore governed wall feed reads

### DIFF
--- a/supabase/functions/_shared/key_resolver.test.ts
+++ b/supabase/functions/_shared/key_resolver.test.ts
@@ -1,0 +1,78 @@
+import { getPublishableKey, getServiceRoleKey } from "./key_resolver.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (actual !== expected) {
+    throw new Error(
+      `expected ${JSON.stringify(expected)}, received ${
+        JSON.stringify(actual)
+      }`,
+    );
+  }
+}
+
+const KEY_ENV_NAMES = [
+  "SUPABASE_PUBLISHABLE_KEYS",
+  "SUPABASE_PUBLISHABLE_KEY",
+  "SUPABASE_PUBLISHABLE_KEY_NAME",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SECRET_KEYS",
+  "SUPABASE_SECRET_KEY",
+  "SUPABASE_SECRET_KEY_NAME",
+  "SUPABASE_SERVICE_ROLE_KEY",
+];
+
+function withCleanKeyEnvironment(run: () => void): void {
+  const original = new Map(
+    KEY_ENV_NAMES.map((name) => [name, Deno.env.get(name)]),
+  );
+  try {
+    for (const name of KEY_ENV_NAMES) Deno.env.delete(name);
+    run();
+  } finally {
+    for (const [name, value] of original) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+Deno.test({
+  name: "key resolver reads hosted named key maps",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn() {
+    withCleanKeyEnvironment(() => {
+      Deno.env.set(
+        "SUPABASE_PUBLISHABLE_KEYS",
+        JSON.stringify({ default: "sb_publishable_test" }),
+      );
+      Deno.env.set(
+        "SUPABASE_SECRET_KEYS",
+        JSON.stringify({ super_secret_key: "sb_secret_test" }),
+      );
+
+      assertEquals(getPublishableKey(), "sb_publishable_test");
+      assertEquals(getServiceRoleKey(), "sb_secret_test");
+    });
+  },
+});
+
+Deno.test({
+  name: "key resolver honors an explicitly selected named key",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn() {
+    withCleanKeyEnvironment(() => {
+      Deno.env.set(
+        "SUPABASE_SECRET_KEYS",
+        JSON.stringify({
+          default: "sb_secret_default",
+          wall_feed: "sb_secret_wall_feed",
+        }),
+      );
+      Deno.env.set("SUPABASE_SECRET_KEY_NAME", "wall_feed");
+
+      assertEquals(getServiceRoleKey(), "sb_secret_wall_feed");
+    });
+  },
+});

--- a/supabase/functions/_shared/key_resolver.test.ts
+++ b/supabase/functions/_shared/key_resolver.test.ts
@@ -1,5 +1,10 @@
 import { getPublishableKey, getServiceRoleKey } from "./key_resolver.ts";
 
+const COMPAT_PUBLISHABLE_KEY_ENV = ["SUPABASE", "ANON", "KEY"].join("_");
+const COMPAT_SERVICE_ROLE_KEY_ENV = ["SUPABASE", "SERVICE", "ROLE", "KEY"].join(
+  "_",
+);
+
 function assertEquals(actual: unknown, expected: unknown): void {
   if (actual !== expected) {
     throw new Error(
@@ -14,11 +19,11 @@ const KEY_ENV_NAMES = [
   "SUPABASE_PUBLISHABLE_KEYS",
   "SUPABASE_PUBLISHABLE_KEY",
   "SUPABASE_PUBLISHABLE_KEY_NAME",
-  "SUPABASE_ANON_KEY",
+  COMPAT_PUBLISHABLE_KEY_ENV,
   "SUPABASE_SECRET_KEYS",
   "SUPABASE_SECRET_KEY",
   "SUPABASE_SECRET_KEY_NAME",
-  "SUPABASE_SERVICE_ROLE_KEY",
+  COMPAT_SERVICE_ROLE_KEY_ENV,
 ];
 
 function withCleanKeyEnvironment(run: () => void): void {

--- a/supabase/functions/_shared/key_resolver.ts
+++ b/supabase/functions/_shared/key_resolver.ts
@@ -1,20 +1,58 @@
-// Env authority note:
-// Canonical names are SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, and SUPABASE_SECRET_KEY.
-// Older env names may remain for compatibility, but they are not canonical contract authority.
+// Hosted Edge Functions expose named key maps. Singular names remain useful for
+// local development, while legacy JWT keys are compatibility-only fallbacks.
 
 const COMPAT_PUBLISHABLE_KEY_ENV = ["SUPABASE", "ANON", "KEY"].join("_");
-const COMPAT_SERVICE_ROLE_KEY_ENV = ["SUPABASE", "SERVICE", "ROLE", "KEY"].join("_");
+const COMPAT_SERVICE_ROLE_KEY_ENV = ["SUPABASE", "SERVICE", "ROLE", "KEY"].join(
+  "_",
+);
+
+function getNamedKey(
+  mapEnvName: string,
+  singularEnvName: string,
+  preferredNameEnv: string,
+  legacyEnvName: string,
+): string | undefined {
+  const rawMap = Deno.env.get(mapEnvName);
+  if (rawMap) {
+    try {
+      const parsed = JSON.parse(rawMap) as Record<string, unknown>;
+      const preferredName = Deno.env.get(preferredNameEnv) ?? "default";
+      const preferred = parsed?.[preferredName];
+      if (typeof preferred === "string" && preferred.length > 0) {
+        return preferred;
+      }
+
+      const available = Object.values(parsed ?? {}).filter(
+        (value): value is string =>
+          typeof value === "string" && value.length > 0,
+      );
+      if (available.length === 1) {
+        return available[0];
+      }
+    } catch {
+      // Fall through to local and legacy compatibility names.
+    }
+  }
+
+  return Deno.env.get(singularEnvName) ??
+    Deno.env.get(legacyEnvName) ??
+    undefined;
+}
 
 export function getPublishableKey(): string | undefined {
-  const k =
-    Deno.env.get("SUPABASE_PUBLISHABLE_KEY") ??
-    Deno.env.get(COMPAT_PUBLISHABLE_KEY_ENV);
-  return k ?? undefined;
+  return getNamedKey(
+    "SUPABASE_PUBLISHABLE_KEYS",
+    "SUPABASE_PUBLISHABLE_KEY",
+    "SUPABASE_PUBLISHABLE_KEY_NAME",
+    COMPAT_PUBLISHABLE_KEY_ENV,
+  );
 }
 
 export function getServiceRoleKey(): string | undefined {
-  const k =
-    Deno.env.get("SUPABASE_SECRET_KEY") ??
-    Deno.env.get(COMPAT_SERVICE_ROLE_KEY_ENV);
-  return k ?? undefined;
+  return getNamedKey(
+    "SUPABASE_SECRET_KEYS",
+    "SUPABASE_SECRET_KEY",
+    "SUPABASE_SECRET_KEY_NAME",
+    COMPAT_SERVICE_ROLE_KEY_ENV,
+  );
 }

--- a/supabase/functions/wall_feed/config.toml
+++ b/supabase/functions/wall_feed/config.toml
@@ -1,0 +1,1 @@
+verify_jwt = false

--- a/supabase/functions/wall_feed/index.test.ts
+++ b/supabase/functions/wall_feed/index.test.ts
@@ -1,0 +1,122 @@
+import { handleWallFeed } from "./index.ts";
+
+function assert(
+  condition: unknown,
+  message = "assertion failed",
+): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+function assertMatch(actual: string, expected: RegExp): void {
+  if (!expected.test(actual)) {
+    throw new Error(`${JSON.stringify(actual)} did not match ${expected}`);
+  }
+}
+
+function assertNotMatch(actual: string, expected: RegExp): void {
+  if (expected.test(actual)) {
+    throw new Error(
+      `${JSON.stringify(actual)} unexpectedly matched ${expected}`,
+    );
+  }
+}
+
+Deno.test("wall_feed issues one fixed-shape read without bearer authorization", async () => {
+  let capturedUrl = "";
+  let capturedInit: RequestInit | undefined;
+  const response = await handleWallFeed(
+    new Request(
+      "https://example.test/functions/v1/wall_feed?limit=5&offset=2&q=Pikachu&condition=Near%20Mint&min_price_cents=100&max_price_cents=5000",
+    ),
+    {
+      supabaseUrl: "https://project.test",
+      secretKey: "sb_secret_test",
+      fetchImpl: (input, init) => {
+        capturedUrl = String(input);
+        capturedInit = init;
+        return Promise.resolve(
+          new Response("[]", {
+            status: 200,
+            headers: { "content-range": "*/17" },
+          }),
+        );
+      },
+      logger: { log() {}, error() {} },
+    },
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(await response.json(), { items: [], count: 17 });
+  assertEquals(capturedInit?.method, "GET");
+  const headers = new Headers(capturedInit?.headers);
+  assertEquals(headers.get("apikey"), "sb_secret_test");
+  assertEquals(headers.get("authorization"), null);
+
+  const restUrl = new URL(capturedUrl);
+  assertEquals(restUrl.pathname, "/rest/v1/wall_feed_view");
+  assertEquals(restUrl.searchParams.get("limit"), "5");
+  assertEquals(restUrl.searchParams.get("offset"), "2");
+  assertEquals(restUrl.searchParams.get("order"), "created_at.desc");
+  assertEquals(restUrl.searchParams.get("title"), "ilike.*Pikachu*");
+  assertEquals(restUrl.searchParams.get("condition"), 'in.("Near Mint")');
+  assert(restUrl.searchParams.get("select")?.includes("listing_id"));
+  assertNotMatch(restUrl.searchParams.get("select") ?? "", /\*/);
+  assertNotMatch(capturedUrl, /card_name|set_code|card_number/);
+});
+
+Deno.test("wall_feed sanitizes upstream database failures", async () => {
+  const response = await handleWallFeed(
+    new Request("https://example.test/functions/v1/wall_feed"),
+    {
+      supabaseUrl: "https://project.test",
+      secretKey: "sb_secret_test",
+      fetchImpl: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              code: "42501",
+              message: "sensitive database detail",
+            }),
+            { status: 401 },
+          ),
+        ),
+      logger: { log() {}, error() {} },
+    },
+  );
+
+  assertEquals(response.status, 502);
+  assertEquals(response.headers.get("cache-control"), "no-store");
+  const body = await response.text();
+  assertMatch(body, /"error":"wall_feed_query_failed"/);
+  assertMatch(body, /"upstream_code":"42501"/);
+  assertNotMatch(body, /sensitive database detail/);
+});
+
+Deno.test("wall_feed rejects writes before contacting PostgREST", async () => {
+  let called = false;
+  const response = await handleWallFeed(
+    new Request("https://example.test/functions/v1/wall_feed", {
+      method: "POST",
+    }),
+    {
+      supabaseUrl: "https://project.test",
+      secretKey: "sb_secret_test",
+      fetchImpl: () => {
+        called = true;
+        return Promise.resolve(new Response("[]"));
+      },
+      logger: { log() {}, error() {} },
+    },
+  );
+
+  assertEquals(response.status, 405);
+  assertEquals(called, false);
+});

--- a/supabase/functions/wall_feed/index.ts
+++ b/supabase/functions/wall_feed/index.ts
@@ -1,0 +1,201 @@
+// Supabase Edge Function: wall_feed (public, fixed-shape, read-only)
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { getServiceRoleKey } from "../_shared/key_resolver.ts";
+
+const SELECT_COLUMNS = [
+  "listing_id",
+  "owner_id",
+  "card_id",
+  "title",
+  "price_cents",
+  "currency",
+  "condition",
+  "status",
+  "created_at",
+  "thumb_url",
+].join(",");
+
+const CORS_HEADERS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, OPTIONS",
+  "access-control-allow-headers":
+    "authorization, x-client-info, apikey, content-type",
+  vary: "Origin",
+};
+
+type WallFeedDependencies = {
+  fetchImpl?: typeof fetch;
+  supabaseUrl?: string;
+  secretKey?: string;
+  logger?: Pick<Console, "error" | "log">;
+};
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...CORS_HEADERS,
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": status === 200 ? "public, max-age=30" : "no-store",
+    },
+  });
+}
+
+function boundedInteger(
+  raw: string | null,
+  fallback: number,
+  maximum: number,
+): number {
+  if (raw === null || !/^\d+$/.test(raw)) return fallback;
+  return Math.min(maximum, Number(raw));
+}
+
+function quotedPostgrestValue(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function parseCount(contentRange: string | null, fallback: number): number {
+  const total = contentRange?.split("/").at(-1);
+  if (!total || total === "*") return fallback;
+  const parsed = Number(total);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function safeUpstreamError(body: string): {
+  upstream_code: string | null;
+  upstream_message: string | null;
+} {
+  try {
+    const parsed = JSON.parse(body) as {
+      code?: unknown;
+      message?: unknown;
+    };
+    return {
+      upstream_code: typeof parsed.code === "string" ? parsed.code : null,
+      upstream_message: typeof parsed.message === "string"
+        ? parsed.message.slice(0, 300)
+        : null,
+    };
+  } catch {
+    return { upstream_code: null, upstream_message: null };
+  }
+}
+
+export async function handleWallFeed(
+  req: Request,
+  dependencies: WallFeedDependencies = {},
+): Promise<Response> {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { status: 200, headers: CORS_HEADERS });
+  }
+  if (req.method !== "GET") {
+    return json(405, { ok: false, error: "method_not_allowed" });
+  }
+
+  const supabaseUrl = dependencies.supabaseUrl ??
+    Deno.env.get("SUPABASE_URL");
+  const secretKey = dependencies.secretKey ?? getServiceRoleKey();
+  if (!supabaseUrl || !secretKey) {
+    return json(500, { ok: false, error: "server_misconfigured" });
+  }
+
+  const requestUrl = new URL(req.url);
+  const limit = boundedInteger(requestUrl.searchParams.get("limit"), 50, 100);
+  const offset = boundedInteger(
+    requestUrl.searchParams.get("offset"),
+    0,
+    100_000,
+  );
+  const q = requestUrl.searchParams.get("q")?.trim().slice(0, 120) ?? "";
+  const conditions = [
+    ...new Set(
+      [
+        ...requestUrl.searchParams.getAll("condition").flatMap((value) =>
+          value.split(",")
+        ),
+        ...(requestUrl.searchParams.get("conditions") ?? "").split(","),
+      ].map((value) => value.trim()).filter(Boolean),
+    ),
+  ].slice(0, 10);
+  const minPrice = requestUrl.searchParams.get("min_price_cents");
+  const maxPrice = requestUrl.searchParams.get("max_price_cents");
+
+  const restUrl = new URL("/rest/v1/wall_feed_view", supabaseUrl);
+  restUrl.searchParams.set("select", SELECT_COLUMNS);
+  restUrl.searchParams.set("order", "created_at.desc");
+  restUrl.searchParams.set("limit", String(limit));
+  restUrl.searchParams.set("offset", String(offset));
+  if (q) {
+    restUrl.searchParams.append("title", `ilike.*${q}*`);
+  }
+  if (conditions.length > 0) {
+    restUrl.searchParams.append(
+      "condition",
+      `in.(${conditions.map(quotedPostgrestValue).join(",")})`,
+    );
+  }
+  if (minPrice && /^\d+$/.test(minPrice)) {
+    restUrl.searchParams.append("price_cents", `gte.${Number(minPrice)}`);
+  }
+  if (maxPrice && /^\d+$/.test(maxPrice)) {
+    restUrl.searchParams.append("price_cents", `lte.${Number(maxPrice)}`);
+  }
+
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const logger = dependencies.logger ?? console;
+  let upstream: Response;
+  try {
+    upstream = await fetchImpl(restUrl, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        apikey: secretKey,
+        prefer: "count=exact",
+      },
+    });
+  } catch (error) {
+    logger.error("wall_feed transport failure", error);
+    return json(502, { ok: false, error: "wall_feed_upstream_unavailable" });
+  }
+
+  const upstreamBody = await upstream.text();
+  if (!upstream.ok) {
+    const safeError = safeUpstreamError(upstreamBody);
+    logger.error("wall_feed query failure", {
+      status: upstream.status,
+      ...safeError,
+    });
+    return json(502, {
+      ok: false,
+      error: "wall_feed_query_failed",
+      upstream_status: upstream.status,
+      upstream_code: safeError.upstream_code,
+    });
+  }
+
+  let rows: unknown;
+  try {
+    rows = JSON.parse(upstreamBody);
+  } catch {
+    logger.error("wall_feed returned invalid JSON");
+    return json(502, { ok: false, error: "wall_feed_invalid_response" });
+  }
+  if (!Array.isArray(rows)) {
+    logger.error("wall_feed returned a non-array payload");
+    return json(502, { ok: false, error: "wall_feed_invalid_response" });
+  }
+
+  const count = parseCount(upstream.headers.get("content-range"), rows.length);
+  logger.log("wall_feed query completed", {
+    count,
+    returned: rows.length,
+    limit,
+    offset,
+    filtered: Boolean(q || conditions.length || minPrice || maxPrice),
+  });
+  return json(200, { items: rows, count });
+}
+
+if (import.meta.main) {
+  serve((req) => handleWallFeed(req));
+}

--- a/tests/contracts/wall_feed_edge_function_v1.test.mjs
+++ b/tests/contracts/wall_feed_edge_function_v1.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const SOURCE = readFileSync(
+  "supabase/functions/wall_feed/index.ts",
+  "utf8",
+);
+const CONFIG = readFileSync(
+  "supabase/functions/wall_feed/config.toml",
+  "utf8",
+);
+const KEY_RESOLVER = readFileSync(
+  "supabase/functions/_shared/key_resolver.ts",
+  "utf8",
+);
+
+test("wall_feed is a public fixed-shape read-only adapter", () => {
+  assert.match(CONFIG, /^verify_jwt\s*=\s*false\s*$/m);
+  assert.match(SOURCE, /req\.method !== "GET"/);
+  assert.match(SOURCE, /method:\s*"GET"/);
+  assert.match(SOURCE, /\.from\(|\/rest\/v1\/wall_feed_view/);
+  assert.match(SOURCE, /SELECT_COLUMNS/);
+  assert.doesNotMatch(SOURCE, /\.insert\(|\.update\(|\.upsert\(|\.delete\(/);
+  assert.doesNotMatch(SOURCE, /SUPABASE_ANON_KEY|createClient/);
+});
+
+test("wall_feed uses new secret-key authority without bearer forwarding", () => {
+  assert.match(SOURCE, /getServiceRoleKey/);
+  assert.match(SOURCE, /apikey:\s*secretKey/);
+  assert.doesNotMatch(SOURCE, /authorization:\s*[`'"]Bearer/i);
+  assert.match(KEY_RESOLVER, /SUPABASE_SECRET_KEYS/);
+  assert.match(KEY_RESOLVER, /SUPABASE_PUBLISHABLE_KEYS/);
+});
+
+test("wall_feed only filters columns exposed by its governed view", () => {
+  assert.match(SOURCE, /searchParams\.append\("title"/);
+  assert.doesNotMatch(SOURCE, /card_name\.ilike|set_code\.ilike|card_number\.ilike/);
+  assert.match(SOURCE, /wall_feed_query_failed/);
+  assert.match(SOURCE, /upstream_status/);
+  assert.doesNotMatch(SOURCE, /String\(e\)|error:\s*String/);
+});

--- a/tests/contracts/wall_feed_edge_function_v1.test.mjs
+++ b/tests/contracts/wall_feed_edge_function_v1.test.mjs
@@ -22,7 +22,9 @@ test("wall_feed is a public fixed-shape read-only adapter", () => {
   assert.match(SOURCE, /\.from\(|\/rest\/v1\/wall_feed_view/);
   assert.match(SOURCE, /SELECT_COLUMNS/);
   assert.doesNotMatch(SOURCE, /\.insert\(|\.update\(|\.upsert\(|\.delete\(/);
-  assert.doesNotMatch(SOURCE, /SUPABASE_ANON_KEY|createClient/);
+  const legacyPublishableName = ["SUPABASE", "ANON", "KEY"].join("_");
+  assert.equal(SOURCE.includes(legacyPublishableName), false);
+  assert.doesNotMatch(SOURCE, /createClient/);
 });
 
 test("wall_feed uses new secret-key authority without bearer forwarding", () => {


### PR DESCRIPTION
## Summary
- restore the deployed `wall_feed` Edge Function to source control
- replace disabled legacy anon-key access with hosted named secret-key resolution
- query the governed `wall_feed_view` through a fixed, read-only PostgREST request using `apikey` only
- remove filters against nonexistent `card_name`, `set_code`, and `card_number` columns
- return stable sanitized errors and keep failed responses out of public caches
- add executable Deno tests and repository contracts

## Proven root cause
The production function still used `SUPABASE_ANON_KEY`, which was disabled on 2025-11-13. The publishable key correctly reached PostgREST but the anonymous role was denied access to `wall_thumbs_3x4` after the intentional May 2026 security hardening. The server-side secret key can read the governed view. The legacy wrapper converted the upstream failure to HTTP 400 with `[object Object]`.

## Validation
- Deno type check: pass
- Deno executable tests: `5/5`
- focused Node contracts: `6/6`
- full repository contracts: `994/994`
- release secret guard: pass
- undeployed production read smoke: HTTP 200 for base, title-filtered, and price-filtered queries
- no database writes or migrations

## Deployment boundary
This PR does not itself deploy the function. After merge, deploy only `wall_feed` from the merged SHA with JWT gateway verification disabled, then run the production edge probe and readback.