### PR TITLE
fix: bootstrap Flutter in Xcode Cloud

### DIFF
--- a/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
+++ b/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
@@ -108,9 +108,22 @@ The Xcode Cloud build for deployed main revision
 The immediately preceding builds for `258215033d8ea35417fbba3f0766da91506344e4`
 and `8933fd73177b26eea8cc96b3e5f2b7d31b8eab3a` also failed. GitHub exposes
 the App Store Connect build link and final status but not the archive log.
-Local Flutter analysis and tests are green, so the Apple failure remains
-unclassified until its Xcode Cloud log is inspected. No successful TestFlight
-artifact from current `main` is proven.
+The Apple email for build 248 supplied the missing failure evidence:
+
+- `ios/Flutter/Release.xcconfig` could not include `Generated.xcconfig`
+- Xcode could not load the CocoaPods Runner framework output file list
+
+The repository did not contain Xcode Cloud's recognized
+`ios/ci_scripts/ci_post_clone.sh`, so the temporary macOS worker ran neither
+`flutter pub get` nor `pod install` before archive. This is a dependency
+bootstrap failure, not a Flutter test or application-code failure.
+
+The repair candidate adds the official post-clone integration point, pins the
+repository-tested Flutter `3.35.2` release, precaches iOS artifacts, resolves
+the locked Dart packages, installs CocoaPods when absent, and runs `pod
+install`. A new contract protects the complete bootstrap sequence. The repair
+is not production-proven until a fresh Xcode Cloud archive passes. No
+successful TestFlight artifact from current `main` is proven yet.
 
 Expanded beta requires:
 
@@ -171,9 +184,8 @@ missing core architecture.
 
 ## Exact Next Gate
 
-Inspect the failed Xcode Cloud archive log, repair the specific Apple build or
-signing failure, and produce a successful TestFlight artifact from current
-`main`. Then validate the clean-account journey on a physical iPhone.
-Independently, preserve the frozen pricing canary until
+Merge the Xcode Cloud dependency-bootstrap repair and require a successful
+archive and TestFlight artifact from the resulting `main`. Then validate the
+clean-account journey on a physical iPhone. Independently, preserve the frozen pricing canary until
 `2026-08-03T10:34:15.670Z`, then run its mandatory final pass before applying
 any post-canary pricing migration.

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+: "${CI_PRIMARY_REPOSITORY_PATH:?CI_PRIMARY_REPOSITORY_PATH is required}"
+
+FLUTTER_VERSION="${FLUTTER_VERSION:-3.35.2}"
+FLUTTER_HOME="${HOME}/flutter"
+
+cd "${CI_PRIMARY_REPOSITORY_PATH}"
+
+if [ ! -x "${FLUTTER_HOME}/bin/flutter" ]; then
+  git clone \
+    --depth 1 \
+    --branch "${FLUTTER_VERSION}" \
+    https://github.com/flutter/flutter.git \
+    "${FLUTTER_HOME}"
+fi
+
+export PATH="${FLUTTER_HOME}/bin:${PATH}"
+
+flutter config --no-analytics
+flutter precache --ios
+flutter pub get
+
+if ! command -v pod >/dev/null 2>&1; then
+  export HOMEBREW_NO_AUTO_UPDATE=1
+  brew install cocoapods
+fi
+
+cd ios
+pod install

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const script = readFileSync("ios/ci_scripts/ci_post_clone.sh", "utf8");
+
+test("Xcode Cloud bootstraps Flutter from the repository root", () => {
+  assert.match(script, /^#!\/bin\/sh\r?\n/);
+  assert.match(script, /set -eu/);
+  assert.match(script, /CI_PRIMARY_REPOSITORY_PATH is required/);
+  assert.match(script, /cd "\$\{CI_PRIMARY_REPOSITORY_PATH\}"/);
+});
+
+test("Xcode Cloud uses the repository-tested Flutter release", () => {
+  assert.match(script, /FLUTTER_VERSION="\$\{FLUTTER_VERSION:-3\.35\.2\}"/);
+  assert.match(script, /--branch "\$\{FLUTTER_VERSION\}"/);
+  assert.match(script, /https:\/\/github\.com\/flutter\/flutter\.git/);
+  assert.match(script, /flutter precache --ios/);
+});
+
+test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
+  assert.match(script, /flutter pub get/);
+  assert.match(script, /command -v pod/);
+  assert.match(script, /brew install cocoapods/);
+  assert.match(script, /cd ios\r?\npod install/);
+});


### PR DESCRIPTION
## Root cause
Xcode Cloud builds 238-248 failed before application compilation because Flutter Generated.xcconfig and CocoaPods Runner xcfilelists were absent. The repository had no recognized ios/ci_scripts/ci_post_clone.sh.

## Repair
- add executable Xcode Cloud post-clone bootstrap
- pin the repository-tested Flutter 3.35.2 release
- run iOS precache, flutter pub get, CocoaPods installation fallback, and pod install
- add deterministic contracts for the complete bootstrap
- update the permanent release audit with the classified failure

## Verification
- full contract suite: 1185/1185 passed
- targeted Xcode Cloud contracts: 3/3 passed
- release secret guard: passed
- Git Bash syntax check: passed
- executable git mode: 100755
- git diff --check: passed

The isolated checkout has no SUPABASE_DB_URL, so the managed-DB preflight hook was unavailable. No database behavior changed.