### PR TITLE
Harden active runtime security boundaries

### DIFF
--- a/backend/identity/normalizeCardNameV1.mjs
+++ b/backend/identity/normalizeCardNameV1.mjs
@@ -21,7 +21,6 @@ function sanitizeBrokenCharacters(value) {
 function normalizeForDistance(value) {
   return collapseWhitespace(sanitizeBrokenCharacters(value))
     .toLowerCase()
-    .replace(/\bex\b/g, 'ex')
     .trim();
 }
 

--- a/backend/identity_v3/scanner_v5/run_scanner_v5_identity_service_v1.mjs
+++ b/backend/identity_v3/scanner_v5/run_scanner_v5_identity_service_v1.mjs
@@ -77,9 +77,10 @@ async function main() {
   };
   const server = createServer((request, response) => {
     handleRequest(request, response, service).catch((error) => {
+      console.error('[scanner-v5] unhandled request failure', error);
       writeJson(response, 500, {
         ok: false,
-        error: error?.message || String(error),
+        error: 'internal_error',
       });
     });
   });
@@ -235,7 +236,7 @@ async function handleRequest(request, response, service) {
         rectification: null,
         rectified_debug_path: null,
         retake_hint: 'Retake with the full card centered, in focus, and evenly lit.',
-        error: error?.message || String(error),
+        error: 'scan_processing_failed',
       });
     }
     return;

