### PR TITLE
docs: record release readiness audit

### DIFF
--- a/docs/checkpoints/CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/CHECKPOINT_INDEX.md
@@ -1,5 +1,6 @@
 # CHECKPOINT_INDEX
 
+- `RELEASE_READINESS_AUDIT_20260731_V1` — `2026-07-31` — Controlled-beta release audit proving the deployed wall-feed and merged pricing/read boundaries while preserving Xcode Cloud, physical-iPhone, 72-hour pricing, 17-surface, and unattended-cycle gates
 - `CAMEO_SEARCH_ROTOMAMITI_REFRESH_20260618_V1` — `2026-06-18` — Additive RotomAmiti cameo enrichment refresh: 60 logical-new `card_print_cameos` rows applied, active source count now 1,421, 38 preservation-review rows intentionally retained, and future refreshes locked to logical cameo identity instead of volatile sheet row hashes
 - `DB_CANON_COMPLETE_BEFORE_WEB_CHANGES_RESTORE_POINT_V1` — `2026-06-16` — Restore instructions for git checkpoint `checkpoint/db-canon-complete-before-web-20260616` / commit `fb95dff5`, preserving the current DB canon, enrichment, image-truth, Pocket GV-ID, external mapping alias, and website baseline before further website changes
 - `LOCAL_COMMUNITY_FEED_V1_INTERNAL_PREVIEW_COMPLETE` — `2026-05-21` — Permanent project-memory checkpoint locking Local Community Feed V1 as accepted internal-preview infrastructure, with authenticated opt-in access, coarse locality only, block/mute safety, sanitized public-safe images, mobile drawer-only scope, and no public production enablement

--- a/docs/checkpoints/product/CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/product/CHECKPOINT_INDEX.md
@@ -5,3 +5,4 @@
 - `public_provisional_warehouse_hardening_v1.md` — `2026-04-22` — COMPLETE — Locks the public provisional warehouse search-only trust boundary, adapter-only access, canonical separation, UI restrictions, and anti-drift checks.
 - `image_surfacing_hardening_v1.md` — `2026-04-22` — COMPLETE — Locks `display_image_url` as the primary product image contract, preserves representative image rendering, and keeps provisional image safety strict.
 - `image_truth_display_coverage_and_exact_variant_handoff_v1.md` — `2026-06-18` — COMPLETE — Records that English physical display coverage is closed while exact variant image truth remains a separate backlog requiring honest product labeling.
+- `RELEASE_READINESS_AUDIT_20260731_V1.md` — `2026-07-31` — ACTIVE GATES — Records the production-proven wall-feed repair, merged pricing surfaces, full verification results, current controlled-beta verdict, pending Xcode Cloud/TestFlight proof, and the frozen post-72-hour pricing handoff.

