### PR TITLE
Probe the governed pricing read model in the canary

### DIFF
--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -257,12 +257,12 @@ async function queryEvidence(client, args, asOf) {
       `select
          has_function_privilege(
            'authenticated',
-           'public.get_top_market_pricing_v1(integer)',
+           'public.get_market_pricing_read_model_v1(uuid[],uuid[])',
            'EXECUTE'
          ) as authenticated_execute_granted,
          has_function_privilege(
            'anon',
-           'public.get_top_market_pricing_v1(integer)',
+           'public.get_market_pricing_read_model_v1(uuid[],uuid[])',
            'EXECUTE'
          ) as anonymous_execute_granted,
          has_function_privilege(
@@ -273,17 +273,38 @@ async function queryEvidence(client, args, asOf) {
     )
   ).rows[0];
 
+  const sampleCardPrintIds = (
+    await client.query(
+      `select distinct current_price.card_print_id
+       from public.v_market_price_current_v1 current_price
+       where current_price.card_print_id is not null
+       order by current_price.card_print_id
+       limit 1`,
+    )
+  ).rows.map((row) => row.card_print_id);
+  if (sampleCardPrintIds.length !== 1) {
+    throw new Error("No current card print is available for the authenticated read-model probe");
+  }
+
   let authenticatedReadCount = 0;
+  let authenticatedRuntimeLatencyMs = null;
   await client.query("set role authenticated");
   try {
+    const startedAt = performance.now();
     authenticatedReadCount = Number(
       (
         await client.query(
           `select count(*)::integer as row_count
-           from public.get_top_market_pricing_v1($1)`,
-          [args.expectedCount],
+           from public.get_market_pricing_read_model_v1(
+             $1::uuid[],
+             '{}'::uuid[]
+           )`,
+          [sampleCardPrintIds],
         )
       ).rows[0]?.row_count ?? 0,
+    );
+    authenticatedRuntimeLatencyMs = Number(
+      (performance.now() - startedAt).toFixed(3),
     );
   } finally {
     await client.query("reset role");
@@ -295,8 +316,11 @@ async function queryEvidence(client, args, asOf) {
   try {
     await client.query(
       `select count(*)::integer
-       from public.get_top_market_pricing_v1($1)`,
-      [1],
+       from public.get_market_pricing_read_model_v1(
+         $1::uuid[],
+         '{}'::uuid[]
+       )`,
+      [sampleCardPrintIds],
     );
   } catch (error) {
     anonymousRuntimeCode = error.code ?? null;
@@ -316,6 +340,8 @@ async function queryEvidence(client, args, asOf) {
       authenticated_execute_granted:
         grants.authenticated_execute_granted === true,
       authenticated_read_count: authenticatedReadCount,
+      authenticated_runtime_latency_ms: authenticatedRuntimeLatencyMs,
+      sampled_card_print_ids: sampleCardPrintIds,
       anonymous_execute_granted: grants.anonymous_execute_granted === true,
       anonymous_runtime_denied: anonymousRuntimeDenied,
       anonymous_runtime_code: anonymousRuntimeCode,
@@ -361,6 +387,7 @@ function markdown(report) {
     "## Access",
     "",
     `- Authenticated runtime rows: \`${report.access.authenticated_read_count}\``,
+    `- Authenticated runtime latency: \`${report.access.authenticated_runtime_latency_ms} ms\``,
     `- Anonymous runtime denied: \`${report.access.anonymous_runtime_denied}\``,
     `- Anonymous denial code: \`${report.access.anonymous_runtime_code}\``,
     "",

--- a/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_workflow_v1.test.mjs
@@ -16,6 +16,10 @@ const WORKFLOW_PATH = path.join(
   "tcgplayer-market-canary-observation.yml",
 );
 const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+const observer = fs.readFileSync(
+  path.join(ROOT, "scripts", "audits", "tcgplayer_market_canary_observation_v1.mjs"),
+  "utf8",
+);
 
 test("scheduled canary observer is pinned to the reviewed source and canary", () => {
   assert.match(
@@ -65,4 +69,18 @@ test("scheduled canary observer is read-only and cannot apply migrations", () =>
   assert.doesNotMatch(workflow, /pricing:market:[^\s]*apply/i);
   assert.doesNotMatch(workflow, /tcgplayer_market_publication_worker_v1/i);
   assert.doesNotMatch(workflow, /tcgplayer_market_pipeline_v1/i);
+});
+
+test("canary runtime probe exercises the governed shared read model", () => {
+  assert.match(
+    observer,
+    /get_market_pricing_read_model_v1\(uuid\[\],uuid\[\]\)/,
+  );
+  assert.match(
+    observer,
+    /from public\.get_market_pricing_read_model_v1\([\s\S]*?\$1::uuid\[\][\s\S]*?'\{\}'::uuid\[\]/,
+  );
+  assert.match(observer, /authenticated_runtime_latency_ms/);
+  assert.match(observer, /sampled_card_print_ids/);
+  assert.doesNotMatch(observer, /from public\.get_top_market_pricing_v1\(/);
 });


### PR DESCRIPTION
## What changed
- replace the canary's catalog-wide top-market RPC probe with a bounded authenticated call to `get_market_pricing_read_model_v1`
- sample one currently published canonical card for the runtime proof
- verify the same governed RPC is denied to `anon`
- record runtime latency and the sampled card ID

## Root cause
The observer was certifying access through `get_top_market_pricing_v1`, whose pre-migration parent-summary plan expands the active-listing evidence graph and timed out after 120 seconds. The canary is intended to certify the shared pricing read contract, not the post-migration top-market browse surface.

## Live proof
- status: `observing`
- current prices: 100/100 positive USD
- missing provenance/stale/broken traces: 0/0/0
- authenticated shared-read result: 1 row in 150.211 ms
- anonymous call: denied with SQLSTATE 42501
- findings: none
- persistent database writes: none

## Verification
- focused canary contracts: 10/10
- full repository contracts: passed
- runtime preflight: 0 critical failures
- syntax and diff checks: passed

The top-market browse RPC remains a post-migration performance/surface gate; this change does not apply migrations or alter production pricing.