--- a/backend/ingestion/controlled_growth_ingestion_worker_v1.mjs
+++ b/backend/ingestion/controlled_growth_ingestion_worker_v1.mjs
@@ -24,8 +24,8 @@ if (HAS_APPLY && HAS_DRY_RUN) {
 
 const APOSTROPHE_VARIANTS_RE = /[\u2018\u2019`´]/g;
 const DASH_SEPARATOR_VARIANTS_RE = /[\u2013\u2014]/g;
-const TERMINAL_EX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+EX$/i;
-const TERMINAL_GX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+GX$/i;
+const TERMINAL_EX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)EX$/i;
+const TERMINAL_GX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)GX$/i;
 const PRODUCT_NOISE_RE = /\bcode\s*card\b/i;
 
 function normalizeTextOrNull(value) {

--- a/backend/pricing/run_pricing_observation_live_validation_v1.mjs
+++ b/backend/pricing/run_pricing_observation_live_validation_v1.mjs
@@ -34,7 +34,7 @@ function buildRunId(explicitRunId = null) {
   if (explicitRunId && String(explicitRunId).trim()) {
     return String(explicitRunId).trim();
   }
-  return `live_validation_v1_${new Date().toISOString().replace(/[-:.]/g, '').replace('Z', 'Z')}`;
+  return `live_validation_v1_${new Date().toISOString().replace(/[-:.]/g, '')}`;
 }
 
 function printJsonBlock(label, value) {

--- a/supabase/functions/identity_scan_enqueue_v1/index.ts
+++ b/supabase/functions/identity_scan_enqueue_v1/index.ts
@@ -17,23 +17,6 @@ function isUuid(v: string | undefined | null): boolean {
 
 serve(async (req) => {
   try {
-    const authHeader = req.headers.get("authorization") ?? "";
-    const xbear = req.headers.get("x-gv-bearer") ?? "";
-    console.log(
-      JSON.stringify(
-        {
-          stage: "auth_probe",
-          has_auth: !!authHeader,
-          auth_len: authHeader.length,
-          auth_prefix: authHeader.slice(0, 20),
-          has_xbear: !!xbear,
-          xbear_len: xbear.length,
-          xbear_prefix: xbear.slice(0, 20),
-        },
-        null,
-        0,
-      ),
-    );
     if (req.method === "OPTIONS") {
       return new Response("ok", { status: 200 });
     }
@@ -82,7 +65,7 @@ serve(async (req) => {
       .eq("id", candidateId)
       .eq("user_id", userId)
       .maybeSingle();
-    if (identityErr) return json(500, { error: "snapshot_lookup_failed", detail: identityErr.message });
+    if (identityErr) return json(500, { error: "snapshot_lookup_failed" });
     if (identitySnap) {
       resolvedSnapshotId = identitySnap.id;
       snapshotUserId = identitySnap.user_id ?? null;
@@ -95,7 +78,7 @@ serve(async (req) => {
         .eq("id", candidateId)
         .eq("user_id", userId)
         .maybeSingle();
-      if (snapErr) return json(500, { error: "snapshot_lookup_failed", detail: snapErr.message });
+      if (snapErr) return json(500, { error: "snapshot_lookup_failed" });
       if (!snap) return json(404, { error: "snapshot_not_found" });
       resolvedSnapshotId = snap.id;
       snapshotUserId = snap.user_id ?? null;
@@ -141,11 +124,12 @@ serve(async (req) => {
       .maybeSingle();
 
     if (insErr || !inserted?.id) {
-      return json(500, { error: "enqueue_failed", detail: insErr?.message ?? "unknown" });
+      return json(500, { error: "enqueue_failed" });
     }
 
     return json(200, { identity_scan_event_id: inserted.id, status: "pending" });
   } catch (e) {
-    return json(500, { error: "internal_error", detail: String((e as Error)?.message ?? e) });
+    console.error("[identity_scan_enqueue_v1] request failed", e);
+    return json(500, { error: "internal_error" });
   }
 });

--- a/supabase/functions/identity_scan_get_v1/index.ts
+++ b/supabase/functions/identity_scan_get_v1/index.ts
@@ -23,9 +23,12 @@ serve(async (req) => {
       sb = auth.sb;
       userId = auth.userId;
     } catch (err) {
-      if (err?.code === "missing_bearer_token") return json(401, { error: "missing_bearer_token" });
-      if (err?.code === "invalid_jwt") return json(401, { error: "invalid_jwt" });
-      if (err?.code === "server_misconfigured") return json(500, { error: "server_misconfigured" });
+      const code = (typeof err === "object" && err !== null && "code" in err)
+        ? String((err as { code?: unknown }).code ?? "")
+        : "";
+      if (code === "missing_bearer_token") return json(401, { error: "missing_bearer_token" });
+      if (code === "invalid_jwt") return json(401, { error: "invalid_jwt" });
+      if (code === "server_misconfigured") return json(500, { error: "server_misconfigured" });
       throw err;
     }
 
@@ -45,7 +48,7 @@ serve(async (req) => {
         .eq("user_id", userId)
         .maybeSingle();
 
-      if (error) return json(500, { error: "fetch_failed", detail: error.message });
+      if (error) return json(500, { error: "fetch_failed" });
       if (!data) return json(404, { error: "not_found" });
       return json(200, { event: data });
     }
@@ -58,9 +61,10 @@ serve(async (req) => {
       .order("id", { ascending: false })
       .range(offset, offset + limit - 1);
 
-    if (error) return json(500, { error: "fetch_failed", detail: error.message });
+    if (error) return json(500, { error: "fetch_failed" });
     return json(200, { events: data ?? [] });
   } catch (e) {
-    return json(500, { error: "internal_error", detail: String((e as Error)?.message ?? e) });
+    console.error("[identity_scan_get_v1] request failed", e);
+    return json(500, { error: "internal_error" });
   }
 });

--- a/supabase/functions/ingestion-enqueue-v1/index.ts
+++ b/supabase/functions/ingestion-enqueue-v1/index.ts
@@ -78,7 +78,7 @@ const handler = async (req: Request): Promise<Response> => {
     .single();
 
   if (error || !data) {
-    return json(500, { error: "enqueue_failed", detail: error?.message ?? "Failed to enqueue job" });
+    return json(500, { error: "enqueue_failed" });
   }
 
   return json(201, {

--- a/supabase/functions/notification-dispatcher/index.ts
+++ b/supabase/functions/notification-dispatcher/index.ts
@@ -990,7 +990,7 @@ serve(async (req) => {
                 .toISOString(),
             }, invocationSignal),
           ]);
-          return { id: row.id, status: "error", reason };
+          return { id: row.id, status: "error", reason: "dispatch_failed" };
         }
       }));
       results.push(...chunkResults);
@@ -1003,10 +1003,10 @@ serve(async (req) => {
       fcm_mode: shouldUseMockFcm(requestBody) ? "mock" : "real",
     });
   } catch (error) {
+    console.error("[notification-dispatcher] request failed", error);
     return corsJson(500, {
       ok: false,
       error: "notification_dispatcher_failed",
-      detail: String((error as Error)?.message ?? error),
     });
   }
 });

--- a/supabase/functions/operations-webhook-v1/index.ts
+++ b/supabase/functions/operations-webhook-v1/index.ts
@@ -121,10 +121,10 @@ serve(async (req) => {
       dispatch,
     });
   } catch (error) {
+    console.error("[operations-webhook-v1] request failed", error);
     return corsJson(500, {
       ok: false,
       error: "operations_webhook_failed",
-      detail: String((error as Error)?.message ?? error),
     });
   }
 });

--- a/supabase/functions/scan-read/index.ts
+++ b/supabase/functions/scan-read/index.ts
@@ -20,7 +20,7 @@ serve(async (req) => {
 
     const url = Deno.env.get("SUPABASE_URL");
     const publishableKey = getPublishableKey();
-    if (!url || !publishableKey) return json(500, { error: "missing_env", details: "SUPABASE_URL / SUPABASE_PUBLISHABLE_KEY" });
+    if (!url || !publishableKey) return json(500, { error: "server_misconfigured" });
 
     const authHeader = req.headers.get("authorization") ?? "";
     if (!authHeader.toLowerCase().startsWith("bearer ")) return json(401, { error: "missing_bearer_token" });
@@ -43,7 +43,7 @@ serve(async (req) => {
       .eq("user_id", userId)
       .maybeSingle();
 
-    if (snapErr) return json(500, { error: "db_error", details: snapErr.message });
+    if (snapErr) return json(500, { error: "snapshot_lookup_failed" });
     if (!snap) return json(404, { error: "not_found" });
 
     const images = snap.images as any;
@@ -85,6 +85,7 @@ serve(async (req) => {
       expires_in: expiresIn,
     });
   } catch (e) {
-    return json(500, { error: "internal_error", details: String((e as Error)?.message ?? e) });
+    console.error("[scan-read] request failed", e);
+    return json(500, { error: "internal_error" });
   }
 });

--- a/supabase/functions/scan-upload-plan/index.ts
+++ b/supabase/functions/scan-upload-plan/index.ts
@@ -5,7 +5,6 @@ import { getServiceRoleKey } from "../_shared/key_resolver.ts";
 type ReqBody = {
   vault_item_id: string;
   slots: string[];
-  debug?: boolean;
 };
 
 const ALLOWED_SLOTS = new Set([
@@ -43,46 +42,12 @@ serve(async (req) => {
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
     const serviceRoleKey = getServiceRoleKey();
     if (!supabaseUrl || !serviceRoleKey) {
-      return new Response(
-        JSON.stringify({ code: 500, message: "Server misconfigured: missing Supabase env vars" }),
-        { status: 500 },
-      );
+      return json(500, { error: "server_misconfigured" });
     }
 
     const body = (await req.json()) as Partial<ReqBody>;
     const vaultItemId = (body.vault_item_id ?? "").trim();
     const slots = Array.isArray(body.slots) ? body.slots.map((s) => String(s).trim()) : [];
-    const debug = body.debug === true;
-
-    if (debug) {
-      const authHeader = req.headers.get("authorization") ?? req.headers.get("Authorization") ?? "";
-      const apikey = req.headers.get("apikey") ?? req.headers.get("x-apikey") ?? "";
-      const token = extractBearerToken(req);
-      const hasAuth = authHeader.length > 0;
-      const bearerExtracted = !!token;
-      const keys: string[] = [];
-      for (const [k] of req.headers.entries()) {
-        if (["authorization", "apikey", "x-apikey"].includes(k.toLowerCase())) {
-          keys.push(k);
-        }
-      }
-      return json(200, {
-        debug: true,
-        has_authorization_header: hasAuth,
-        authorization_header_prefix: authHeader.slice(0, 20),
-        bearer_extracted: bearerExtracted,
-        token_len: token?.length ?? 0,
-        token_prefix: token ? token.slice(0, 12) : null,
-        token_suffix: token ? token.slice(-6) : null,
-        token_has_whitespace: token ? /\s/.test(token) : false,
-        has_apikey: apikey.length > 0,
-        apikey_prefix: apikey.slice(0, 8),
-        auth_header_keys: keys,
-        env_has_supabase_url: !!supabaseUrl,
-        env_has_supabase_secret_key: !!serviceRoleKey,
-        supabase_url_prefix: supabaseUrl ? supabaseUrl.slice(0, 24) : null,
-      });
-    }
 
     const token = extractBearerToken(req);
     if (!token) return json(401, { error: "missing_bearer_token" });
@@ -93,16 +58,7 @@ serve(async (req) => {
 
     const { data: userData, error: userErr } = await sb.auth.getUser(token);
     if (userErr || !userData?.user) {
-      return new Response(
-        JSON.stringify({
-          code: 401,
-          message: "Invalid JWT",
-          detail: userErr?.message ?? null,
-          token_prefix: token.slice(0, 12),
-          token_len: token.length,
-        }),
-        { status: 401 },
-      );
+      return json(401, { error: "invalid_jwt" });
     }
     const userId = userData.user.id;
 
@@ -135,7 +91,6 @@ serve(async (req) => {
         return json(403, {
           error: "signed_upload_denied",
           slot,
-          details: error?.message ?? "unknown",
         });
       }
 
@@ -152,6 +107,7 @@ serve(async (req) => {
       },
     });
   } catch (e) {
-    return json(500, { error: "internal_error", details: String((e as Error)?.message ?? e) });
+    console.error("[scan-upload-plan] request failed", e);
+    return json(500, { error: "internal_error" });
   }
 });

--- a/supabase/functions/vault-add-card-instance-v1/index.ts
+++ b/supabase/functions/vault-add-card-instance-v1/index.ts
@@ -79,7 +79,6 @@ serve(async (req) => {
     if (error || !data) {
       return corsJson(500, {
         error: "vault_add_failed",
-        detail: error?.message ?? "unknown",
       });
     }
 
@@ -88,9 +87,9 @@ serve(async (req) => {
       result: data,
     });
   } catch (err) {
+    console.error("[vault-add-card-instance-v1] request failed", err);
     return corsJson(500, {
       error: "internal_error",
-      detail: String((err as Error)?.message ?? err),
     });
   }
 });

--- a/supabase/functions/warehouse-intake-v1/index.ts
+++ b/supabase/functions/warehouse-intake-v1/index.ts
@@ -215,7 +215,6 @@ serve(async (req) => {
     if (error || !data) {
       return corsJson(500, {
         error: "warehouse_intake_failed",
-        detail: error?.message ?? "unknown",
       });
     }
 
@@ -224,8 +223,6 @@ serve(async (req) => {
       candidate_id: data,
     });
   } catch (err) {
-    const detail = String((err as Error)?.message ?? err);
-
     switch ((err as { code?: string })?.code) {
       case "notes_required":
       case "invalid_submission_intent":
@@ -239,9 +236,10 @@ serve(async (req) => {
       case "missing_image_storage_path":
       case "evidence_required":
       case "missing_image_requires_reference":
-        return corsJson(400, { error: (err as { code?: string }).code, detail });
+        return corsJson(400, { error: (err as { code?: string }).code });
       default:
-        return corsJson(500, { error: "internal_error", detail });
+        console.error("[warehouse-intake-v1] request failed", err);
+        return corsJson(500, { error: "internal_error" });
     }
   }
 });

--- a/tests/contracts/active_runtime_security_boundaries_v1.test.mjs
+++ b/tests/contracts/active_runtime_security_boundaries_v1.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function source(path) {
+  return readFileSync(path, "utf8");
+}
+
+const ingestionWorker = source(
+  "backend/ingestion/controlled_growth_ingestion_worker_v1.mjs",
+);
+const pricingValidation = source(
+  "backend/pricing/run_pricing_observation_live_validation_v1.mjs",
+);
+const nameNormalizer = source("backend/identity/normalizeCardNameV1.mjs");
+const scannerService = source(
+  "backend/identity_v3/scanner_v5/run_scanner_v5_identity_service_v1.mjs",
+);
+
+const edgeSources = [
+  "supabase/functions/scan-upload-plan/index.ts",
+  "supabase/functions/scan-read/index.ts",
+  "supabase/functions/identity_scan_enqueue_v1/index.ts",
+  "supabase/functions/identity_scan_get_v1/index.ts",
+  "supabase/functions/ingestion-enqueue-v1/index.ts",
+  "supabase/functions/operations-webhook-v1/index.ts",
+  "supabase/functions/vault-add-card-instance-v1/index.ts",
+  "supabase/functions/warehouse-intake-v1/index.ts",
+  "supabase/functions/notification-dispatcher/index.ts",
+].map((path) => ({ path, value: source(path) }));
+
+test("controlled-growth suffix normalization avoids ambiguous nested repetition", () => {
+  assert.match(
+    ingestionWorker,
+    /const TERMINAL_EX_RE = \/\(\[A-Za-z0-9\]\)\(\?:\\s\*-\\s\*\|\\s\+\)EX\$\/i;/,
+  );
+  assert.match(
+    ingestionWorker,
+    /const TERMINAL_GX_RE = \/\(\[A-Za-z0-9\]\)\(\?:\\s\*-\\s\*\|\\s\+\)GX\$\/i;/,
+  );
+  assert.doesNotMatch(
+    ingestionWorker,
+    /\(\?:\\s\*-\\s\*\|\\s\+\)\+(?:EX|GX)\$/,
+  );
+
+  const ex = /([A-Za-z0-9])(?:\s*-\s*|\s+)EX$/i;
+  const gx = /([A-Za-z0-9])(?:\s*-\s*|\s+)GX$/i;
+  assert.equal("Charizard - EX".replace(ex, "$1-EX"), "Charizard-EX");
+  assert.equal("Pikachu   EX".replace(ex, "$1-EX"), "Pikachu-EX");
+  assert.equal("Raichu - GX".replace(gx, "$1-GX"), "Raichu-GX");
+});
+
+test("runtime responses never expose credential fragments", () => {
+  const joined = edgeSources.map(({ value }) => value).join("\n");
+  for (const forbidden of [
+    "authorization_header_prefix",
+    "token_prefix",
+    "token_suffix",
+    "token_len",
+    "apikey_prefix",
+    "auth_prefix",
+    "xbear_prefix",
+  ]) {
+    assert.doesNotMatch(joined, new RegExp(forbidden), forbidden);
+  }
+});
+
+test("deployed runtime boundaries return stable errors instead of raw exceptions", () => {
+  for (const { path, value } of edgeSources) {
+    assert.doesNotMatch(
+      value,
+      /details?:\s*(?:[^\n]*\.message|String\s*\()/,
+      `${path} must not return raw error details`,
+    );
+  }
+
+  assert.match(scannerService, /error: 'internal_error'/);
+  assert.match(scannerService, /error: 'scan_processing_failed'/);
+  assert.doesNotMatch(
+    scannerService,
+    /writeJson\([^;]{0,500}error:\s*error\?\.message/s,
+  );
+});
+
+test("identity replacements removed by this repair remain absent", () => {
+  assert.doesNotMatch(pricingValidation, /\.replace\('Z',\s*'Z'\)/);
+  assert.doesNotMatch(nameNormalizer, /\.replace\(\/\\bex\\b\/g,\s*'ex'\)/);
+});


### PR DESCRIPTION
## Summary
- remove credential-fragment debug responses from scan upload and identity enqueue
- return stable client error codes while retaining server-side diagnostics
- remove ambiguous terminal EX/GX regex repetition and no-op replacements
- add deterministic contracts for runtime response and normalization boundaries

## Validation
- deno check --no-config on all nine changed Edge functions
- 
pm run contracts:test: 1227/1227
- 
ode --check on changed Node runtimes
- scripts/guard_no_legacy_keys.ps1
- git diff --check

No migrations or database writes.