### PR TITLE
Preserve public wall feed deployment behavior

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -388,3 +388,8 @@ entrypoint = "./functions/notification-dispatcher/index.ts"
 enabled = true
 verify_jwt = false
 entrypoint = "./functions/operations-webhook-v1/index.ts"
+
+[functions.wall_feed]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/wall_feed/index.ts"

--- a/supabase/functions/wall_feed/index.test.ts
+++ b/supabase/functions/wall_feed/index.test.ts
@@ -111,16 +111,10 @@ Deno.test("wall_feed returns an empty page for an out-of-range PostgREST request
       secretKey: "sb_secret_test",
       fetchImpl: () =>
         Promise.resolve(
-          new Response(
-            JSON.stringify({
-              code: "PGRST103",
-              message: "Requested range not satisfiable",
-            }),
-            {
-              status: 416,
-              headers: { "content-range": "*/17" },
-            },
-          ),
+          new Response("", {
+            status: 416,
+            headers: { "content-range": "*/17" },
+          }),
         ),
       logger: { log() {}, error() {} },
     },

--- a/supabase/functions/wall_feed/index.ts
+++ b/supabase/functions/wall_feed/index.ts
@@ -239,7 +239,10 @@ export async function handleWallFeed(
   }
   if (!upstream.ok) {
     const safeError = safeUpstreamError(upstreamBody);
-    if (upstream.status === 416 && safeError.upstream_code === "PGRST103") {
+    // The bounded GET is the only upstream operation. PostgREST may omit its
+    // JSON error body for an unsatisfiable offset, so status 416 is sufficient
+    // evidence that pagination reached the end of the feed.
+    if (upstream.status === 416) {
       const count = parseCount(upstream.headers.get("content-range"), 0);
       logger.log("wall_feed query completed beyond available range", {
         count,

--- a/tests/contracts/wall_feed_edge_function_v1.test.mjs
+++ b/tests/contracts/wall_feed_edge_function_v1.test.mjs
@@ -10,6 +10,7 @@ const CONFIG = readFileSync(
   "supabase/functions/wall_feed/config.toml",
   "utf8",
 );
+const ROOT_CONFIG = readFileSync("supabase/config.toml", "utf8");
 const KEY_RESOLVER = readFileSync(
   "supabase/functions/_shared/key_resolver.ts",
   "utf8",
@@ -17,6 +18,10 @@ const KEY_RESOLVER = readFileSync(
 
 test("wall_feed is a public fixed-shape read-only adapter", () => {
   assert.match(CONFIG, /^verify_jwt\s*=\s*false\s*$/m);
+  assert.match(
+    ROOT_CONFIG,
+    /\[functions\.wall_feed\][\s\S]*?enabled\s*=\s*true[\s\S]*?verify_jwt\s*=\s*false[\s\S]*?entrypoint\s*=\s*"\.\/functions\/wall_feed\/index\.ts"/,
+  );
   assert.match(SOURCE, /req\.method !== "GET"/);
   assert.match(SOURCE, /method:\s*"GET"/);
   assert.match(SOURCE, /\.from\(|\/rest\/v1\/wall_feed_view/);


### PR DESCRIPTION
## Summary
- registers wall_feed in root Supabase config with JWT verification disabled
- treats any bounded PostgREST 416 as an empty feed page, including live responses without a PGRST103 body
- adds deployment-config and bodyless-416 regressions

## Verification
- Deno format/check: pass
- wall_feed Deno tests: 7/7
- wall/probe Node contracts: 6/6
- live anonymous base/search/wildcard/write-rejection probes verified; out-of-range will be re-probed after deploy