### PR TITLE
fix: order Xcode Cloud dependency setup

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -22,12 +22,15 @@ export PATH="${FLUTTER_HOME}/bin:${PATH}"
 flutter config --no-analytics
 flutter precache --ios
 flutter pub get
-flutter build ios --config-only --release
 
 if ! command -v pod >/dev/null 2>&1; then
   export HOMEBREW_NO_AUTO_UPDATE=1
   brew install cocoapods
 fi
 
-cd ios
-pod install
+(
+  cd ios
+  pod install
+)
+
+flutter build ios --config-only --release

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -23,5 +23,15 @@ test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
   assert.match(script, /flutter build ios --config-only --release/);
   assert.match(script, /command -v pod/);
   assert.match(script, /brew install cocoapods/);
-  assert.match(script, /cd ios\r?\npod install/);
+  assert.match(script, /cd ios\r?\n\s+pod install/);
+
+  const podAvailabilityIndex = script.indexOf("if ! command -v pod");
+  const podInstallIndex = script.indexOf("pod install", podAvailabilityIndex);
+  const releaseConfigIndex = script.indexOf(
+    "flutter build ios --config-only --release",
+  );
+
+  assert.ok(podAvailabilityIndex >= 0);
+  assert.ok(podInstallIndex > podAvailabilityIndex);
+  assert.ok(releaseConfigIndex > podInstallIndex);
 });


### PR DESCRIPTION
## Problem
Flutter 3.35.2's config-only iOS command calls CocoaPods internally. The build-250 follow-up initially placed Release configuration before the CocoaPods availability guard.

## Repair
- install CocoaPods before any Flutter iOS configuration command
- run explicit pod install in an isolated subshell
- generate Release configuration only after Pods inputs exist
- enforce the ordering in the bootstrap contract

## Verification
- Xcode Cloud bootstrap contracts: 3/3 passed
- Git Bash syntax check: passed
- git diff --check: passed

This closes a deterministic ordering risk before the next Apple build is launched.