### PR TITLE
Bind privacy checks to the signed-in viewer

### DIFF
--- a/apps/web/src/lib/network/insertCardInteraction.ts
+++ b/apps/web/src/lib/network/insertCardInteraction.ts
@@ -78,6 +78,17 @@ async function isBlocked(
   senderUserId: string,
   receiverUserId: string,
 ) {
+  const currentViewerResult = await client.rpc(
+    "trust_block_exists_for_current_viewer_v1",
+    { p_other_user_id: receiverUserId },
+  );
+
+  if (!currentViewerResult.error) {
+    return currentViewerResult.data !== false;
+  }
+
+  // The wrapper lands after the pricing canary migrations. Keep the existing
+  // fail-closed boundary available until that ordered migration is deployed.
   const { data, error } = await client.rpc("trust_block_exists_between_v1", {
     p_user_id: senderUserId,
     p_other_user_id: receiverUserId,

--- a/scripts/audits/supabase_viewer_argument_binding_rollback_proof_v1.mjs
+++ b/scripts/audits/supabase_viewer_argument_binding_rollback_proof_v1.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+const PACKAGE_ID = "SUPABASE_VIEWER_ARGUMENT_BINDING_ROLLBACK_PROOF_V1";
+const DEFAULT_MIGRATION =
+  "supabase/migrations/20260731211500_security_advisor_viewer_argument_binding_v1.sql";
+
+const signatures = [
+  "public.interest_graph_collectors_visible_to_viewer_v1(uuid,uuid,uuid)",
+  "public.interest_graph_card_event_visible_to_viewer_v1(uuid,uuid,uuid,text)",
+  "public.card_events_resolve_visibility_v1(text,uuid,text,jsonb)",
+  "public.local_community_collector_visible_to_viewer_v1(uuid,uuid)",
+  "public.trust_block_exists_between_v1(uuid,uuid)",
+  "public.binder_card_event_visible_to_viewer_v1(uuid,text,uuid,uuid,uuid,text,jsonb,text)",
+];
+
+function parseArg(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) ?? null;
+}
+
+function loadPg(envPath) {
+  for (const root of [process.cwd(), path.dirname(envPath)]) {
+    const packagePath = path.join(root, "package.json");
+    if (!fs.existsSync(packagePath)) continue;
+    try {
+      return createRequire(packagePath)("pg");
+    } catch (error) {
+      if (error?.code !== "MODULE_NOT_FOUND") throw error;
+    }
+  }
+  throw new Error("The pg package is required");
+}
+
+function migrationBody(migrationPath) {
+  const sql = fs.readFileSync(migrationPath, "utf8");
+  const beginIndex = sql.search(/\bbegin\s*;/i);
+  const commitIndex = sql.search(/\bcommit\s*;\s*$/i);
+  assert.ok(beginIndex >= 0 && commitIndex > beginIndex, "migration must have one outer transaction");
+  return sql
+    .slice(sql.indexOf(";", beginIndex) + 1, commitIndex)
+    .replace(/notify\s+pgrst\s*,\s*'reload schema'\s*;/gi, "")
+    .trim();
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+async function readFunctionHashes(client) {
+  const hashes = {};
+  for (const signature of signatures) {
+    const result = await client.query(
+      "select pg_get_functiondef($1::regprocedure) as definition",
+      [signature],
+    );
+    hashes[signature] = sha256(result.rows[0].definition);
+  }
+  return hashes;
+}
+
+async function selectUsers(client) {
+  const result = await client.query(`
+    select user_id
+    from public.public_profiles
+    order by user_id
+    limit 3
+  `);
+  assert.ok(result.rowCount >= 2, "at least two public profile users are required");
+  return {
+    viewer: result.rows[0].user_id,
+    actor: result.rows[1].user_id,
+    spoofedViewer: result.rows[2]?.user_id ?? "00000000-0000-4000-8000-000000000003",
+  };
+}
+
+async function setAuthenticatedContext(client, userId) {
+  await client.query("set local role authenticated");
+  await client.query("select set_config('request.jwt.claim.sub', $1, true)", [userId]);
+  await client.query(
+    "select set_config('request.jwt.claims', $1, true)",
+    [JSON.stringify({ role: "authenticated", sub: userId })],
+  );
+}
+
+async function resetRole(client) {
+  await client.query("reset role");
+}
+
+async function runOwnViewerProbes(client, users) {
+  const result = await client.query(
+    `select
+      public.interest_graph_collectors_visible_to_viewer_v1($1, $2, null) as collectors_visible,
+      public.interest_graph_card_event_visible_to_viewer_v1($1, $2, null, 'public') as event_visible,
+      public.local_community_collector_visible_to_viewer_v1($1, $2) as local_visible,
+      public.trust_block_exists_between_v1($1, $2) as blocked,
+      public.card_events_resolve_visibility_v1('vault_added', $1, null, '{}'::jsonb) as resolved_visibility,
+      public.binder_card_event_visible_to_viewer_v1(
+        $1, 'vault_added', null, $2, null, 'public', '{}'::jsonb, null
+      ) as binder_event_visible`,
+    [users.viewer, users.actor],
+  );
+  return result.rows[0];
+}
+
+async function runSpoofedViewerProbes(client, users) {
+  const result = await client.query(
+    `select
+      public.interest_graph_collectors_visible_to_viewer_v1($1, $2, null) as collectors_visible,
+      public.interest_graph_card_event_visible_to_viewer_v1($1, $2, null, 'public') as event_visible,
+      public.local_community_collector_visible_to_viewer_v1($1, $2) as local_visible,
+      public.trust_block_exists_between_v1($1, $2) as blocked,
+      public.card_events_resolve_visibility_v1('collector_followed', $1, null, '{}'::jsonb) as resolved_visibility,
+      public.binder_card_event_visible_to_viewer_v1(
+        $1, 'vault_added', null, $2, null, 'public', '{}'::jsonb, null
+      ) as binder_event_visible`,
+    [users.spoofedViewer, users.actor],
+  );
+  return result.rows[0];
+}
+
+async function main() {
+  const envPath = path.resolve(parseArg("env-file") ?? ".env.local");
+  const migrationPath = path.resolve(parseArg("migration") ?? DEFAULT_MIGRATION);
+  process.loadEnvFile(envPath);
+  const connectionString =
+    process.env.SUPABASE_DB_URL ?? process.env.DATABASE_URL ?? process.env.POSTGRES_URL;
+  assert.ok(connectionString, "SUPABASE_DB_URL/DATABASE_URL/POSTGRES_URL is required");
+
+  const { Client } = loadPg(envPath);
+  const client = new Client({ connectionString });
+  let transactionOpen = false;
+  try {
+    await client.connect();
+    const baselineHashes = await readFunctionHashes(client);
+    await client.query("begin isolation level repeatable read read write");
+    transactionOpen = true;
+    const users = await selectUsers(client);
+
+    await setAuthenticatedContext(client, users.viewer);
+    const before = await runOwnViewerProbes(client, users);
+    await resetRole(client);
+
+    await client.query(migrationBody(migrationPath));
+
+    await setAuthenticatedContext(client, users.viewer);
+    const after = await runOwnViewerProbes(client, users);
+    const spoofed = await runSpoofedViewerProbes(client, users);
+    await resetRole(client);
+
+    assert.deepEqual(after, before, "current-viewer behavior changed after hardening");
+    assert.equal(spoofed.collectors_visible, false);
+    assert.equal(spoofed.event_visible, false);
+    assert.equal(spoofed.local_visible, false);
+    assert.equal(spoofed.blocked, true, "unrelated block probe must fail closed");
+    assert.equal(spoofed.resolved_visibility, "private");
+    assert.equal(spoofed.binder_event_visible, false);
+
+    await client.query("rollback");
+    transactionOpen = false;
+    const finalHashes = await readFunctionHashes(client);
+    assert.deepEqual(finalHashes, baselineHashes, "rollback did not restore function definitions");
+
+    process.stdout.write(`${JSON.stringify({
+      package_id: PACKAGE_ID,
+      mode: "rollback_only",
+      migration: path.relative(process.cwd(), migrationPath).replaceAll("\\", "/"),
+      current_viewer_behavior_unchanged: true,
+      spoofed_viewer_results: spoofed,
+      function_definitions_restored: true,
+      persistent_database_changes: 0,
+      verdict: "pass",
+    }, null, 2)}\n`);
+  } finally {
+    if (transactionOpen) {
+      await resetRole(client).catch(() => {});
+      await client.query("rollback").catch(() => {});
+    }
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${PACKAGE_ID}: ${error?.stack ?? error}\n`);
+  process.exitCode = 1;
+});

--- a/supabase/migrations/20260731211500_security_advisor_viewer_argument_binding_v1.sql
+++ b/supabase/migrations/20260731211500_security_advisor_viewer_argument_binding_v1.sql
@@ -1,0 +1,390 @@
+-- SECURITY_ADVISOR_VIEWER_ARGUMENT_BINDING_V1
+-- Prevents authenticated callers from evaluating privacy predicates as an
+-- arbitrary viewer while preserving service-owned composition and RLS calls.
+
+begin;
+
+create or replace function public.interest_graph_collectors_visible_to_viewer_v1(
+  p_viewer_user_id uuid,
+  p_actor_user_id uuid,
+  p_subject_user_id uuid default null
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is not null
+     and p_viewer_user_id is distinct from auth.uid() then
+    return false;
+  end if;
+
+  if p_viewer_user_id is null or p_actor_user_id is null then
+    return false;
+  end if;
+
+  if public.interest_graph_collector_public_v1(p_actor_user_id) is false then
+    return false;
+  end if;
+
+  if p_subject_user_id is not null
+     and p_subject_user_id <> p_viewer_user_id
+     and public.interest_graph_collector_public_v1(p_subject_user_id) is false then
+    return false;
+  end if;
+
+  if public.local_community_collectors_are_blocked_v1(p_viewer_user_id, p_actor_user_id) then
+    return false;
+  end if;
+
+  if p_subject_user_id is not null
+     and p_subject_user_id <> p_actor_user_id
+     and public.local_community_collectors_are_blocked_v1(p_viewer_user_id, p_subject_user_id) then
+    return false;
+  end if;
+
+  if exists (
+    select 1
+    from public.collector_local_mutes m
+    where m.muter_user_id = p_viewer_user_id
+      and m.muted_user_id = p_actor_user_id
+      and (m.expires_at is null or m.expires_at > now())
+  ) then
+    return false;
+  end if;
+
+  if p_subject_user_id is not null
+     and p_subject_user_id <> p_actor_user_id
+     and exists (
+       select 1
+       from public.collector_local_mutes m
+       where m.muter_user_id = p_viewer_user_id
+         and m.muted_user_id = p_subject_user_id
+         and (m.expires_at is null or m.expires_at > now())
+     ) then
+    return false;
+  end if;
+
+  return true;
+end;
+$$;
+
+create or replace function public.interest_graph_card_event_visible_to_viewer_v1(
+  p_viewer_user_id uuid,
+  p_actor_user_id uuid,
+  p_subject_user_id uuid,
+  p_visibility text
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is not null
+     and p_viewer_user_id is distinct from auth.uid() then
+    return false;
+  end if;
+
+  if p_viewer_user_id is null then
+    return false;
+  end if;
+
+  if p_actor_user_id = p_viewer_user_id
+     or p_subject_user_id = p_viewer_user_id then
+    return true;
+  end if;
+
+  if p_visibility = 'private' then
+    return false;
+  end if;
+
+  if public.interest_graph_collectors_visible_to_viewer_v1(
+    p_viewer_user_id,
+    p_actor_user_id,
+    p_subject_user_id
+  ) is false then
+    return false;
+  end if;
+
+  if p_visibility = 'followers' then
+    return exists (
+      select 1
+      from public.collector_follows cf
+      where cf.follower_user_id = p_viewer_user_id
+        and cf.followed_user_id = p_actor_user_id
+    );
+  end if;
+
+  return p_visibility = 'public';
+end;
+$$;
+
+create or replace function public.card_events_resolve_visibility_v1(
+  p_event_type text,
+  p_actor_user_id uuid,
+  p_requested_visibility text default null,
+  p_payload jsonb default '{}'::jsonb
+)
+returns text
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_event_type text := lower(btrim(coalesce(p_event_type, '')));
+  v_requested text := lower(btrim(coalesce(p_requested_visibility, 'private')));
+  v_next_intent text := lower(btrim(coalesce(p_payload ->> 'next_intent', '')));
+begin
+  if auth.uid() is not null
+     and p_actor_user_id is distinct from auth.uid() then
+    return 'private';
+  end if;
+
+  if v_event_type = 'vault_added' then
+    if public.interest_graph_collector_public_v1(p_actor_user_id) then
+      return 'public';
+    end if;
+    return 'private';
+  end if;
+
+  if v_event_type = 'vault_intent_changed' then
+    if v_next_intent = any (array['trade'::text, 'sell'::text, 'showcase'::text])
+       and public.interest_graph_collector_public_v1(p_actor_user_id) then
+      return 'public';
+    end if;
+    return 'private';
+  end if;
+
+  if v_event_type = 'wall_updated' then
+    if public.interest_graph_collector_public_v1(p_actor_user_id) then
+      return 'public';
+    end if;
+    return 'private';
+  end if;
+
+  if v_event_type = 'collector_followed' then
+    return 'followers';
+  end if;
+
+  if v_event_type = any (array[
+    'collector_unfollowed'::text,
+    'want_added'::text,
+    'want_removed'::text,
+    'set_completion_crossed'::text,
+    'dex_completion_crossed'::text,
+    'vault_import'::text,
+    'scanner_v5_vault_add_enriched'::text
+  ]) then
+    return 'private';
+  end if;
+
+  if v_requested = any (array['public'::text, 'followers'::text, 'private'::text]) then
+    return v_requested;
+  end if;
+
+  return 'private';
+end;
+$$;
+
+create or replace function public.local_community_collector_visible_to_viewer_v1(
+  p_viewer_user_id uuid,
+  p_owner_user_id uuid
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is not null
+     and p_viewer_user_id is distinct from auth.uid() then
+    return false;
+  end if;
+
+  if p_viewer_user_id is null or p_owner_user_id is null then
+    return false;
+  end if;
+
+  if public.interest_graph_collector_public_v1(p_owner_user_id) is false then
+    return false;
+  end if;
+
+  if public.local_community_collectors_are_blocked_v1(p_viewer_user_id, p_owner_user_id) then
+    return false;
+  end if;
+
+  if exists (
+    select 1
+    from public.collector_local_mutes m
+    where m.muter_user_id = p_viewer_user_id
+      and m.muted_user_id = p_owner_user_id
+      and (m.expires_at is null or m.expires_at > now())
+  ) then
+    return false;
+  end if;
+
+  return true;
+end;
+$$;
+
+create or replace function public.trust_block_exists_between_v1(
+  p_user_id uuid,
+  p_other_user_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select case
+    when auth.uid() is not null
+         and auth.uid() is distinct from p_user_id
+         and auth.uid() is distinct from p_other_user_id
+      then true
+    else exists (
+      select 1
+      from public.trust_blocks tb
+      where (
+        tb.user_id = p_user_id
+        and tb.blocked_user_id = p_other_user_id
+      )
+      or (
+        tb.user_id = p_other_user_id
+        and tb.blocked_user_id = p_user_id
+      )
+    )
+  end;
+$$;
+
+create or replace function public.binder_card_event_visible_to_viewer_v1(
+  p_viewer_user_id uuid,
+  p_event_type text,
+  p_card_print_id uuid,
+  p_actor_user_id uuid,
+  p_subject_user_id uuid,
+  p_visibility text,
+  p_payload jsonb,
+  p_dedupe_key text
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_event_type text := lower(btrim(coalesce(p_event_type, '')));
+  v_public_id uuid;
+  v_revision integer;
+  v_threshold integer;
+begin
+  if auth.uid() is not null
+     and p_viewer_user_id is distinct from auth.uid() then
+    return false;
+  end if;
+
+  if left(v_event_type, 7) <> 'binder_' then
+    return public.interest_graph_card_event_visible_to_viewer_v1(
+      p_viewer_user_id,
+      p_actor_user_id,
+      p_subject_user_id,
+      p_visibility
+    );
+  end if;
+  if v_event_type <> 'binder_milestone_shared'
+     or p_card_print_id is not null
+     or p_subject_user_id is not null
+     or p_visibility <> 'public'
+     or jsonb_typeof(coalesce(p_payload, 'null'::jsonb)) <> 'object'
+     or not public.interest_graph_card_event_visible_to_viewer_v1(
+       p_viewer_user_id,
+       p_actor_user_id,
+       p_subject_user_id,
+       p_visibility
+     ) then
+    return false;
+  end if;
+
+  v_public_id := public.pulse_jsonb_uuid_v1(p_payload ->> 'binder_public_id');
+  if nullif(p_payload ->> 'definition_revision', '') !~ '^[0-9]+$'
+     or nullif(p_payload ->> 'threshold', '') !~ '^[0-9]+$' then
+    return false;
+  end if;
+  v_revision := (p_payload ->> 'definition_revision')::integer;
+  v_threshold := (p_payload ->> 'threshold')::integer;
+  if v_public_id is null
+     or v_revision < 1
+     or v_threshold not in (25, 50, 75, 90, 100)
+     or p_dedupe_key is distinct from concat_ws(
+       ':',
+       'binder-milestone',
+       v_public_id::text,
+       v_revision::text,
+       v_threshold::text
+     ) then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.binders b
+    where b.public_id = v_public_id
+      and b.owner_user_id = p_actor_user_id
+      and b.definition_revision = v_revision
+      and b.lifecycle = 'active'
+      and b.moderation_state = 'clear'
+      and b.read_access = 'public'
+      and b.discoverability = 'listed'
+      and public.binder_feature_enabled_v1('schema_internal')
+      and public.binder_feature_enabled_v1('public')
+      and public.binder_feature_enabled_v1('pulse_milestones')
+      and public.binder_target_enabled_v1(b.id)
+      and public.interest_graph_collector_public_v1(b.owner_user_id)
+      and not public.binder_pair_blocked_v1(p_viewer_user_id, b.owner_user_id)
+      and exists (
+        select 1
+        from public.binder_progress_crossings crossing
+        where crossing.binder_id = b.id
+          and crossing.definition_revision = v_revision
+          and crossing.threshold = v_threshold
+      )
+      and exists (
+        select 1
+        from public.binder_activity_events activity
+        where activity.binder_id = b.id
+          and activity.event_type = 'milestone_shared_to_pulse'
+          and activity.actor_kind = 'user'
+          and activity.actor_user_id = b.owner_user_id
+          and activity.payload ->> 'definition_revision' = v_revision::text
+          and activity.payload ->> 'threshold' = v_threshold::text
+      )
+  );
+exception
+  when others then
+    return false;
+end;
+$$;
+
+comment on function public.interest_graph_collectors_visible_to_viewer_v1(uuid, uuid, uuid) is
+'Viewer privacy predicate. Authenticated callers are bound to auth.uid(); service-owned composition remains supported.';
+comment on function public.interest_graph_card_event_visible_to_viewer_v1(uuid, uuid, uuid, text) is
+'Event privacy predicate. Authenticated callers are bound to auth.uid(); service-owned composition remains supported.';
+comment on function public.card_events_resolve_visibility_v1(text, uuid, text, jsonb) is
+'Write-time visibility predicate. Authenticated actor claims are bound to auth.uid(); mismatches resolve private.';
+comment on function public.local_community_collector_visible_to_viewer_v1(uuid, uuid) is
+'Local-community privacy predicate. Authenticated callers are bound to auth.uid(); service-owned composition remains supported.';
+comment on function public.trust_block_exists_between_v1(uuid, uuid) is
+'Block privacy predicate. Authenticated callers may evaluate only a pair involving auth.uid(); mismatches fail closed.';
+comment on function public.binder_card_event_visible_to_viewer_v1(uuid, text, uuid, uuid, uuid, text, jsonb, text) is
+'Binder event privacy predicate. Authenticated callers are bound to auth.uid(); service-owned composition remains supported.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/contracts/supabase_viewer_argument_binding_v1.test.mjs
+++ b/tests/contracts/supabase_viewer_argument_binding_v1.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const migration = fs.readFileSync(
+  "supabase/migrations/20260731211500_security_advisor_viewer_argument_binding_v1.sql",
+  "utf8",
+);
+const interactionHelper = fs.readFileSync(
+  "apps/web/src/lib/network/insertCardInteraction.ts",
+  "utf8",
+);
+
+const viewerBoundFunctions = [
+  "interest_graph_collectors_visible_to_viewer_v1",
+  "interest_graph_card_event_visible_to_viewer_v1",
+  "local_community_collector_visible_to_viewer_v1",
+  "binder_card_event_visible_to_viewer_v1",
+];
+
+test("viewer-aware privacy helpers bind authenticated calls to auth.uid", () => {
+  for (const functionName of viewerBoundFunctions) {
+    const start = migration.indexOf(`function public.${functionName}(`);
+    assert.notEqual(start, -1, `${functionName} must be redefined`);
+    const body = migration.slice(start, migration.indexOf("$$;", start));
+    assert.match(body, /auth\.uid\(\) is not null/i);
+    assert.match(body, /p_viewer_user_id is distinct from auth\.uid\(\)/i);
+    assert.match(body, /return false/i);
+  }
+});
+
+test("event actor and trust-pair mismatches fail closed", () => {
+  assert.match(
+    migration,
+    /p_actor_user_id is distinct from auth\.uid\(\)[\s\S]*?return 'private'/i,
+  );
+  assert.match(
+    migration,
+    /auth\.uid\(\) is distinct from p_user_id[\s\S]*?auth\.uid\(\) is distinct from p_other_user_id[\s\S]*?then true/i,
+  );
+});
+
+test("web trust check prefers the current-viewer wrapper and remains transition-safe", () => {
+  const wrapper = interactionHelper.indexOf("trust_block_exists_for_current_viewer_v1");
+  const fallback = interactionHelper.indexOf("trust_block_exists_between_v1");
+  assert.ok(wrapper >= 0, "current-viewer wrapper must be used");
+  assert.ok(fallback > wrapper, "legacy call may exist only as a post-wrapper transition fallback");
+  assert.match(interactionHelper, /if \(!currentViewerResult\.error\)/);
+  assert.match(interactionHelper, /return error \? true : data !== false/);
+});
+
+test("migration preserves service-owned execution and fixed search paths", () => {
+  assert.doesNotMatch(migration, /revoke\s+execute[\s\S]*service_role/i);
+  assert.equal(
+    (migration.match(/security definer/gi) ?? []).length,
+    viewerBoundFunctions.length + 2,
+  );
+  assert.equal(
+    (migration.match(/set search_path = public/gi) ?? []).length,
+    viewerBoundFunctions.length + 2,
+  );
+});


### PR DESCRIPTION
## What changed
- bind viewer-aware privacy predicates to `auth.uid()` for authenticated calls
- fail closed when event actor or trust-pair arguments do not involve the signed-in user
- prefer the current-viewer trust wrapper in the web interaction path with a deployment-order fallback
- add deterministic contracts and a rollback-only live database proof

## Why
Several `SECURITY DEFINER` helpers intentionally remain callable by signed-in users for RLS and governed RPC composition. Their viewer parameters still needed to be bound to the actual signed-in caller so direct RPC calls cannot inspect another collector's privacy context.

## Verification
- rollback-only production proof: current-viewer outputs unchanged, six spoofed probes fail closed, zero persistent writes
- full contracts: 1,222/1,222 passed
- web typecheck, lint, strict production build, runtime preflight, secret guard, and `git diff --check` passed
- local Flutter was blocked by VS Code holding the SDK `icudtl.dat`; GitHub CI is the authoritative clean-run check

## Deployment boundary
The migration remains ordered behind the active pricing canary migrations. This PR does not apply any production database change.