### PR TITLE
fix: generate Xcode Cloud release config

### DIFF
--- a/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
+++ b/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
@@ -125,6 +125,15 @@ install`. A new contract protects the complete bootstrap sequence. The repair
 is not production-proven until a fresh Xcode Cloud archive passes. No
 successful TestFlight artifact from current `main` is proven yet.
 
+The first repair was merged as
+`ac8a32290513702ef0870be231763d40a7006137`. Xcode Cloud build 250 then
+advanced beyond both missing-input failures and reached Flutter's archive
+configuration guard. It failed because the generated iOS settings were still
+Debug and explicitly required `flutter build ios --config-only --release`.
+The follow-up candidate adds that exact release-configuration step before the
+Xcode archive. This is a new, narrower bootstrap class; live proof remains the
+next Xcode Cloud build from the follow-up merge.
+
 Expanded beta requires:
 
 1. a successful Xcode Cloud archive and distributable TestFlight build

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -22,6 +22,7 @@ export PATH="${FLUTTER_HOME}/bin:${PATH}"
 flutter config --no-analytics
 flutter precache --ios
 flutter pub get
+flutter build ios --config-only --release
 
 if ! command -v pod >/dev/null 2>&1; then
   export HOMEBREW_NO_AUTO_UPDATE=1

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -20,6 +20,7 @@ test("Xcode Cloud uses the repository-tested Flutter release", () => {
 
 test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
   assert.match(script, /flutter pub get/);
+  assert.match(script, /flutter build ios --config-only --release/);
   assert.match(script, /command -v pod/);
   assert.match(script, /brew install cocoapods/);
   assert.match(script, /cd ios\r?\npod install/);


### PR DESCRIPTION
## Evidence
Xcode Cloud build 250 advanced past the repaired Generated.xcconfig and CocoaPods failures, then Flutter stopped archive because the generated iOS settings were Debug.

Apple's exact instruction was:

    flutter build ios --config-only --release

## Repair
- run the required Release configuration generation after flutter pub get
- assert the command in the Xcode Cloud bootstrap contract
- record build 250 and the follow-up gate in the release checkpoint

## Verification
- Xcode Cloud bootstrap contracts: 3/3 passed
- Git Bash syntax check: passed
- git diff --check: passed

No database or application-runtime behavior changed.