### PR TITLE
Harden CodeQL-scanned maintenance tooling

### DIFF
--- a/backend/identity/card_name_suffix_normalization_v1.mjs
+++ b/backend/identity/card_name_suffix_normalization_v1.mjs
@@ -1,0 +1,19 @@
+const SUPPORTED_SUFFIXES = new Set(["EX", "GX"]);
+
+export function normalizeTerminalCardSuffix(value, suffix, separator) {
+  const text = String(value ?? "");
+  const normalizedSuffix = String(suffix ?? "").toUpperCase();
+  if (!SUPPORTED_SUFFIXES.has(normalizedSuffix)) {
+    throw new Error(`unsupported_terminal_card_suffix:${normalizedSuffix}`);
+  }
+  if (separator !== " " && separator !== "-") {
+    throw new Error(`unsupported_terminal_card_suffix_separator:${separator}`);
+  }
+  if (!text.toUpperCase().endsWith(normalizedSuffix)) return text;
+
+  const baseWithDelimiter = text.slice(0, -normalizedSuffix.length);
+  if (!/[\s-]$/.test(baseWithDelimiter)) return text;
+
+  const base = baseWithDelimiter.replace(/[\s-]+$/g, "");
+  return base ? `${base}${separator}${normalizedSuffix}` : text;
+}

--- a/backend/identity/g1_post_normalization_drift_repair_v2.mjs
+++ b/backend/identity/g1_post_normalization_drift_repair_v2.mjs
@@ -13,6 +13,7 @@
 import '../env.mjs';
 import { Client } from 'pg';
 
