### PR TITLE
Probe the governed wall feed boundary

### DIFF
--- a/.github/workflows/prod-probe.yml
+++ b/.github/workflows/prod-probe.yml
@@ -57,7 +57,7 @@ jobs:
             --connect-timeout 10 \
             --max-time 30 \
             -H "apikey: $ANON" \
-            -H "Authorization: Bearer $ANON" \
+            --oauth2-bearer "$ANON" \
             "${SUPABASE_URL%/}/functions/v1/wall_feed?limit=1")
 
           jq -n \

--- a/.github/workflows/prod-probe.yml
+++ b/.github/workflows/prod-probe.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REST: ${{ secrets.PROD_REST }}
+      SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
       ANON: ${{ secrets.PROD_PUBLISHABLE_KEY }}
     steps:
       - name: Validate probe configuration
@@ -18,18 +19,19 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p probe-artifacts
-          if [[ -z "$REST" || -z "$ANON" ]]; then
+          if [[ -z "$REST" || -z "$SUPABASE_URL" || -z "$ANON" ]]; then
             {
               echo "# Production Core API Probe"
               echo
               echo "Probe configuration is incomplete."
-              [[ -n "$REST" ]] || echo "- PROD_REST is missing"
-              [[ -n "$ANON" ]] || echo "- PROD_PUBLISHABLE_KEY is missing"
+            [[ -n "$REST" ]] || echo "- PROD_REST is missing"
+            [[ -n "$SUPABASE_URL" ]] || echo "- PROD_SUPABASE_URL is missing"
+            [[ -n "$ANON" ]] || echo "- PROD_PUBLISHABLE_KEY is missing"
             } | tee probe-artifacts/SUMMARY.md >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
-      - name: Probe public search RPC and wall view
+      - name: Probe public search RPC and wall feed edge function
         shell: bash
         run: |
           set -euo pipefail
@@ -49,26 +51,26 @@ jobs:
             -d "$rpc_body" \
             "$REST/rpc/search_cards")
 
-          view_code=$(curl --silent --show-error \
+          wall_code=$(curl --silent --show-error \
             --output "$artifact_dir/wall_feed.json" \
             --write-out "%{http_code}" \
             --connect-timeout 10 \
             --max-time 30 \
             -H "apikey: $ANON" \
-            -H "Accept-Profile: public" \
-            "$REST/v_wall_feed?select=card_id&limit=1")
+            -H "Authorization: Bearer $ANON" \
+            "${SUPABASE_URL%/}/functions/v1/wall_feed?limit=1")
 
           jq -n \
             --arg rpc_code "$rpc_code" \
-            --arg view_code "$view_code" \
-            '{schema_version:"PROD_CORE_API_PROBE_RESULT_V1",search_cards_http_status:($rpc_code|tonumber),wall_feed_http_status:($view_code|tonumber)}' \
+            --arg wall_code "$wall_code" \
+            '{schema_version:"PROD_CORE_API_PROBE_RESULT_V1",search_cards_http_status:($rpc_code|tonumber),wall_feed_edge_http_status:($wall_code|tonumber)}' \
             > "$artifact_dir/probe.json"
 
           {
             echo "# Production Core API Probe"
             echo
             echo "- search_cards RPC: HTTP $rpc_code"
-            echo "- v_wall_feed view: HTTP $view_code"
+            echo "- wall_feed Edge Function: HTTP $wall_code"
           } | tee "$artifact_dir/SUMMARY.md" >> "$GITHUB_STEP_SUMMARY"
 
           test "$rpc_code" = "200" || {
@@ -76,13 +78,14 @@ jobs:
             cat "$artifact_dir/search_cards.json" >&2
             exit 1
           }
