### PR TITLE
Constrain GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci-guard-keys.yml
+++ b/.github/workflows/ci-guard-keys.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
     branches: [ main ]
+
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: windows-latest

--- a/.github/workflows/contracts-drift-gate.yml
+++ b/.github/workflows/contracts-drift-gate.yml
@@ -22,6 +22,9 @@ on:
       - 'package-lock.json'
       - '.github/workflows/contracts-drift-gate.yml'
 
+permissions:
+  contents: read
+
 jobs:
   drift-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts-runtime-protection.yml
+++ b/.github/workflows/contracts-runtime-protection.yml
@@ -38,6 +38,9 @@ on:
       - 'package-lock.json'
       - '.github/workflows/contracts-runtime-protection.yml'
 
+permissions:
+  contents: read
+
 jobs:
   runtime-protection:
     runs-on: ubuntu-latest

--- a/.github/workflows/flutter-build-apk.yml
+++ b/.github/workflows/flutter-build-apk.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-apk:
     runs-on: ubuntu-latest

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -15,6 +15,10 @@ on:
       - 'pubspec.yaml'
       - 'analysis_options.yaml'
       - '.github/workflows/flutter-ci.yml'
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-probe.yml
+++ b/.github/workflows/staging-probe.yml
@@ -3,6 +3,9 @@ name: Staging Probe (read-only)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   probe:
     runs-on: ubuntu-latest

--- a/tests/contracts/github_actions_permissions_v1.test.mjs
+++ b/tests/contracts/github_actions_permissions_v1.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflows = [
+  ".github/workflows/staging-probe.yml",
+  ".github/workflows/contracts-runtime-protection.yml",
+  ".github/workflows/flutter-ci.yml",
+  ".github/workflows/flutter-build-apk.yml",
+  ".github/workflows/contracts-drift-gate.yml",
+  ".github/workflows/ci-guard-keys.yml",
+];
+
+test("runtime workflows declare a least-privilege repository permission boundary", () => {
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(workflow, "utf8");
+    assert.match(source, /^permissions:\r?\n  contents: read$/m, workflow);
+    assert.doesNotMatch(
+      source,
+      /^\s{2}(actions|checks|deployments|issues|packages|pull-requests|security-events|statuses): write$/m,
+      workflow,
+    );
+  }
+});


### PR DESCRIPTION
## What changed

- declares an explicit top-level `contents: read` permission boundary on six runtime, Flutter, probe, drift, and key-guard workflows
- adds a contract preventing these workflows from regaining broad write permissions

## Why

CodeQL identified these workflows as relying on repository-default token authority. Each workflow only checks out code or runs read-only operations and does not need write access.

## Validation

- focused workflow-permissions contract: pass
- full repository contracts: 1,218/1,218 pass
- `git diff --check`: pass
