### PR TITLE
fix: disable signing during Xcode bootstrap

### DIFF
--- a/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
+++ b/docs/checkpoints/product/RELEASE_READINESS_AUDIT_20260731_V1.md
@@ -166,6 +166,13 @@ and uses distinct non-secret exit codes for clone, precache, package, pod, and
 release-configuration phases. The disposable diagnostic branch is not part of
 the release and must not be merged.
 
+Build 255 returned the new phase-specific exit code `26`, proving Flutter SDK
+setup, package resolution, and CocoaPods completed and the failure occurred in
+the release-configuration command. Flutter's current iOS CI guidance generates
+configuration with `--no-codesign`; Xcode Cloud performs signing during the
+subsequent archive. The next candidate therefore keeps Release/config-only
+generation but explicitly disables signing discovery in the post-clone phase.
+
 Expanded beta requires:
 
 1. a successful Xcode Cloud archive and distributable TestFlight build

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -57,6 +57,6 @@ echo "xcode-cloud-bootstrap phase=pod-install"
 ) || exit 25
 
 echo "xcode-cloud-bootstrap phase=release-config"
-flutter build ios --config-only --release || exit 26
+flutter build ios --release --no-codesign --config-only || exit 26
 
 echo "xcode-cloud-bootstrap phase=complete"

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -30,7 +30,7 @@ test("Xcode Cloud uses the UIScene-compatible Flutter release", () => {
 
 test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
   assert.match(script, /flutter pub get --enforce-lockfile/);
-  assert.match(script, /flutter build ios --config-only --release/);
+  assert.match(script, /flutter build ios --release --no-codesign --config-only/);
   assert.match(script, /command -v pod/);
   assert.match(script, /brew install cocoapods/);
   assert.match(script, /cd ios\r?\n\s+pod install/);
@@ -40,12 +40,15 @@ test("Xcode Cloud generates Flutter and CocoaPods build inputs", () => {
   assert.match(script, /phase=complete/);
   assert.match(script, /flutter pub get --enforce-lockfile \|\| exit 23/);
   assert.match(script, /pod install\r?\n\) \|\| exit 25/);
-  assert.match(script, /flutter build ios --config-only --release \|\| exit 26/);
+  assert.match(
+    script,
+    /flutter build ios --release --no-codesign --config-only \|\| exit 26/,
+  );
 
   const podAvailabilityIndex = script.indexOf("if ! command -v pod");
   const podInstallIndex = script.indexOf("pod install", podAvailabilityIndex);
   const releaseConfigIndex = script.indexOf(
-    "flutter build ios --config-only --release",
+    "flutter build ios --release --no-codesign --config-only",
   );
 
   assert.ok(podAvailabilityIndex >= 0);


### PR DESCRIPTION
## Summary
- generate Flutter Release configuration without initiating code-signing discovery
- preserve Xcode Cloud as the authority for signing during archive
- record Build 255 phase proof and the official CI-aligned repair

## Root cause evidence
Build 255 exited with phase-specific code `26`, proving Flutter setup, package resolution, and CocoaPods passed and `flutter build ios --config-only --release` failed. Flutter's current iOS CI guidance uses `--no-codesign` for configuration generation. The exact repaired script passed disposable macOS 15 run 30645264704 in 3m39s.

## Verification
- disposable macOS 15 exact-script run: passed
- `bash -n ios/ci_scripts/ci_post_clone.sh`: passed
- Xcode bootstrap contracts: 3/3 passed
- full Node contracts: 1,185/1,185 passed
- release secret guard: passed
- `git diff --check`: passed

## Boundaries
No application behavior, database, pricing, publication, or deployment change. The diagnostic workflow branch was deleted and is not part of this PR.