-          test "$view_code" = "200" || {
-            echo "v_wall_feed returned HTTP $view_code" >&2
+          test "$wall_code" = "200" || {
+            echo "wall_feed Edge Function returned HTTP $wall_code" >&2
             cat "$artifact_dir/wall_feed.json" >&2
             exit 1
           }
           jq -e 'type == "array"' "$artifact_dir/search_cards.json" > /dev/null
-          jq -e 'type == "array"' "$artifact_dir/wall_feed.json" > /dev/null
+          jq -e '(.items | type == "array") and (.count | type == "number")' \
+            "$artifact_dir/wall_feed.json" > /dev/null
 
       - name: Upload probe evidence
         if: ${{ always() }}

--- a/tests/contracts/prod_core_api_probe_truthfulness_v1.test.mjs
+++ b/tests/contracts/prod_core_api_probe_truthfulness_v1.test.mjs
@@ -12,17 +12,26 @@ const WORKFLOW = readFileSync(
 
 test("production core API probe fails when required configuration is missing", () => {
   assert.match(WORKFLOW, /set -euo pipefail/);
-  assert.match(WORKFLOW, /\[\[ -z "\$REST" \|\| -z "\$ANON" \]\]/);
+  assert.match(
+    WORKFLOW,
+    /\[\[ -z "\$REST" \|\| -z "\$SUPABASE_URL" \|\| -z "\$ANON" \]\]/,
+  );
   assert.match(WORKFLOW, /PROD_REST is missing/);
+  assert.match(WORKFLOW, /PROD_SUPABASE_URL is missing/);
   assert.match(WORKFLOW, /PROD_PUBLISHABLE_KEY is missing/);
   assert.doesNotMatch(WORKFLOW, /Always succeed/);
 });
 
 test("production core API probe enforces HTTP and JSON response contracts", () => {
   assert.match(WORKFLOW, /test "\$rpc_code" = "200"/);
-  assert.match(WORKFLOW, /test "\$view_code" = "200"/);
+  assert.match(WORKFLOW, /test "\$wall_code" = "200"/);
   assert.match(WORKFLOW, /jq -e 'type == "array"' "\$artifact_dir\/search_cards\.json"/);
-  assert.match(WORKFLOW, /jq -e 'type == "array"' "\$artifact_dir\/wall_feed\.json"/);
+  assert.match(
+    WORKFLOW,
+    /jq -e '\(\.items \| type == "array"\) and \(\.count \| type == "number"\)'/,
+  );
+  assert.match(WORKFLOW, /\/functions\/v1\/wall_feed\?limit=1/);
+  assert.doesNotMatch(WORKFLOW, /\/v_wall_feed\?/);
   assert.doesNotMatch(WORKFLOW, /\|\| echo N\/A/);
 });
 

--- a/tests/contracts/prod_core_api_probe_truthfulness_v1.test.mjs
+++ b/tests/contracts/prod_core_api_probe_truthfulness_v1.test.mjs
@@ -31,6 +31,8 @@ test("production core API probe enforces HTTP and JSON response contracts", () =
     /jq -e '\(\.items \| type == "array"\) and \(\.count \| type == "number"\)'/,
   );
   assert.match(WORKFLOW, /\/functions\/v1\/wall_feed\?limit=1/);
+  assert.match(WORKFLOW, /--oauth2-bearer "\$ANON"/);
+  assert.doesNotMatch(WORKFLOW, /Authorization:\s*Bearer/);
   assert.doesNotMatch(WORKFLOW, /\/v_wall_feed\?/);
   assert.doesNotMatch(WORKFLOW, /\|\| echo N\/A/);
 });


### PR DESCRIPTION
## What changed
- update the production core API probe to call the deployed `wall_feed` Edge Function instead of anonymously reading the private database view
- require the production Supabase URL secret explicitly
- send the public API key through the same headers as the real client boundary
- validate the Edge response contract as `{ items: array, count: number }`

## Root cause
The probe still targeted `/rest/v1/v_wall_feed`. That view is intentionally not an anonymous product boundary and correctly failed with `42501` on its underlying materialized view. The deployed read-only Edge Function owns the service authority and fixed response shape.

## Evidence
- old core probe failure: HTTP 401 / SQLSTATE 42501 on direct view access
- independent current Edge probe: passed
- focused workflow contracts: 3/3 passed
- `git diff --check`: passed

This change does not alter production data or Edge Function behavior.