### PR TITLE
fix: freeze Xcode Cloud Flutter release

### DIFF
--- a/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
+++ b/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
@@ -155,6 +155,17 @@ cache. The next candidate uses a version-specific SDK cache, verifies the
 cached framework version before dependency resolution, and emits bounded phase
 markers so future custom-script failures identify the exact failed stage.
 
+Build 254 still failed inside the custom script. The same merged script then
+passed end to end on a disposable GitHub macOS 15 runner in 4m42s, including
+Flutter package resolution, CocoaPods installation, and release configuration.
+That isolates the remaining failure to Xcode Cloud-specific state rather than
+portable script behavior. The candidate still allowed a hidden
+`FLUTTER_VERSION` workflow variable to override the repository default. The
+next candidate removes that override path, freezes Flutter 3.44.7 in source,
+and uses distinct non-secret exit codes for clone, precache, package, pod, and
+release-configuration phases. The disposable diagnostic branch is not part of
+the release and must not be merged.
+
 Expanded beta requires:
 
 1. a successful Xcode Cloud archive and distributable TestFlight build

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -4,7 +4,7 @@ set -eu
 
 : "${CI_PRIMARY_REPOSITORY_PATH:?CI_PRIMARY_REPOSITORY_PATH is required}"
 
-FLUTTER_VERSION="${FLUTTER_VERSION:-3.44.7}"
+FLUTTER_VERSION="3.44.7"
 FLUTTER_HOME="${HOME}/flutter-${FLUTTER_VERSION}"
 
 cd "${CI_PRIMARY_REPOSITORY_PATH}"
@@ -21,7 +21,8 @@ if [ ! -x "${FLUTTER_HOME}/bin/flutter" ]; then
     --depth 1 \
     --branch "${FLUTTER_VERSION}" \
     https://github.com/flutter/flutter.git \
-    "${FLUTTER_HOME}"
+    "${FLUTTER_HOME}" \
+    || exit 20
 fi
 
 export PATH="${FLUTTER_HOME}/bin:${PATH}"
@@ -37,25 +38,25 @@ if [ "${ACTUAL_FLUTTER_VERSION}" != "${FLUTTER_VERSION}" ]; then
 fi
 
 echo "xcode-cloud-bootstrap phase=flutter-precache version=${ACTUAL_FLUTTER_VERSION}"
-flutter config --no-analytics
-flutter precache --ios
+flutter config --no-analytics || exit 21
+flutter precache --ios || exit 22
 
 echo "xcode-cloud-bootstrap phase=flutter-packages"
-flutter pub get --enforce-lockfile
+flutter pub get --enforce-lockfile || exit 23
 
 if ! command -v pod >/dev/null 2>&1; then
   echo "xcode-cloud-bootstrap phase=cocoapods-install"
   export HOMEBREW_NO_AUTO_UPDATE=1
-  brew install cocoapods
+  brew install cocoapods || exit 24
 fi
 
 echo "xcode-cloud-bootstrap phase=pod-install"
 (
   cd ios
   pod install
-)
+) || exit 25
 
 echo "xcode-cloud-bootstrap phase=release-config"
-flutter build ios --config-only --release
+flutter build ios --config-only --release || exit 26
 
 echo "xcode-cloud-bootstrap phase=complete"

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -14,7 +14,8 @@ test("Xcode Cloud bootstraps Flutter from the repository root", () => {
 });
 
 test("Xcode Cloud uses the UIScene-compatible Flutter release", () => {
-  assert.match(script, /FLUTTER_VERSION="\$\{FLUTTER_VERSION:-3\.44\.7\}"/);
+  assert.match(script, /FLUTTER_VERSION="3\.44\.7"/);
+  assert.doesNotMatch(script, /^FLUTTER_VERSION="\$\{/m);
   assert.match(script, /FLUTTER_HOME="\$\{HOME\}\/flutter-\$\{FLUTTER_VERSION\}"/);
   assert.match(script, /--branch "\$\{FLUTTER_VERSION\}"/);
   assert.match(script, /https:\/\/github\.com\/flutter\/flutter\.git/);
@@ -37,6 +38,9 @@ test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
   assert.match(script, /phase=pod-install/);
   assert.match(script, /phase=release-config/);
   assert.match(script, /phase=complete/);
+  assert.match(script, /flutter pub get --enforce-lockfile \|\| exit 23/);
+  assert.match(script, /pod install\r?\n\) \|\| exit 25/);
+  assert.match(script, /flutter build ios --config-only --release \|\| exit 26/);
 
   const podAvailabilityIndex = script.indexOf("if ! command -v pod");
   const podInstallIndex = script.indexOf("pod install", podAvailabilityIndex);


### PR DESCRIPTION
## Summary
- make Flutter 3.44.7 repository-authoritative in Xcode Cloud
- remove hidden workflow-variable override of the release SDK
- assign phase-specific exit codes to clone, precache, package, CocoaPods, and release-config failures
- preserve the Build 254 and macOS diagnostic evidence

## Evidence
Build 254 failed inside the Xcode custom script. The exact merged script passed end to end on disposable GitHub macOS 15 run 30644133432 in 4m42s, including package resolution, pod install, and release configuration. The remaining mutable input was an Xcode Cloud `FLUTTER_VERSION` environment override; this repair removes it.

## Verification
- disposable macOS 15 script run: passed
- `bash -n ios/ci_scripts/ci_post_clone.sh`: passed
- Xcode bootstrap contracts: 3/3 passed
- full Node contracts: 1,185/1,185 passed
- release secret guard: passed
- `git diff --check`: passed

## Boundaries
No application behavior, database, pricing, publication, or deployment change. The disposable diagnostic branch was deleted and is not part of this PR.