### PR TITLE
Honor pricing canary terminal completion grace

### DIFF
--- a/.github/workflows/tcgplayer-market-canary-observation.yml
+++ b/.github/workflows/tcgplayer-market-canary-observation.yml
@@ -22,6 +22,7 @@ jobs:
       CANARY_ACTIVATION_RUN_ID: "0c23045d-8141-4b9c-ba41-2f8c44522921"
       CANARY_EXPECTED_COMMIT_SHA: "416c4691d1c1d6be8a1461c148deebe627e813f8"
       CANARY_EXPECTED_COUNT: "100"
+      CANARY_COMPLETION_GRACE_SECONDS: "28800"
       OBSERVER_SOURCE_SHA: "416c4691d1c1d6be8a1461c148deebe627e813f8"
       SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
@@ -48,7 +49,8 @@ jobs:
 
           now_epoch="$(date -u +%s)"
           required_end_epoch="$(date -u -d "${CANARY_REQUIRED_END}" +%s)"
-          final_observation_deadline="$((required_end_epoch + 21600))"
+          final_completion_deadline="$((required_end_epoch + CANARY_COMPLETION_GRACE_SECONDS))"
+          final_observation_deadline="$((final_completion_deadline + 21600))"
 
           if (( now_epoch > final_observation_deadline )); then
             echo "The frozen canary observation window is complete; no further scheduled reads are required."
@@ -57,7 +59,7 @@ jobs:
           fi
 
           require_pass=()
-          if (( now_epoch >= required_end_epoch )); then
+          if (( now_epoch >= final_completion_deadline )); then
             require_pass=(--require-pass)
           fi
 

--- a/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
@@ -34,12 +34,23 @@ test("scheduled canary observer is pinned to the reviewed source and canary", ()
   assert.match(workflow, /ref: \$\{\{ env\.OBSERVER_SOURCE_SHA \}\}/);
 });
 
-test("scheduled canary observer requires the terminal pass after 72 hours", () => {
+test("scheduled canary observer allows final-slot completion before requiring a terminal pass", () => {
   assert.match(workflow, /CANARY_WINDOW_START: "2026-07-31T10:34:15\.670Z"/);
   assert.match(workflow, /CANARY_REQUIRED_END: "2026-08-03T10:34:15\.670Z"/);
+  assert.match(workflow, /CANARY_COMPLETION_GRACE_SECONDS: "28800"/);
   assert.match(workflow, /--required-hours=72/);
   assert.match(workflow, /--schedule-tolerance-minutes=90/);
   assert.match(workflow, /--schedule-completion-grace-minutes=480/);
+  assert.match(
+    workflow,
+    /final_completion_deadline="\$\(\(required_end_epoch \+ CANARY_COMPLETION_GRACE_SECONDS\)\)"/,
+  );
+  assert.match(
+    workflow,
+    /final_observation_deadline="\$\(\(final_completion_deadline \+ 21600\)\)"/,
+  );
+  assert.match(workflow, /now_epoch >= final_completion_deadline/);
+  assert.doesNotMatch(workflow, /now_epoch >= required_end_epoch/);
   assert.match(workflow, /require_pass=\(--require-pass\)/);
   assert.match(workflow, /"\$\{require_pass\[@\]\}"/);
 });


### PR DESCRIPTION
## Summary
- keep an incomplete final daily slot in observing state through the configured 8-hour completion grace
- delay --require-pass until the grace expires
- retain another 6-hour observation interval for a terminal proof

## Why
The observer policy allows an on-time source trigger 8 hours to complete, but the workflow wrapper previously demanded pass and stopped observing after 6 hours. That could create another false failure at the final slot.

## Verification
- full repository shipcheck passed on 4824473de
- workflow contracts: 3/3