+import { normalizeTerminalCardSuffix } from './card_name_suffix_normalization_v1.mjs';
 import { installIdentityMaintenanceBoundaryV1 } from './identity_maintenance_boundary_v1.mjs';
 
 if (!process.env.ENABLE_IDENTITY_MAINTENANCE_MODE) {
@@ -115,9 +116,6 @@ const EXPECTED_BY_ID = new Map(EXPECTED_DRIFT_ROWS.map((row) => [row.id, row]));
 
 const APOSTROPHE_VARIANTS_RE = /[\u2018\u2019`´]/g;
 const DASH_SEPARATOR_VARIANTS_RE = /[\u2013\u2014]/g;
-const TERMINAL_EX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+EX$/i;
-const TERMINAL_GX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+GX$/i;
-
 function normalizeCount(value) {
   return Number(value ?? 0);
 }
@@ -153,8 +151,8 @@ function toCanonicalDisplayNameV3(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1-GX');
-  value = value.replace(TERMINAL_EX_RE, '$1-EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', '-');
+  value = normalizeTerminalCardSuffix(value, 'EX', '-');
   value = collapseWhitespace(value);
   return value;
 }
@@ -164,8 +162,8 @@ function toNameNormalizeV3Key(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1 GX');
-  value = value.replace(TERMINAL_EX_RE, '$1 EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', ' ');
+  value = normalizeTerminalCardSuffix(value, 'EX', ' ');
   value = collapseWhitespace(value).toLowerCase();
   return value;
 }

--- a/backend/identity/xy3_post_normalization_drift_repair_v1.mjs
+++ b/backend/identity/xy3_post_normalization_drift_repair_v1.mjs
@@ -13,6 +13,7 @@
 import '../env.mjs';
 import { Client } from 'pg';
 
+import { normalizeTerminalCardSuffix } from './card_name_suffix_normalization_v1.mjs';
 import { installIdentityMaintenanceBoundaryV1 } from './identity_maintenance_boundary_v1.mjs';
 
 if (!process.env.ENABLE_IDENTITY_MAINTENANCE_MODE) {
@@ -60,9 +61,6 @@ const MAX_EXPECTED_DRIFT_ROWS = 1;
 
 const APOSTROPHE_VARIANTS_RE = /[\u2018\u2019`´]/g;
 const DASH_SEPARATOR_VARIANTS_RE = /[\u2013\u2014]/g;
-const TERMINAL_EX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+EX$/i;
-const TERMINAL_GX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+GX$/i;
-
 function normalizeCount(value) {
   return Number(value ?? 0);
 }
@@ -98,8 +96,8 @@ function toCanonicalDisplayNameV3(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1-GX');
-  value = value.replace(TERMINAL_EX_RE, '$1-EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', '-');
+  value = normalizeTerminalCardSuffix(value, 'EX', '-');
   value = collapseWhitespace(value);
   return value;
 }
@@ -109,8 +107,8 @@ function toNameNormalizeV3Key(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1 GX');
-  value = value.replace(TERMINAL_EX_RE, '$1 EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', ' ');
+  value = normalizeTerminalCardSuffix(value, 'EX', ' ');
   value = collapseWhitespace(value).toLowerCase();
   return value;
 }

--- a/backend/identity/xy4_post_normalization_drift_repair_v1.mjs
+++ b/backend/identity/xy4_post_normalization_drift_repair_v1.mjs
@@ -13,6 +13,7 @@
 import '../env.mjs';
 import { Client } from 'pg';
 
+import { normalizeTerminalCardSuffix } from './card_name_suffix_normalization_v1.mjs';
 import { installIdentityMaintenanceBoundaryV1 } from './identity_maintenance_boundary_v1.mjs';
 
 if (!process.env.ENABLE_IDENTITY_MAINTENANCE_MODE) {
@@ -60,9 +61,6 @@ const MAX_EXPECTED_DRIFT_ROWS = 1;
 
 const APOSTROPHE_VARIANTS_RE = /[\u2018\u2019`´]/g;
 const DASH_SEPARATOR_VARIANTS_RE = /[\u2013\u2014]/g;
-const TERMINAL_EX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+EX$/i;
-const TERMINAL_GX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+GX$/i;
-
 function normalizeCount(value) {
   return Number(value ?? 0);
 }
@@ -98,8 +96,8 @@ function toCanonicalDisplayNameV3(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1-GX');
-  value = value.replace(TERMINAL_EX_RE, '$1-EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', '-');
+  value = normalizeTerminalCardSuffix(value, 'EX', '-');
   value = collapseWhitespace(value);
   return value;
 }
@@ -109,8 +107,8 @@ function toNameNormalizeV3Key(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1 GX');
-  value = value.replace(TERMINAL_EX_RE, '$1 EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', ' ');
+  value = normalizeTerminalCardSuffix(value, 'EX', ' ');
   value = collapseWhitespace(value).toLowerCase();
   return value;
 }

--- a/backend/identity/xy6_post_normalization_drift_repair_v2.mjs
+++ b/backend/identity/xy6_post_normalization_drift_repair_v2.mjs
@@ -13,6 +13,7 @@
 import '../env.mjs';
 import { Client } from 'pg';
 
+import { normalizeTerminalCardSuffix } from './card_name_suffix_normalization_v1.mjs';
 import { installIdentityMaintenanceBoundaryV1 } from './identity_maintenance_boundary_v1.mjs';
 
 if (!process.env.ENABLE_IDENTITY_MAINTENANCE_MODE) {
@@ -55,9 +56,6 @@ const MAX_EXPECTED_DRIFT_ROWS = 1;
 
 const APOSTROPHE_VARIANTS_RE = /[\u2018\u2019`´]/g;
 const DASH_SEPARATOR_VARIANTS_RE = /[\u2013\u2014]/g;
-const TERMINAL_EX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+EX$/i;
-const TERMINAL_GX_RE = /([A-Za-z0-9])(?:\s*-\s*|\s+)+GX$/i;
-
 function normalizeCount(value) {
   return Number(value ?? 0);
 }
@@ -93,8 +91,8 @@ function toCanonicalDisplayNameV3(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1-GX');
-  value = value.replace(TERMINAL_EX_RE, '$1-EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', '-');
+  value = normalizeTerminalCardSuffix(value, 'EX', '-');
   value = collapseWhitespace(value);
   return value;
 }
@@ -104,8 +102,8 @@ function toNameNormalizeV3Key(name) {
   value = value.replace(APOSTROPHE_VARIANTS_RE, "'");
   value = value.replace(DASH_SEPARATOR_VARIANTS_RE, ' ');
   value = collapseWhitespace(value);
-  value = value.replace(TERMINAL_GX_RE, '$1 GX');
-  value = value.replace(TERMINAL_EX_RE, '$1 EX');
+  value = normalizeTerminalCardSuffix(value, 'GX', ' ');
+  value = normalizeTerminalCardSuffix(value, 'EX', ' ');
   value = collapseWhitespace(value).toLowerCase();
   return value;
 }

--- a/docs/checkpoints/CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/CHECKPOINT_INDEX.md
@@ -1,5 +1,6 @@
 # CHECKPOINT_INDEX
 
+- `CODEQL_TOOLING_REMEDIATION_20260731_V1` — `2026-07-31` — First governed default-branch CodeQL backlog pass: repairs 31 high-severity findings in owned maintenance/acquisition code, preserves full owned-code scanning, and classifies 46 downloaded HTML alerts as non-executable third-party evidence without weakening runtime coverage
 - `RELEASE_READINESS_AUDIT_20260731_V1` — `2026-07-31` — Controlled-beta release audit proving the deployed wall-feed, merged pricing/read boundaries, and TestFlight Build 258 while preserving physical-iPhone, 72-hour pricing, 17-surface, and unattended-cycle gates
 - `RELEASE_READINESS_AUDIT_20260731_V2` — `2026-07-31` — Current-main release audit proving live core/web/Edge security boundaries while preserving physical-iPhone, 72-hour pricing, ordered-migration, 17-surface, unattended-cycle, and licensing gates
 - `CAMEO_SEARCH_ROTOMAMITI_REFRESH_20260618_V1` — `2026-06-18` — Additive RotomAmiti cameo enrichment refresh: 60 logical-new `card_print_cameos` rows applied, active source count now 1,421, 38 preservation-review rows intentionally retained, and future refreshes locked to logical cameo identity instead of volatile sheet row hashes

--- a/docs/checkpoints/security/CODEQL_TOOLING_REMEDIATION_20260731_V1.md
+++ b/docs/checkpoints/security/CODEQL_TOOLING_REMEDIATION_20260731_V1.md
@@ -1,0 +1,117 @@
+# CodeQL Tooling Remediation 20260731 V1
+
+## Context
+
+- Repository: `OriginalSoseji/grookai_vault`
+- Branch: `security/codeql-tooling-boundary-v1`
+- Baseline default-branch commit: `f8cfee590994bfd465d87a47f7cdf5307bb81067`
+- Baseline open CodeQL alerts on `refs/heads/main`: `526`
+- CodeQL setup: GitHub default setup, default query suite, remote threat model
+- Runtime security fixes from PR `#161` were already merged and deployed before this pass.
+
+## Problem
+
+The remaining CodeQL total mixed three different authorities:
+
+1. owned executable maintenance and acquisition code;
+2. historical one-shot tooling that remains executable when an operator invokes it;
+3. immutable downloaded HTML retained only as source evidence.
+
+Treating the total as one runtime defect count was inaccurate. Excluding all audit paths would also be unsafe because Grookai-owned scripts in those paths can fetch remote data, connect to production, or perform guarded writes.
+
+## Baseline Inventory
+
+### By path authority
+
+| Scope | Alerts |
+|---|---:|
+| `scripts/audits/**` | 444 |
+| `docs/audits/**/raw_sources/**` | 38 |
+| `backend/warehouse/**` | 24 |
+| `backend/identity/**` | 9 |
+| `docs/audits/**/cache/**` | 8 |
+| `scripts/ingest/**` | 3 |
+
+### Leading rules
+
+| Rule | Alerts |
+|---|---:|
+| `js/incomplete-sanitization` | 275 |
+| `js/double-escaping` | 88 |
+| `js/functionality-from-untrusted-source` | 38 |
+| `js/incomplete-url-substring-sanitization` | 25 |
+| `js/identity-replacement` | 24 |
+| `js/disabling-certificate-validation` | 22 |
+| `js/incomplete-hostname-regexp` | 17 |
+| `js/bad-tag-filter` | 14 |
+| `js/redos` | 9 |
+| `js/xss-through-dom` | 8 |
+
+## Decision
+
+- Keep CodeQL enabled for all Grookai-owned JavaScript and TypeScript, including audit and maintenance scripts.
+- Do not switch to advanced setup or add a broad path exclusion to reduce the alert count.
+- Classify the 46 alerts in downloaded HTML/cache files as non-executable third-party evidence. These files are never imported, bundled, served, or executed by Grookai.
+- Repair owned high-severity reusable code first.
+- Preserve database TLS behavior outside this pass unless the affected connection can be verified under its own production contract.
+
+## Repairs
+
+This pass is designed to close 31 high-severity alerts:
+
+- 8 `js/redos` alerts in four identity maintenance scripts by replacing ambiguous suffix regular expressions with one linear shared normalizer;
+- 1 `js/redos` alert in official checklist PDF extraction by replacing a multi-alternative token regex with bounded operator parsing;
+- 22 `js/disabling-certificate-validation` alerts by restoring peer verification for HTTPS acquisition and for the pinned PostgreSQL bootstrap.
+
+Operator-specific certificate authorities must be supplied through the normal Node trust configuration, such as `NODE_EXTRA_CA_CERTS`. Disabling peer verification is no longer an accepted fallback.
+
+## Evidence Boundary
+
+The 46 third-party evidence alerts are confined to:
+
+- `docs/audits/new_set_release_ingestion_v1/20260714_abyss_eye_pitch_black/raw_sources/abyss_eye_jp/*.html` (`38`)
+- `docs/audits/english_master_index_source_exhaustion_v1/justinbasil_prize_pack_finish_acquisition_v1/cache/*.html` (`8`)
+
+They are retained byte-for-byte for provenance. Their classification does not authorize dismissing any alert in `scripts/**`, `backend/**`, `apps/**`, or `supabase/**`.
+
+## Verification
+
+- Targeted security/ingestion/WH22/WH23 tests: `32/32` passed.
+- Full contract suite: `1235/1235` passed.
+- Syntax checks for all new and directly changed shared modules: passed.
+- `git diff --check`: passed.
+- The managed shipcheck hook could not pass `grookai:preflight` because this isolated worktree has no `SUPABASE_DB_URL`; the repository's documented intentional `--no-verify` publication path was used only after the independent secret guard, syntax, targeted, full-contract, and diff gates passed.
+- Database writes: none.
+- Supabase deployments: none.
+- Production configuration changes: none.
+- Active pricing canary: unchanged.
+
+## Current Truths
+
+- The deployed runtime CodeQL findings repaired in PR `#161` remain closed.
+- This pass materially reduces high-severity maintenance-tool risk but does not clear the full historical backlog.
+- The open count after merge and default-branch CodeQL analysis is authoritative; projected counts are not completion evidence.
+- The 46 downloaded-evidence alerts may be dismissed only with an explicit non-executable-evidence rationale after path-by-path readback.
+- Every remaining owned-code alert must be repaired or individually adjudicated. It must not be hidden by excluding audit directories.
+
+## Invariants
+
+- Never disable TLS certificate verification to work around a local trust-chain problem.
+- Never provide credentials to an unverified PostgreSQL peer.
+- Never treat downloaded HTML evidence as application code.
+- Never use evidence classification to suppress Grookai-owned executable tooling.
+- Never claim CodeQL completion from a projected alert count.
+- Never modify production data as part of static-analysis remediation.
+
+## Remaining Work
+
+1. Merge this pass and require the default-branch CodeQL scan to finish.
+2. Confirm all 31 targeted alert numbers close on `main` and no replacement findings appear.
+3. Path-check and explicitly adjudicate the 46 downloaded-evidence alerts.
+4. Re-inventory the remaining owned-code alerts by reusable tool family.
+5. Repair URL/hostname handling before lower-risk output-normalization warnings.
+6. Continue release gates separately: physical clean-account iPhone journey, 72-hour pricing canary completion, ordered migrations, 17-surface proof, and seven unattended cycles.
+
+## Explicit Next Gate
+
+The next gate is a merged default-branch CodeQL readback proving the 31 targeted high-severity findings are closed without new alerts. No CodeQL alert classification or further repair batch should be declared complete before that readback.

--- a/scripts/audits/english_master_index_official_checklist_pdf_acquisition_v1.mjs
+++ b/scripts/audits/english_master_index_official_checklist_pdf_acquisition_v1.mjs
@@ -11,6 +11,7 @@ import {
   normalizeNumber,
   normalizeText,
 } from './verified_master_set_index_v1/shared.mjs';
+import { extractPdfTextItems } from './lib/pdf_text_operators_v1.mjs';
 
 const GAPS_PATH = 'docs/audits/english_master_index_source_exhaustion_v1/english_master_index_remaining_gap_facts_v1.json';
 const SETS_PATH = 'docs/audits/verified_master_set_index_v1/english_master_index_v1/english_master_index_sets_v1.json';
@@ -133,34 +134,6 @@ async function fetchPdf(set) {
   throw new Error(errors.join(' | '));
 }
 
-function decodePdfString(value) {
-  return String(value ?? '')
-    .replace(/\\\(/g, '(')
-    .replace(/\\\)/g, ')')
-    .replace(/\\\\/g, '\\')
-    .replace(/\\222/g, "'")
-    .replace(/\\226/g, '-')
-    .replace(/\\227/g, '-')
-    .replace(/\\251/g, '(c)')
-    .replace(/\\256/g, '(r)')
-    .replace(/\\351/g, 'é')
-    .replace(/\\034/g, '')
-    .replace(/\\035/g, '')
-    .replace(/\\036/g, '')
-    .replace(/\\037/g, '')
-    .replace(/\\[0-7]{1,3}/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function decodePdfArrayText(value) {
-  return [...String(value ?? '').matchAll(/\((?:\\.|[^\\)])*\)/g)]
-    .map((match) => decodePdfString(match[0].slice(1, -1)))
-    .join('')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
 function inflatePdfStreams(body) {
   const streams = [];
   let position = 0;
@@ -194,34 +167,12 @@ function inflatePdfStreams(body) {
   return streams;
 }
 
-function extractTextItems(streamText) {
-  if (!streamText.includes('Tj') && !streamText.includes('TJ')) return [];
-  const items = [];
-  let x = null;
-  let y = null;
-  const tokenRegex = /(-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Tm)|(\[(?:\\.|[^\]])*\]TJ)|(\((?:\\.|[^\\)])*\)Tj)/g;
-  for (const match of streamText.matchAll(tokenRegex)) {
-    if (match[1]) {
-      x = Number(match[2]);
-      y = Number(match[3]);
-      continue;
-    }
-    const text = match[4]
-      ? decodePdfArrayText(match[4])
-      : decodePdfString(match[5].slice(1, -3));
-    if (text && Number.isFinite(x) && Number.isFinite(y)) {
-      items.push({ x, y, text });
-    }
-  }
-  return items;
-}
-
 function parseOfficialRows(body) {
   return parseOfficialRowsFromStreams(body);
 }
 
 function parseOfficialRowsFromStreams(body) {
-  const items = inflatePdfStreams(body).flatMap(extractTextItems);
+  const items = inflatePdfStreams(body).flatMap(extractPdfTextItems);
   const groups = new Map();
   for (const item of items) {
     const rowY = Math.round(item.y * 2) / 2;

--- a/scripts/audits/gv_id_public_coverage_audit_v1.mjs
+++ b/scripts/audits/gv_id_public_coverage_audit_v1.mjs
@@ -32,7 +32,7 @@ const PUBLIC_VIEW_NAMES = [
 ];
 
 const TLS_NOTE =
-  'Node fetch required NODE_TLS_REJECT_UNAUTHORIZED=0 in this local environment due local certificate chain verification failure. Browser-facing HTTPS responses were still fetched from https://grookaivault.com.';
+  'Node fetch uses normal certificate validation. Operator-specific trust roots must be supplied through NODE_EXTRA_CA_CERTS rather than disabling TLS verification.';
 
 function quoteIdent(identifier) {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
@@ -487,10 +487,6 @@ function rowMatchesSearchResult(row, result) {
 }
 
 async function verifyWebsiteSample(rows) {
-  if (!process.env.NODE_TLS_REJECT_UNAUTHORIZED) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-  }
-
   const checks = [];
   for (const row of rows) {
     const searchQuery = buildSampleSearchQuery(row);

--- a/scripts/audits/image_truth_trainer_kit_mcd_404_pass_v1.mjs
+++ b/scripts/audits/image_truth_trainer_kit_mcd_404_pass_v1.mjs
@@ -197,7 +197,7 @@ async function headWithTlsFallback(url) {
       url,
       {
         method: 'HEAD',
-        rejectUnauthorized: false,
+        rejectUnauthorized: true,
       },
       (response) => {
         response.resume();

--- a/scripts/audits/image_truth_v1_img20a_trainer_kit_malie_fallback_audit.mjs
+++ b/scripts/audits/image_truth_v1_img20a_trainer_kit_malie_fallback_audit.mjs
@@ -132,7 +132,7 @@ function hasRuntimeResolverDisplay(row) {
 }
 
 function fetchText(url) {
-  const agent = new https.Agent({ rejectUnauthorized: false });
+  const agent = new https.Agent({ rejectUnauthorized: true });
   return new Promise((resolve, reject) => {
     https
       .get(url, { agent, headers: { 'user-agent': 'grookai-image-audit/1.0' } }, (response) => {

--- a/scripts/audits/image_truth_v1_img20b_trainer_kit_residual_tcgcollector_audit.mjs
+++ b/scripts/audits/image_truth_v1_img20b_trainer_kit_residual_tcgcollector_audit.mjs
@@ -133,7 +133,7 @@ function hasRuntimeResolverDisplay(row) {
 }
 
 function fetchText(url) {
-  const agent = new https.Agent({ rejectUnauthorized: false });
+  const agent = new https.Agent({ rejectUnauthorized: true });
   return new Promise((resolve, reject) => {
     https
       .get(url, { agent, headers: { 'user-agent': 'grookai-image-audit/1.0' } }, (response) => {

--- a/scripts/audits/jpn_pikachu_promo_end_to_end_apply_v1.mjs
+++ b/scripts/audits/jpn_pikachu_promo_end_to_end_apply_v1.mjs
@@ -90,7 +90,7 @@ function httpsGetBuffer(url) {
     const request = https.get(
       url,
       {
-        rejectUnauthorized: false,
+      rejectUnauthorized: true,
         headers: {
           'user-agent': 'Mozilla/5.0 GrookaiVaultImageIngestion/1.0',
           accept: 'text/html,image/avif,image/webp,image/apng,image/*,*/*;q=0.8',

--- a/scripts/audits/jpn_pikachu_promo_gap_audit_v1.mjs
+++ b/scripts/audits/jpn_pikachu_promo_gap_audit_v1.mjs
@@ -120,7 +120,7 @@ async function fetchHtml(url) {
               'user-agent': 'GrookaiVaultAudit/1.0 read-only gap analysis',
               accept: 'text/html',
             },
-            rejectUnauthorized: false,
+      rejectUnauthorized: true,
           },
           (response) => {
             if ((response.statusCode ?? 500) >= 400) {

--- a/scripts/audits/lib/pdf_text_operators_v1.mjs
+++ b/scripts/audits/lib/pdf_text_operators_v1.mjs
@@ -1,5 +1,17 @@
 const PDF_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
 const TEXT_OPERATOR_RE = /(?:Tm|TJ|Tj)\b/g;
+const PDF_OCTAL_REPLACEMENTS = new Map([
+  ["222", "'"],
+  ["226", "-"],
+  ["227", "-"],
+  ["251", "(c)"],
+  ["256", "(r)"],
+  ["351", "é"],
+  ["034", ""],
+  ["035", ""],
+  ["036", ""],
+  ["037", ""],
+]);
 
 function isEscapedAt(text, index) {
   let slashCount = 0;
@@ -37,23 +49,34 @@ function textMatrixCoordinates(text, operatorIndex) {
 }
 
 export function decodePdfString(value) {
-  return String(value ?? "")
-    .replace(/\\\(/g, "(")
-    .replace(/\\\)/g, ")")
-    .replace(/\\\\/g, "\\")
-    .replace(/\\222/g, "'")
-    .replace(/\\226/g, "-")
-    .replace(/\\227/g, "-")
-    .replace(/\\251/g, "(c)")
-    .replace(/\\256/g, "(r)")
-    .replace(/\\351/g, "é")
-    .replace(/\\034/g, "")
-    .replace(/\\035/g, "")
-    .replace(/\\036/g, "")
-    .replace(/\\037/g, "")
-    .replace(/\\[0-7]{1,3}/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  const input = String(value ?? "");
+  let decoded = "";
+  for (let cursor = 0; cursor < input.length; cursor += 1) {
+    const character = input[cursor];
+    if (character !== "\\" || cursor + 1 >= input.length) {
+      decoded += character;
+      continue;
+    }
+
+    const escaped = input[cursor + 1];
+    if (escaped === "(" || escaped === ")" || escaped === "\\") {
+      decoded += escaped;
+      cursor += 1;
+      continue;
+    }
+    if (/[0-7]/.test(escaped)) {
+      let end = cursor + 1;
+      while (end < input.length && end <= cursor + 3 && /[0-7]/.test(input[end])) {
+        end += 1;
+      }
+      const octal = input.slice(cursor + 1, end);
+      decoded += PDF_OCTAL_REPLACEMENTS.get(octal) ?? "";
+      cursor = end - 1;
+      continue;
+    }
+    decoded += character;
+  }
+  return decoded.replace(/\s+/g, " ").trim();
 }
 
 export function decodePdfArrayText(value) {

--- a/scripts/audits/lib/pdf_text_operators_v1.mjs
+++ b/scripts/audits/lib/pdf_text_operators_v1.mjs
@@ -1,0 +1,111 @@
+const PDF_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+const TEXT_OPERATOR_RE = /(?:Tm|TJ|Tj)\b/g;
+
+function isEscapedAt(text, index) {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function enclosedOperand(text, operatorIndex, opening, closing) {
+  let end = operatorIndex;
+  while (end > 0 && /\s/.test(text[end - 1])) end -= 1;
+  if (text[end - 1] !== closing || isEscapedAt(text, end - 1)) return null;
+
+  let depth = 0;
+  for (let cursor = end - 1; cursor >= 0; cursor -= 1) {
+    if (isEscapedAt(text, cursor)) continue;
+    if (text[cursor] === closing) {
+      depth += 1;
+    } else if (text[cursor] === opening) {
+      depth -= 1;
+      if (depth === 0) return text.slice(cursor, end);
+    }
+  }
+  return null;
+}
+
+function textMatrixCoordinates(text, operatorIndex) {
+  const prefix = text.slice(Math.max(0, operatorIndex - 512), operatorIndex).trimEnd();
+  const tokens = prefix.split(/\s+/).slice(-6);
+  if (tokens.length !== 6 || !tokens.every((token) => PDF_NUMBER_RE.test(token))) {
+    return null;
+  }
+  return { x: Number(tokens[4]), y: Number(tokens[5]) };
+}
+
+export function decodePdfString(value) {
+  return String(value ?? "")
+    .replace(/\\\(/g, "(")
+    .replace(/\\\)/g, ")")
+    .replace(/\\\\/g, "\\")
+    .replace(/\\222/g, "'")
+    .replace(/\\226/g, "-")
+    .replace(/\\227/g, "-")
+    .replace(/\\251/g, "(c)")
+    .replace(/\\256/g, "(r)")
+    .replace(/\\351/g, "é")
+    .replace(/\\034/g, "")
+    .replace(/\\035/g, "")
+    .replace(/\\036/g, "")
+    .replace(/\\037/g, "")
+    .replace(/\\[0-7]{1,3}/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function decodePdfArrayText(value) {
+  const text = String(value ?? "");
+  const parts = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    if (text[cursor] !== "(" || isEscapedAt(text, cursor)) {
+      cursor += 1;
+      continue;
+    }
+    let depth = 1;
+    let end = cursor + 1;
+    for (; end < text.length; end += 1) {
+      if (isEscapedAt(text, end)) continue;
+      if (text[end] === "(") depth += 1;
+      if (text[end] === ")") depth -= 1;
+      if (depth === 0) break;
+    }
+    if (depth !== 0) break;
+    parts.push(decodePdfString(text.slice(cursor + 1, end)));
+    cursor = end + 1;
+  }
+  return parts.join("").replace(/\s+/g, " ").trim();
+}
+
+export function extractPdfTextItems(streamText) {
+  const text = String(streamText ?? "");
+  if (!text.includes("Tj") && !text.includes("TJ")) return [];
+
+  const items = [];
+  let x = null;
+  let y = null;
+  for (const match of text.matchAll(TEXT_OPERATOR_RE)) {
+    const operator = match[0];
+    const operatorIndex = match.index;
+    if (operator === "Tm") {
+      const coordinates = textMatrixCoordinates(text, operatorIndex);
+      if (coordinates) ({ x, y } = coordinates);
+      continue;
+    }
+
+    const operand = operator === "TJ"
+      ? enclosedOperand(text, operatorIndex, "[", "]")
+      : enclosedOperand(text, operatorIndex, "(", ")");
+    if (!operand) continue;
+    const decoded = operator === "TJ"
+      ? decodePdfArrayText(operand)
+      : decodePdfString(operand.slice(1, -1));
+    if (decoded && Number.isFinite(x) && Number.isFinite(y)) {
+      items.push({ x, y, text: decoded });
+    }
+  }
+  return items;
+}

--- a/scripts/audits/self_hosted_images_wh05a_trainer_kit_runtime_upload_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh05a_trainer_kit_runtime_upload_dry_run.mjs
@@ -312,7 +312,7 @@ async function queryTrainerKitRows() {
 }
 
 function fetchImageBuffer(url) {
-  const agent = new https.Agent({ rejectUnauthorized: false });
+  const agent = new https.Agent({ rejectUnauthorized: true });
   return new Promise((resolve, reject) => {
     const request = https.get(url, {
       agent,

--- a/scripts/audits/self_hosted_images_wh06a_mcdonalds_runtime_upload_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh06a_mcdonalds_runtime_upload_dry_run.mjs
@@ -134,7 +134,7 @@ function looksLikeHtml(buffer) {
 }
 
 function fetchImageBuffer(url, redirects = 4) {
-  const agent = new https.Agent({ rejectUnauthorized: false });
+  const agent = new https.Agent({ rejectUnauthorized: true });
   return new Promise((resolve, reject) => {
     const request = https.get(url, {
       agent,

--- a/scripts/audits/self_hosted_images_wh06b_mcdonalds_dextcg_upload_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh06b_mcdonalds_dextcg_upload_dry_run.mjs
@@ -102,7 +102,7 @@ function looksLikeHtml(buffer) {
 }
 
 function fetchBuffer(url, redirects = 4) {
-  const agent = new https.Agent({ rejectUnauthorized: false });
+  const agent = new https.Agent({ rejectUnauthorized: true });
   return new Promise((resolve, reject) => {
     const request = https.get(url, {
       agent,

--- a/scripts/audits/self_hosted_images_wh06c_mcdonalds_dextcg_storage_upload_apply.mjs
+++ b/scripts/audits/self_hosted_images_wh06c_mcdonalds_dextcg_storage_upload_apply.mjs
@@ -242,7 +242,7 @@ function renderPlanMarkdown(plan) {
 }
 
 function fetchBuffer(url, timeoutMs, redirects = 4) {
-  const agent = new https.Agent({ rejectUnauthorized: false });
+  const agent = new https.Agent({ rejectUnauthorized: true });
   return new Promise((resolve, reject) => {
     const request = https.get(url, {
       agent,

--- a/scripts/audits/self_hosted_images_wh10c_pokemontcg_residual_parent_source_storage_upload_apply.mjs
+++ b/scripts/audits/self_hosted_images_wh10c_pokemontcg_residual_parent_source_storage_upload_apply.mjs
@@ -206,7 +206,7 @@ async function fetchBuffer(url, timeoutMs, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: timeoutMs,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh11a_residual_parent_source_upload_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh11a_residual_parent_source_upload_dry_run.mjs
@@ -164,7 +164,7 @@ async function fetchBuffer(url, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: FETCH_TIMEOUT_MS,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh11b_residual_parent_source_storage_upload_apply.mjs
+++ b/scripts/audits/self_hosted_images_wh11b_residual_parent_source_storage_upload_apply.mjs
@@ -203,7 +203,7 @@ async function fetchBuffer(url, timeoutMs, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: timeoutMs,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh12a_mfb_parent_source_upload_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh12a_mfb_parent_source_upload_dry_run.mjs
@@ -240,7 +240,7 @@ async function fetchBuffer(url, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: FETCH_TIMEOUT_MS,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh12b_mfb_parent_source_storage_upload_apply.mjs
+++ b/scripts/audits/self_hosted_images_wh12b_mfb_parent_source_storage_upload_apply.mjs
@@ -203,7 +203,7 @@ async function fetchBuffer(url, timeoutMs, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: timeoutMs,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh16a_ex55_tcgcollector_upload_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh16a_ex55_tcgcollector_upload_dry_run.mjs
@@ -165,7 +165,7 @@ async function fetchBuffer(url, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: FETCH_TIMEOUT_MS,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh16b_ex55_tcgcollector_storage_upload_apply.mjs
+++ b/scripts/audits/self_hosted_images_wh16b_ex55_tcgcollector_storage_upload_apply.mjs
@@ -203,7 +203,7 @@ async function fetchBuffer(url, timeoutMs, redirectCount = 0) {
     const request = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: timeoutMs,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location;

--- a/scripts/audits/self_hosted_images_wh22_common.mjs
+++ b/scripts/audits/self_hosted_images_wh22_common.mjs
@@ -445,7 +445,7 @@ async function bootstrapPostgresTlsChain(descriptor) {
   const secureSocket = tls.connect({
     socket: plainSocket,
     servername: descriptor.host,
-    rejectUnauthorized: false,
+    rejectUnauthorized: true,
   });
   await new Promise((resolve, reject) => {
     secureSocket.setTimeout(FETCH_TIMEOUT_MS, () => secureSocket.destroy(new Error('postgres_tls_handshake_timeout')));
@@ -526,7 +526,7 @@ export async function targetBindingFromEnvironment() {
       port: descriptor.port,
       database_name: descriptor.database_name,
       username: descriptor.username,
-      tls_verification: 'bootstrap_no_credentials_then_verified_ca_reconnect',
+      tls_verification: 'verified_no_credentials_then_pinned_ca_reconnect',
       approved_chain: publicTlsChain(chain),
     },
   };

--- a/scripts/audits/tcgplayer_market_canary_image_repair_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_image_repair_v1.mjs
@@ -70,7 +70,7 @@ function fetchBuffer(url) {
     const request = https.get(
       url,
       {
-        rejectUnauthorized: false,
+        rejectUnauthorized: true,
         headers: { "user-agent": "Grookai-Market-Canary-Image-Repair/1.0" },
         timeout: 20_000,
       },

--- a/scripts/audits/tcgplayer_market_canary_verify_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_verify_v1.mjs
@@ -141,9 +141,8 @@ function fetchBuffer(url, redirects = 0, headers = {}) {
     const request = https.get(
       url,
       {
-        // The operator environment uses a local TLS inspection chain that Node
-        // cannot validate. Image bytes remain content-hashed in the audit.
-        rejectUnauthorized: false,
+        // Operator-specific trust roots must use NODE_EXTRA_CA_CERTS.
+        rejectUnauthorized: true,
         headers: {
           "user-agent": "Grookai-Market-Canary-Verifier/1.0",
           ...headers,

--- a/scripts/ingest/new_set_release_ingest_v1.mjs
+++ b/scripts/ingest/new_set_release_ingest_v1.mjs
@@ -169,7 +169,7 @@ async function fetchText(url) {
         'user-agent': USER_AGENT,
       },
       timeout: 45000,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const status = response.statusCode ?? 0;
       if ([301, 302, 303, 307, 308].includes(status) && response.headers.location) {
@@ -203,7 +203,7 @@ async function fetchBuffer(url, redirectCount = 0) {
     const req = client.get(parsed, {
       headers: { 'user-agent': USER_AGENT },
       timeout: 45000,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }, (response) => {
       const status = response.statusCode ?? 0;
       if ([301, 302, 303, 307, 308].includes(status) && response.headers.location) {

--- a/tests/contracts/audit_https_certificate_validation_v1.test.mjs
+++ b/tests/contracts/audit_https_certificate_validation_v1.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const ACQUISITION_FILES = [
+  "scripts/audits/gv_id_public_coverage_audit_v1.mjs",
+  "scripts/audits/image_truth_trainer_kit_mcd_404_pass_v1.mjs",
+  "scripts/audits/image_truth_v1_img20a_trainer_kit_malie_fallback_audit.mjs",
+  "scripts/audits/image_truth_v1_img20b_trainer_kit_residual_tcgcollector_audit.mjs",
+  "scripts/audits/jpn_pikachu_promo_end_to_end_apply_v1.mjs",
+  "scripts/audits/jpn_pikachu_promo_gap_audit_v1.mjs",
+  "scripts/audits/self_hosted_images_wh05a_trainer_kit_runtime_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh06a_mcdonalds_runtime_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh06b_mcdonalds_dextcg_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh06c_mcdonalds_dextcg_storage_upload_apply.mjs",
+  "scripts/audits/self_hosted_images_wh10c_pokemontcg_residual_parent_source_storage_upload_apply.mjs",
+  "scripts/audits/self_hosted_images_wh11a_residual_parent_source_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh11b_residual_parent_source_storage_upload_apply.mjs",
+  "scripts/audits/self_hosted_images_wh12a_mfb_parent_source_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh12b_mfb_parent_source_storage_upload_apply.mjs",
+  "scripts/audits/self_hosted_images_wh16a_ex55_tcgcollector_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh16b_ex55_tcgcollector_storage_upload_apply.mjs",
+  "scripts/audits/tcgplayer_market_canary_image_repair_v1.mjs",
+  "scripts/audits/tcgplayer_market_canary_verify_v1.mjs",
+  "scripts/ingest/new_set_release_ingest_v1.mjs",
+];
+
+test("audit HTTPS acquisition never disables certificate validation", () => {
+  for (const file of ACQUISITION_FILES) {
+    const source = readFileSync(file, "utf8");
+    assert.doesNotMatch(source, /NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*["']0["']/, file);
+    assert.doesNotMatch(
+      source,
+      /new\s+https\.Agent\(\{\s*rejectUnauthorized:\s*false/,
+      file,
+    );
+
+    for (const match of source.matchAll(/rejectUnauthorized:\s*false/g)) {
+      const context = source.slice(Math.max(0, match.index - 220), match.index + 80);
+      assert.match(context, /(?:new\s+Client|function\s+sslConfig)/, file);
+    }
+  }
+});
+
+test("pinned PostgreSQL bootstrap verifies the peer before chain inspection", () => {
+  const source = readFileSync("scripts/audits/self_hosted_images_wh22_common.mjs", "utf8");
+  assert.doesNotMatch(source, /rejectUnauthorized:\s*false/);
+  assert.match(source, /verified_no_credentials_then_pinned_ca_reconnect/);
+  assert.match(source, /assertPinnedSupabaseTlsChain\(chain, descriptor\)/);
+});

--- a/tests/contracts/card_name_suffix_normalization_v1.test.mjs
+++ b/tests/contracts/card_name_suffix_normalization_v1.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeTerminalCardSuffix } from "../../backend/identity/card_name_suffix_normalization_v1.mjs";
+
+test("terminal EX and GX suffixes normalize without changing embedded text", () => {
+  assert.equal(normalizeTerminalCardSuffix("M Lucario EX", "EX", "-"), "M Lucario-EX");
+  assert.equal(normalizeTerminalCardSuffix("Jolteon-EX", "EX", " "), "Jolteon EX");
+  assert.equal(normalizeTerminalCardSuffix("Zygarde - GX", "GX", "-"), "Zygarde-GX");
+  assert.equal(normalizeTerminalCardSuffix("MewtwoEX", "EX", "-"), "MewtwoEX");
+  assert.equal(normalizeTerminalCardSuffix("EX Deoxys", "EX", "-"), "EX Deoxys");
+});
+
+test("terminal suffix normalization remains linear for long operator input", () => {
+  const input = `Pikachu${" -".repeat(100_000)} EX`;
+  const started = performance.now();
+  assert.equal(normalizeTerminalCardSuffix(input, "EX", "-"), "Pikachu-EX");
+  assert.ok(performance.now() - started < 1_000);
+});
+
+test("terminal suffix normalization rejects unsupported configuration", () => {
+  assert.throws(
+    () => normalizeTerminalCardSuffix("Pikachu V", "V", "-"),
+    /unsupported_terminal_card_suffix/,
+  );
+  assert.throws(
+    () => normalizeTerminalCardSuffix("Pikachu EX", "EX", "/"),
+    /unsupported_terminal_card_suffix_separator/,
+  );
+});

--- a/tests/contracts/pdf_text_operators_v1.test.mjs
+++ b/tests/contracts/pdf_text_operators_v1.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   decodePdfArrayText,
+  decodePdfString,
   extractPdfTextItems,
 } from "../../scripts/audits/lib/pdf_text_operators_v1.mjs";
 
@@ -19,6 +20,8 @@ test("PDF text operators preserve matrix coordinates and decoded strings", () =>
     { x: 340, y: 500, text: "Mr.Mime" },
   ]);
   assert.equal(decodePdfArrayText("[(Farfetch\\'d)]"), "Farfetch\\'d");
+  assert.equal(decodePdfString(String.raw`\\222`), String.raw`\222`);
+  assert.equal(decodePdfString(String.raw`\222`), "'");
 });
 
 test("PDF text extraction handles nested and escaped delimiters", () => {

--- a/tests/contracts/pdf_text_operators_v1.test.mjs
+++ b/tests/contracts/pdf_text_operators_v1.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodePdfArrayText,
+  extractPdfTextItems,
+} from "../../scripts/audits/lib/pdf_text_operators_v1.mjs";
+
+test("PDF text operators preserve matrix coordinates and decoded strings", () => {
+  const stream = [
+    "1 0 0 1 300 500 Tm",
+    "(Pikachu) Tj",
+    "1 0 0 1 340 500 Tm",
+    "[(Mr. ) 10 (Mime)] TJ",
+  ].join("\n");
+
+  assert.deepEqual(extractPdfTextItems(stream), [
+    { x: 300, y: 500, text: "Pikachu" },
+    { x: 340, y: 500, text: "Mr.Mime" },
+  ]);
+  assert.equal(decodePdfArrayText("[(Farfetch\\'d)]"), "Farfetch\\'d");
+});
+
+test("PDF text extraction handles nested and escaped delimiters", () => {
+  const stream = "1 0 0 1 12.5 -3 Tm (A \\(nested\\) value) Tj";
+  assert.deepEqual(extractPdfTextItems(stream), [
+    { x: 12.5, y: -3, text: "A (nested) value" },
+  ]);
+});
+
+test("PDF text extraction remains bounded for long malformed input", () => {
+  const stream = `${"(".repeat(200_000)} Tj`;
+  const started = performance.now();
+  assert.deepEqual(extractPdfTextItems(stream), []);
+  assert.ok(performance.now() - started < 1_000);
+});


### PR DESCRIPTION
## What changed

- replaces eight ambiguous identity-suffix regexes with one linear shared normalizer
- replaces the official-checklist PDF mega-regex with bounded operator parsing
- restores certificate verification for 22 HTTPS/TLS acquisition paths
- documents the 526-alert authority split without excluding owned audit tooling from CodeQL
- adds long-input, parser, and TLS regression coverage

## Why

The release-readiness audit found that the remaining CodeQL total mixed real owned tooling defects with 46 immutable downloaded HTML evidence alerts. This PR repairs the highest-severity owned code while preserving full scanning of Grookai scripts.

## Validation

- targeted contracts: 32/32 passed
- full contract suite: 1235/1235 passed
- syntax checks: passed
- release secret guard: passed
- git diff check: passed
- no database writes or production changes

The managed shipcheck hook could not run runtime preflight because the isolated worktree has no `SUPABASE_DB_URL`; the documented intentional no-verify path was used after the independent gates above passed.