### PR TITLE
Keep wall feed counts usable at scale

### DIFF
--- a/supabase/functions/wall_feed/index.test.ts
+++ b/supabase/functions/wall_feed/index.test.ts
@@ -59,7 +59,7 @@ Deno.test("wall_feed issues one fixed-shape read without bearer authorization", 
   const headers = new Headers(capturedInit?.headers);
   assertEquals(headers.get("apikey"), "sb_secret_test");
   assertEquals(headers.get("authorization"), null);
-  assertEquals(headers.get("prefer"), "count=planned");
+  assertEquals(headers.get("prefer"), "count=estimated");
 
   const restUrl = new URL(capturedUrl);
   assertEquals(restUrl.pathname, "/rest/v1/wall_feed_view");

--- a/supabase/functions/wall_feed/index.ts
+++ b/supabase/functions/wall_feed/index.ts
@@ -222,7 +222,7 @@ export async function handleWallFeed(
       headers: {
         accept: "application/json",
         apikey: secretKey,
-        prefer: "count=planned",
+        prefer: "count=estimated",
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
Use PostgREST count=estimated for wall_feed. It preserves exact counts for small result sets while avoiding exact-count cost once the feed grows.

## Live finding
count=planned returned fewer total rows than the response contained, which could break pagination.

## Verification
- Deno format/check: pass
- wall_feed Deno tests: 7/7
- wall/probe Node contracts: 6/6