--- a/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
+++ b/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
@@ -1,0 +1,179 @@
+# Release Readiness Audit 2026-07-31 V1
+
+## Status
+
+Controlled beta ready. Expanded beta remains gated by the current Xcode Cloud
+result and clean-account physical-iPhone journey proof. Public launch is not
+yet authorized.
+
+This checkpoint supersedes the release-readiness facts in the assessment of
+commit `91ab3c198d6c1fb300cd3f28cf463f72c62e79f6`. The wall-feed defects and
+missing deployment identified there have since been repaired and proven in
+production.
+
+## Audit Scope
+
+The audit covered:
+
+- repository and migration truth on `main`
+- GitHub, Vercel, and Xcode Cloud release state
+- anonymous and authenticated pricing boundaries
+- public web routes and canonical image delivery
+- the production `wall_feed` Edge Function
+- the frozen TCGPlayer Market 72-hour canary
+- Node, Flutter, web, Deno, secret, drift, and runtime-protection checks
+
+No production data mutation was performed by this audit. The only production
+change was deployment of the read-only `wall_feed` function from merged code.
+
+## Release Revisions
+
+- Pricing and release-remediation merge: `8933fd73177b26eea8cc96b3e5f2b7d31b8eab3a`
+- Wall-feed deployment-contract merge: `258215033d8ea35417fbba3f0766da91506344e4`
+- Wall-feed count-quality merge and deployed revision:
+  `40457c1f8c0f80cd91cbb6f92ca6c1d7fb1e30c2`
+
+## Findings
+
+### Closed Findings
+
+1. Out-of-range wall-feed pagination now returns `200` with an empty item list
+   and the available total instead of surfacing upstream `416` as `502`.
+2. Upstream response-body read failures are handled inside the controlled JSON,
+   CORS, and no-store error boundary.
+3. Search metacharacters `%` and `_` are treated as literal input.
+4. Public feed reads are bounded and rate-limited; write methods return `405`.
+5. Feed counts use PostgREST estimated mode, which remains exact for small
+   result sets and avoids unconditional exact-count cost at scale.
+6. Signed-in Pulse network reads retain the verified viewer and exclude that
+   viewer from discovery.
+7. Governed TCGPlayer pricing code, migration history, web surfaces, Flutter
+   surfaces, exact Vault totals, observability, and rollback controls are all on
+   `main`.
+8. Pricing-bearing routes remain authenticated and fail closed for anonymous
+   callers.
+
+### Production Proof
+
+The deployed `wall_feed` revision returned:
+
+| Probe | HTTP | Items | Count | Result |
+| --- | ---: | ---: | ---: | --- |
+| base, limit 5 | 200 | 5 | 7 | pass |
+| search `asdf` | 200 | 2 | 2 | pass |
+| minimum-price filter | 200 | 7 | 7 | pass |
+| literal wildcard input | 200 | 0 | 0 | pass |
+| offset `999999` | 200 | 0 | 7 | pass |
+| POST | 405 | n/a | n/a | pass |
+
+The final merge's Vercel deployment, legacy-key guard, and production edge
+probe passed. Earlier read-only production checks also proved:
+
+- home, login, card detail, set grid, Dex, and Pulse network routes return 200
+- canonical artwork delivery returns a non-empty WebP image
+- anonymous wall access redirects to login
+- anonymous card-pricing API access returns 401
+- card detail renders TCGPlayer Market labeling and the signed-out lock state
+
+### Verification
+
+| Suite | Result |
+| --- | ---: |
+| Node contracts | 1,182 / 1,182 passed |
+| Flutter tests | 541 / 541 passed |
+| Flutter analysis | no issues |
+| Web TypeScript | passed |
+| Web lint | passed |
+| Strict web production build | passed |
+| Wall-feed Deno tests | 7 / 7 passed |
+| Wall/probe Node contracts | 6 / 6 passed |
+| Runtime health and fail-closed reports | passed |
+| Secret guard | passed |
+| Production edge probe | passed |
+| Production DB read-only probe | passed |
+
+The isolated checkout did not contain `SUPABASE_DB_URL`, so a local managed-DB
+preflight was not rerun there. Existing CI and production read-only proofs are
+recorded separately and do not convert that skipped local check into a pass.
+
+## Open Gates
+
+### Xcode Cloud And TestFlight
+
+The Xcode Cloud build for deployed main revision
+`40457c1f8c0f80cd91cbb6f92ca6c1d7fb1e30c2` failed:
+
+`33c5f31d-1e0f-4625-908b-17f9a18fb51e`
+
+The immediately preceding builds for `258215033d8ea35417fbba3f0766da91506344e4`
+and `8933fd73177b26eea8cc96b3e5f2b7d31b8eab3a` also failed. GitHub exposes
+the App Store Connect build link and final status but not the archive log.
+Local Flutter analysis and tests are green, so the Apple failure remains
+unclassified until its Xcode Cloud log is inspected. No successful TestFlight
+artifact from current `main` is proven.
+
+Expanded beta requires:
+
+1. a successful Xcode Cloud archive and distributable TestFlight build
+2. clean-account validation on a physical iPhone
+3. the core journey: sign up, find a card, own it, create a binder, add an
+   intent or listing, and observe the resulting activity
+
+### Pricing Canary
+
+The frozen 100-row TCGPlayer Market canary is healthy and observing. Its
+governed window is:
+
+- start: `2026-07-31T10:34:15.670Z`
+- required end: `2026-08-03T10:34:15.670Z`
+- activation run: `0c23045d-8141-4b9c-ba41-2f8c44522921`
+- frozen pricing commit: `416c4691d1c1d6be8a1461c148deebe627e813f8`
+- expected publication rows: 100
+
+Latest observation is green, with no unhealthy slots or run keys. Production
+V1 cannot be declared complete before the required end and a final
+`--require-pass` observation.
+
+After the canary passes:
+
+1. run the frozen linked migration preflight
+2. apply the governed read-model completion package
+3. verify schema, grants, RLS, authenticated reads, and anonymous denial
+4. deploy the exact web and Flutter clients
+5. execute and reconcile the 17-surface source-to-render proof
+6. enable signed-in full publication through the governed pointer
+7. observe seven unattended production cycles
+8. run rollback rehearsal and publish the final pricing report
+
+## Verdict
+
+| Area | Rating | Audit judgment |
+| --- | ---: | --- |
+| Product foundation | 9.2 / 10 | strong canonical, security, and contract base |
+| Controlled beta readiness | 9 / 10 | authorized with current signed-in boundaries |
+| Expanded beta readiness | 8 / 10 | waits on Apple/TestFlight and physical-device proof |
+| Public launch readiness | 7 / 10 | pricing duration and public/licensing gates remain |
+| Operational confidence | 8 / 10 | substantially improved; final duration gates remain |
+
+Grookai is ready for a controlled invite-only beta. It is not yet ready for an
+unrestricted public launch. The remaining blockers are operational proof, not
+missing core architecture.
+
+## Invariants
+
+- Do not shorten or backdate the 72-hour pricing canary.
+- Do not represent a pending Apple build as distributable.
+- Do not enable anonymous pricing before licensing and display authority.
+- Do not weaken governed pricing, RLS, service-role, or canonical boundaries to
+  satisfy a UI deadline.
+- Do not call Production V1 complete until the final observer, migrations,
+  17-surface proof, and seven unattended cycles all pass.
+
+## Exact Next Gate
+
+Inspect the failed Xcode Cloud archive log, repair the specific Apple build or
+signing failure, and produce a successful TestFlight artifact from current
+`main`. Then validate the clean-account journey on a physical iPhone.
+Independently, preserve the frozen pricing canary until
+`2026-08-03T10:34:15.670Z`, then run its mandatory final pass before applying
+any post-canary pricing migration.


### PR DESCRIPTION
## Summary
- records the 2026-07-31 release-readiness audit
- captures production wall-feed and pricing boundary proofs
- preserves Xcode Cloud, physical-device, and 72-hour pricing gates
- updates checkpoint indexes

## Verification
- git diff --check
- documentation-only change
- pre-commit/pre-push managed-DB preflight could not run in the isolated worktree because SUPABASE_DB_URL is intentionally absent
- full Node, Flutter, web, Deno, CI, and production probe results are recorded in the checkpoint