### PR TITLE
fix: isolate Xcode Cloud Flutter cache

### DIFF
--- a/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
+++ b/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
@@ -145,6 +145,16 @@ the current stable Flutter `3.44.7` SDK while preserving the migrated iOS
 lifecycle and custom scanner registration. The SDK tag is verified upstream;
 the next archive remains the authoritative macOS compile proof.
 
+The Flutter 3.44.7 candidate merged as
+`7cc8f2bf01d1e7ca6b0493b967428704b5d9b51c`. Builds 252 and 253 then failed
+inside `ci_post_clone.sh` before Xcode archive, including one automatic retry
+from unchanged iOS code. The script pinned 3.44.7 but reused the unversioned
+cache path `${HOME}/flutter` whenever any Flutter executable already existed.
+That made the requested SDK version unenforceable against an older Xcode Cloud
+cache. The next candidate uses a version-specific SDK cache, verifies the
+cached framework version before dependency resolution, and emits bounded phase
+markers so future custom-script failures identify the exact failed stage.
+
 Expanded beta requires:
 
 1. a successful Xcode Cloud archive and distributable TestFlight build

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -5,11 +5,18 @@ set -eu
 : "${CI_PRIMARY_REPOSITORY_PATH:?CI_PRIMARY_REPOSITORY_PATH is required}"
 
 FLUTTER_VERSION="${FLUTTER_VERSION:-3.44.7}"
-FLUTTER_HOME="${HOME}/flutter"
+FLUTTER_HOME="${HOME}/flutter-${FLUTTER_VERSION}"
 
 cd "${CI_PRIMARY_REPOSITORY_PATH}"
 
+echo "xcode-cloud-bootstrap phase=flutter-sdk requested=${FLUTTER_VERSION} home=${FLUTTER_HOME}"
+
 if [ ! -x "${FLUTTER_HOME}/bin/flutter" ]; then
+  if [ -e "${FLUTTER_HOME}" ]; then
+    echo "xcode-cloud-bootstrap error=incomplete-flutter-sdk home=${FLUTTER_HOME}" >&2
+    exit 1
+  fi
+
   git clone \
     --depth 1 \
     --branch "${FLUTTER_VERSION}" \
@@ -19,18 +26,36 @@ fi
 
 export PATH="${FLUTTER_HOME}/bin:${PATH}"
 
+ACTUAL_FLUTTER_VERSION="$(
+  flutter --version --machine \
+    | sed -n 's/.*"frameworkVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+)"
+
+if [ "${ACTUAL_FLUTTER_VERSION}" != "${FLUTTER_VERSION}" ]; then
+  echo "xcode-cloud-bootstrap error=flutter-version-mismatch requested=${FLUTTER_VERSION} actual=${ACTUAL_FLUTTER_VERSION:-unknown}" >&2
+  exit 1
+fi
+
+echo "xcode-cloud-bootstrap phase=flutter-precache version=${ACTUAL_FLUTTER_VERSION}"
 flutter config --no-analytics
 flutter precache --ios
+
+echo "xcode-cloud-bootstrap phase=flutter-packages"
 flutter pub get --enforce-lockfile
 
 if ! command -v pod >/dev/null 2>&1; then
+  echo "xcode-cloud-bootstrap phase=cocoapods-install"
   export HOMEBREW_NO_AUTO_UPDATE=1
   brew install cocoapods
 fi
 
+echo "xcode-cloud-bootstrap phase=pod-install"
 (
   cd ios
   pod install
 )
 
+echo "xcode-cloud-bootstrap phase=release-config"
 flutter build ios --config-only --release
+
+echo "xcode-cloud-bootstrap phase=complete"

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -15,8 +15,12 @@ test("Xcode Cloud bootstraps Flutter from the repository root", () => {
 
 test("Xcode Cloud uses the UIScene-compatible Flutter release", () => {
   assert.match(script, /FLUTTER_VERSION="\$\{FLUTTER_VERSION:-3\.44\.7\}"/);
+  assert.match(script, /FLUTTER_HOME="\$\{HOME\}\/flutter-\$\{FLUTTER_VERSION\}"/);
   assert.match(script, /--branch "\$\{FLUTTER_VERSION\}"/);
   assert.match(script, /https:\/\/github\.com\/flutter\/flutter\.git/);
+  assert.match(script, /flutter --version --machine/);
+  assert.match(script, /frameworkVersion.*\[:space:\]/);
+  assert.match(script, /error=flutter-version-mismatch/);
   assert.match(script, /flutter precache --ios/);
   assert.match(appDelegate, /FlutterImplicitEngineDelegate/);
   assert.match(appDelegate, /FlutterImplicitEngineBridge/);
@@ -29,6 +33,10 @@ test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
   assert.match(script, /command -v pod/);
   assert.match(script, /brew install cocoapods/);
   assert.match(script, /cd ios\r?\n\s+pod install/);
+  assert.match(script, /phase=flutter-packages/);
+  assert.match(script, /phase=pod-install/);
+  assert.match(script, /phase=release-config/);
+  assert.match(script, /phase=complete/);
 
   const podAvailabilityIndex = script.indexOf("if ! command -v pod");
   const podInstallIndex = script.indexOf("pod install", podAvailabilityIndex);


### PR DESCRIPTION
## Summary
- bind Xcode Cloud's Flutter cache directory to the requested SDK version
- verify the cached framework version before dependency resolution
- emit non-secret phase markers for future custom-script diagnosis
- record the deterministic Build 252/253 failure class in the release checkpoint

## Root cause boundary
Builds 252 and 253 both failed inside `ci_post_clone.sh` before archive. The script requested Flutter 3.44.7 but reused `${HOME}/flutter` whenever any Flutter executable existed, so an older cached SDK could silently bypass the pin. This repair makes the cache identity version-specific and fails closed on mismatches or incomplete cache state.

## Verification
- `bash -n ios/ci_scripts/ci_post_clone.sh`
- real machine-output parser returns `3.44.7`
- Xcode bootstrap contracts: 3/3 passed
- full Node contracts: 1,185/1,185 passed
- release secret guard: passed
- `git diff --check`: passed

## Boundaries
No application behavior, database, pricing, publication, or deployment change.