### PR TITLE
Restart pricing canary observer on repaired activation

### DIFF
--- a/.github/workflows/tcgplayer-market-canary-observation.yml
+++ b/.github/workflows/tcgplayer-market-canary-observation.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      CANARY_WINDOW_START: "2026-07-30T18:17:48.625Z"
-      CANARY_REQUIRED_END: "2026-08-02T18:17:48.625Z"
-      CANARY_ACTIVATION_RUN_ID: "421f40ab-2d2d-4411-a1b3-7420603c5b86"
-      CANARY_EXPECTED_COMMIT_SHA: "456306bdb2a335286d513c1d612a97a58a1f01cc"
+      CANARY_WINDOW_START: "2026-07-31T10:34:15.670Z"
+      CANARY_REQUIRED_END: "2026-08-03T10:34:15.670Z"
+      CANARY_ACTIVATION_RUN_ID: "0c23045d-8141-4b9c-ba41-2f8c44522921"
+      CANARY_EXPECTED_COMMIT_SHA: "416c4691d1c1d6be8a1461c148deebe627e813f8"
       CANARY_EXPECTED_COUNT: "100"
-      OBSERVER_SOURCE_SHA: "a2267285a236e89330f3002ee567ddce991c4232"
+      OBSERVER_SOURCE_SHA: "416c4691d1c1d6be8a1461c148deebe627e813f8"
       SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
     steps:
@@ -68,6 +68,7 @@ jobs:
             --required-hours=72 \
             "--expected-count=${CANARY_EXPECTED_COUNT}" \
             --schedule-tolerance-minutes=90 \
+            --schedule-completion-grace-minutes=480 \
             --out-root="$RUNNER_TEMP/tcgplayer-market-canary-observation" \
             "${require_pass[@]}"
 

--- a/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
@@ -20,24 +20,26 @@ const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 test("scheduled canary observer is pinned to the reviewed source and canary", () => {
   assert.match(
     workflow,
-    /OBSERVER_SOURCE_SHA: "a2267285a236e89330f3002ee567ddce991c4232"/,
+    /OBSERVER_SOURCE_SHA: "416c4691d1c1d6be8a1461c148deebe627e813f8"/,
   );
   assert.match(
     workflow,
-    /CANARY_EXPECTED_COMMIT_SHA: "456306bdb2a335286d513c1d612a97a58a1f01cc"/,
+    /CANARY_EXPECTED_COMMIT_SHA: "416c4691d1c1d6be8a1461c148deebe627e813f8"/,
   );
   assert.match(
     workflow,
-    /CANARY_ACTIVATION_RUN_ID: "421f40ab-2d2d-4411-a1b3-7420603c5b86"/,
+    /CANARY_ACTIVATION_RUN_ID: "0c23045d-8141-4b9c-ba41-2f8c44522921"/,
   );
   assert.match(workflow, /CANARY_EXPECTED_COUNT: "100"/);
   assert.match(workflow, /ref: \$\{\{ env\.OBSERVER_SOURCE_SHA \}\}/);
 });
 
 test("scheduled canary observer requires the terminal pass after 72 hours", () => {
-  assert.match(workflow, /CANARY_WINDOW_START: "2026-07-30T18:17:48\.625Z"/);
-  assert.match(workflow, /CANARY_REQUIRED_END: "2026-08-02T18:17:48\.625Z"/);
+  assert.match(workflow, /CANARY_WINDOW_START: "2026-07-31T10:34:15\.670Z"/);
+  assert.match(workflow, /CANARY_REQUIRED_END: "2026-08-03T10:34:15\.670Z"/);
   assert.match(workflow, /--required-hours=72/);
+  assert.match(workflow, /--schedule-tolerance-minutes=90/);
+  assert.match(workflow, /--schedule-completion-grace-minutes=480/);
   assert.match(workflow, /require_pass=\(--require-pass\)/);
   assert.match(workflow, /"\$\{require_pass\[@\]\}"/);
 });


### PR DESCRIPTION
## Summary
- pin the observer to repaired pricing producer SHA 416c4691d1c1d6be8a1461c148deebe627e813f8
- restart the 72-hour window from verified activation 0c23045d-8141-4b9c-ba41-2f8c44522921
- enable source-trigger observation with an 8-hour publication completion grace

## Production proof
- canary V2 continuity: 100/100 exact source identities
- replacement publication: 100 selected, eligible, snapshotted, and traced
- required phases: 5/5
- health: healthy
- outer run: completed in one attempt

## Verification
- full repository shipcheck passed on 9f2323ea4
- workflow contract test: 3/3
- no database write capability added to observer