### PR TITLE
Harden audit URL authority checks

### DIFF
--- a/docs/checkpoints/CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/CHECKPOINT_INDEX.md
@@ -1,5 +1,6 @@
 # CHECKPOINT_INDEX
 
+- `CODEQL_URL_AUTHORITY_REMEDIATION_20260731_V1` — `2026-07-31` — Governed repair for 43 high-severity URL/hostname findings: exact parsed authority checks, HTTPS-only API-key forwarding, explicit web-scheme resolution, tuple-safe PKMNCollectors fields, and removal of a legacy certificate-verification bypass
 - `CODEQL_TOOLING_REMEDIATION_20260731_V1_READBACK` — `2026-07-31` — Authoritative default-branch readback proving 32 owned-code findings closed, 46 immutable third-party HTML evidence findings were individually adjudicated, and 448 owned-code alerts remain without weakening scan coverage
 - `CODEQL_TOOLING_REMEDIATION_20260731_V1` — `2026-07-31` — First governed default-branch CodeQL backlog pass: repairs 31 high-severity findings in owned maintenance/acquisition code, preserves full owned-code scanning, and classifies 46 downloaded HTML alerts as non-executable third-party evidence without weakening runtime coverage
 - `RELEASE_READINESS_AUDIT_20260731_V1` — `2026-07-31` — Controlled-beta release audit proving the deployed wall-feed, merged pricing/read boundaries, and TestFlight Build 258 while preserving physical-iPhone, 72-hour pricing, 17-surface, and unattended-cycle gates

--- a/docs/checkpoints/security/CODEQL_URL_AUTHORITY_REMEDIATION_20260731_V1.md
+++ b/docs/checkpoints/security/CODEQL_URL_AUTHORITY_REMEDIATION_20260731_V1.md
@@ -1,0 +1,120 @@
+# CodeQL URL Authority Remediation 20260731 V1
+
+## Context
+
+- Repository: `OriginalSoseji/grookai_vault`
+- Branch: `security/codeql-url-authority-v1`
+- Baseline default-branch commit: `beabcc5fd56eb3672c0857f85eb8038949666430`
+- Baseline open CodeQL alerts: `448`
+- Baseline high-severity URL/hostname findings: `43`
+- Database writes: none
+- Supabase deployments: none
+- Production configuration changes: none
+
+## Problem
+
+Historical acquisition and audit tooling used substring checks to decide whether
+a URL belonged to a trusted source. A lookalike hostname could satisfy those
+checks. Two enrichment scripts could then forward the Pokemon TCG API key to the
+wrong host. Three PKMNCollectors scripts also stored URL strings in positional
+tuples that CodeQL could trace into a dynamic regular-expression helper.
+
+The web cohesion crawler separately excluded only a short list of URL schemes,
+which left other non-web schemes implicit. One legacy image uploader contained
+an adjacent fallback that deliberately disabled certificate verification for
+two source hosts.
+
+## Risk
+
+- Credential disclosure to a lookalike host.
+- Incorrect source-authority classification.
+- Unsafe acceptance of non-HTTP links by audit tooling.
+- Ambiguous URL values reaching a regular-expression sink.
+- Man-in-the-middle exposure in a manually invoked storage uploader.
+
+## Decision
+
+Introduce one shared URL authority module based on the platform `URL` parser:
+
+- accept only `http:` and `https:` URLs;
+- compare normalized hostnames exactly;
+- allow subdomains only when the caller opts in;
+- require HTTPS before forwarding the Pokemon TCG API key;
+- support pathname constraints independently of host authority;
+- resolve crawler links only when the final URL remains HTTP/HTTPS and
+  same-origin.
+
+Convert PKMNCollectors targets from positional tuples to named objects so
+`cardName` and `sourceUrl` remain distinct data-flow properties. Remove the
+legacy certificate-verification bypass instead of narrowing its hostname check.
+
+## Repairs
+
+This pass is designed to close:
+
+- `js/incomplete-url-substring-sanitization`: `25`
+- `js/incomplete-hostname-regexp`: `17`
+- `js/incomplete-url-scheme-check`: `1`
+
+The shared authority policy is applied to:
+
+- Pokemon TCG API credential forwarding;
+- source-family classification;
+- ThePriceDex preserved evidence selection;
+- exact-variant source-lane classification;
+- self-hosted image source-lane classification;
+- web cohesion same-origin link extraction.
+
+## Alternatives Rejected
+
+- Broad CodeQL path exclusions: would hide owned executable tooling.
+- Escaping only the dots in PKMNCollectors URLs: would preserve positional
+  ambiguity instead of separating the fields.
+- Continuing substring checks with additional prefixes: remains vulnerable to
+  credentials, suffixes, and lookalike domains.
+- Keeping the certificate bypass behind an exact hostname allowlist: hostname
+  authority does not make an unverified TLS connection safe.
+
+## Verification
+
+- Shared URL authority contract tests: `5/5` passed.
+- HTTPS acquisition contract tests: `2/2` passed.
+- Full contract suite after the final implementation: `1240/1240` passed.
+- Syntax checks for every changed module and test: passed.
+- `git diff --check`: passed.
+- PKMNCollectors dry-run replay:
+  - Sun & Moon Energy: `9/9` generated.
+  - Yellow A Alternate: `4/4` generated.
+  - Futsal: the historical committed audit proves `4/4` generated, but the
+    isolated worktree has no retained HTML cache and the current remote pages no
+    longer satisfy the historical page assertions. No fixture or evidence was
+    rewritten during this security pass.
+
+## Current Truths
+
+- The code change has not yet been proven by a merged default-branch CodeQL
+  scan.
+- No target alert is claimed fixed until GitHub marks it fixed on `main`.
+- Existing canonical evidence and generated fixtures are unchanged.
+- This pass does not change the active pricing canary or release timing.
+- PostgreSQL client TLS policy is outside this URL-authority pass unless an
+  affected script transmitted credentials to an unverified peer.
+
+## Invariants
+
+- Never forward an API key based on a URL substring.
+- Never treat a registrable-domain suffix as an exact host unless subdomains are
+  explicitly allowed.
+- Never accept non-HTTP schemes as crawlable web links.
+- Never disable TLS certificate verification for acquisition convenience.
+- Never hide owned tooling by excluding audit paths from CodeQL.
+- Never rewrite historical source evidence to make a security replay pass.
+- Never modify production data during static-analysis remediation.
+
+## Explicit Next Gate
+
+Publish this repair, require all repository checks, and wait for the merged
+default-branch JavaScript/TypeScript CodeQL analysis. The gate passes only when
+all `43` targeted alert numbers are fixed with no replacement URL, hostname,
+scheme, or certificate-verification finding. Then record the authoritative open
+count and choose the next reusable owned-code repair family.

--- a/scripts/audits/card_row_enrichment_enrich11_source_mapped_trait_guarded_dry_run_v1.mjs
+++ b/scripts/audits/card_row_enrichment_enrich11_source_mapped_trait_guarded_dry_run_v1.mjs
@@ -6,6 +6,8 @@ import { promisify } from 'node:util';
 import pg from 'pg';
 import dotenv from 'dotenv';
 
+import { isUrlFromHostname } from './lib/url_authority_v1.mjs';
+
 dotenv.config({ path: '.env.local', quiet: true });
 dotenv.config({ quiet: true });
 
@@ -165,7 +167,7 @@ async function fetchJsonWithCurl(url) {
     '-s',
   ];
   const pokemonApiKey = String(process.env.POKEMONAPI_API_KEY ?? '').trim();
-  if (url.includes('api.pokemontcg.io') && pokemonApiKey) {
+  if (isUrlFromHostname(url, 'api.pokemontcg.io', { httpsOnly: true }) && pokemonApiKey) {
     args.push('-H', `X-Api-Key: ${pokemonApiKey}`);
   }
   args.push(url);

--- a/scripts/audits/card_row_enrichment_enrich12a_residual_trait_retry_guarded_dry_run_v1.mjs
+++ b/scripts/audits/card_row_enrichment_enrich12a_residual_trait_retry_guarded_dry_run_v1.mjs
@@ -6,6 +6,8 @@ import { promisify } from 'node:util';
 import pg from 'pg';
 import dotenv from 'dotenv';
 
+import { isUrlFromHostname } from './lib/url_authority_v1.mjs';
+
 dotenv.config({ path: '.env.local', quiet: true });
 dotenv.config({ quiet: true });
 
@@ -179,7 +181,9 @@ async function fetchJson(url) {
     '-s',
   ];
   const pokemonApiKey = String(process.env.POKEMONAPI_API_KEY ?? '').trim();
-  if (url.includes('api.pokemontcg.io') && pokemonApiKey) args.push('-H', `X-Api-Key: ${pokemonApiKey}`);
+  if (isUrlFromHostname(url, 'api.pokemontcg.io', { httpsOnly: true }) && pokemonApiKey) {
+    args.push('-H', `X-Api-Key: ${pokemonApiKey}`);
+  }
   args.push(url);
   const { stdout } = await execFileAsync('curl.exe', args, {
     encoding: 'utf8',

--- a/scripts/audits/english_master_index_pkg17o_league_preserved_evidence_absorption_v1.mjs
+++ b/scripts/audits/english_master_index_pkg17o_league_preserved_evidence_absorption_v1.mjs
@@ -8,6 +8,7 @@ import {
   normalizeNumber,
   normalizeText,
 } from './verified_master_set_index_v1/shared.mjs';
+import { isUrlFromHostname } from './lib/url_authority_v1.mjs';
 
 const ROOT = process.cwd();
 const AUDIT_DIR = path.join(DEFAULT_OUTPUT_DIR, 'english_master_index_v1');
@@ -108,18 +109,19 @@ function evidenceText(record) {
 
 function sourceFamily(record) {
   const sourceKey = String(record.source_key ?? '').toLowerCase();
-  const url = String(record.source_url ?? '').toLowerCase();
-  if (sourceKey.includes('pricecharting') || url.includes('pricecharting.com')) return 'pricecharting';
-  if (sourceKey.includes('pokecardvalues') || url.includes('pokecardvalues.co.uk')) return 'pokecardvalues';
-  if (sourceKey.includes('cardtrader') || url.includes('cardtrader.com')) return 'cardtrader';
-  if (sourceKey.includes('tcgplayer') || url.includes('tcgplayer.com')) return 'tcgplayer';
-  if (sourceKey.includes('bulbapedia') || url.includes('bulbapedia.bulbagarden.net')) return 'bulbapedia';
-  if (sourceKey.includes('doubleholo') || url.includes('doubleholo.com')) return 'doubleholo';
-  if (sourceKey.includes('elitefourum') || url.includes('elitefourum.com')) return 'elitefourum';
-  if (sourceKey.includes('bigorbit') || url.includes('bigorbitcards.co.uk')) return 'bigorbit';
-  if (sourceKey.includes('beckett') || url.includes('beckett.com')) return 'beckett';
-  if (sourceKey.includes('pokumon') || url.includes('pokumon.com')) return 'pokumon';
-  if (sourceKey.includes('tcdb') || url.includes('tcdb.com')) return 'tcdb';
+  const url = record.source_url;
+  const from = (hostname) => isUrlFromHostname(url, hostname, { allowSubdomains: true });
+  if (sourceKey.includes('pricecharting') || from('pricecharting.com')) return 'pricecharting';
+  if (sourceKey.includes('pokecardvalues') || from('pokecardvalues.co.uk')) return 'pokecardvalues';
+  if (sourceKey.includes('cardtrader') || from('cardtrader.com')) return 'cardtrader';
+  if (sourceKey.includes('tcgplayer') || from('tcgplayer.com')) return 'tcgplayer';
+  if (sourceKey.includes('bulbapedia') || from('bulbapedia.bulbagarden.net')) return 'bulbapedia';
+  if (sourceKey.includes('doubleholo') || from('doubleholo.com')) return 'doubleholo';
+  if (sourceKey.includes('elitefourum') || from('elitefourum.com')) return 'elitefourum';
+  if (sourceKey.includes('bigorbit') || from('bigorbitcards.co.uk')) return 'bigorbit';
+  if (sourceKey.includes('beckett') || from('beckett.com')) return 'beckett';
+  if (sourceKey.includes('pokumon') || from('pokumon.com')) return 'pokumon';
+  if (sourceKey.includes('tcdb') || from('tcdb.com')) return 'tcdb';
   return sourceKey || 'unknown';
 }
 

--- a/scripts/audits/english_master_index_pkmncollectors_futsal_acquisition_v1.mjs
+++ b/scripts/audits/english_master_index_pkmncollectors_futsal_acquisition_v1.mjs
@@ -12,10 +12,10 @@ const REPORT_DIR = 'docs/audits/english_master_index_source_exhaustion_v1/pkmnco
 const CACHE_DIR = path.join(REPORT_DIR, 'cache');
 
 const TARGETS = [
-  ['2', 'Eevee on the Ball', 'https://www.pkmncollectors.com/cards/eevee-on-the-ball-pokemon-futsal-2020-2-none'],
-  ['3', 'Grookey on the Ball', 'https://www.pkmncollectors.com/cards/grookey-on-the-ball-pokemon-futsal-2020-3-none'],
-  ['4', 'Scorbunny on the Ball', 'https://www.pkmncollectors.com/cards/scorbunny-on-the-ball-pokemon-futsal-2020-4-none'],
-  ['5', 'Sobble on the Ball', 'https://www.pkmncollectors.com/cards/sobble-on-the-ball-pokemon-futsal-2020-5-none'],
+  { cardNumber: '2', cardName: 'Eevee on the Ball', sourceUrl: 'https://www.pkmncollectors.com/cards/eevee-on-the-ball-pokemon-futsal-2020-2-none' },
+  { cardNumber: '3', cardName: 'Grookey on the Ball', sourceUrl: 'https://www.pkmncollectors.com/cards/grookey-on-the-ball-pokemon-futsal-2020-3-none' },
+  { cardNumber: '4', cardName: 'Scorbunny on the Ball', sourceUrl: 'https://www.pkmncollectors.com/cards/scorbunny-on-the-ball-pokemon-futsal-2020-4-none' },
+  { cardNumber: '5', cardName: 'Sobble on the Ball', sourceUrl: 'https://www.pkmncollectors.com/cards/sobble-on-the-ball-pokemon-futsal-2020-5-none' },
 ];
 
 function parseArgs(argv) {
@@ -73,10 +73,9 @@ function hasExactLabel(html, label) {
 }
 
 function validateTarget(html, target) {
-  const [cardNumber, cardName] = target;
   const checks = {
-    card_name: hasExactLabel(html, cardName),
-    card_number: html.includes(`#${cardNumber} of 5`),
+    card_name: hasExactLabel(html, target.cardName),
+    card_number: html.includes(`#${target.cardNumber} of 5`),
     set_name: hasExactLabel(html, 'Pokémon Futsal 2020') || hasExactLabel(html, 'Pokemon Futsal 2020'),
     available_variants_normal: /Available\s+variants[\s\S]{0,600}>\s*Normal\s*</i.test(html),
   };
@@ -87,22 +86,21 @@ function validateTarget(html, target) {
 }
 
 function recordFromTarget(target, generatedAt) {
-  const [cardNumber, cardName, sourceUrl] = target;
   return {
     source_key: 'pkmncollectors_futsal',
     source_kind: 'collector_reference',
-    source_url: sourceUrl,
+    source_url: target.sourceUrl,
     set_key: 'fut2020',
     set_name: 'Pokémon Futsal 2020',
-    card_number: cardNumber,
-    card_name: cardName,
+    card_number: target.cardNumber,
+    card_name: target.cardName,
     finish_key: 'normal',
     rarity: null,
     evidence_type: 'finish_presence',
     evidence_label: 'PKMN Collectors card page lists Available variants: Normal',
     language: 'en',
     retrieved_at: generatedAt,
-    raw_snapshot_ref: `pkmncollectors_futsal:${cardNumber}:${slugFromUrl(sourceUrl)}`,
+    raw_snapshot_ref: `pkmncollectors_futsal:${target.cardNumber}:${slugFromUrl(target.sourceUrl)}`,
     notes: 'Exact Pokémon Futsal 2020 card page with Available variants: Normal. Audit-only source evidence.',
   };
 }
@@ -123,12 +121,11 @@ async function main() {
   const records = [];
 
   for (const target of TARGETS) {
-    const [cardNumber, cardName, sourceUrl] = target;
     let status = 'source_unavailable';
     let validation = null;
     let error = null;
     try {
-      const html = await fetchHtmlCached(sourceUrl, options);
+      const html = await fetchHtmlCached(target.sourceUrl, options);
       validation = validateTarget(html, target);
       status = validation.ok ? 'generated' : 'validation_failed';
       if (validation.ok) records.push(recordFromTarget(target, generatedAt));
@@ -138,10 +135,10 @@ async function main() {
     results.push({
       set_key: 'fut2020',
       set_name: 'Pokémon Futsal 2020',
-      card_number: cardNumber,
-      card_name: cardName,
+      card_number: target.cardNumber,
+      card_name: target.cardName,
       finish_key: 'normal',
-      source_url: sourceUrl,
+      source_url: target.sourceUrl,
       status,
       validation,
       error,

--- a/scripts/audits/english_master_index_pkmncollectors_sm1_energy_acquisition_v1.mjs
+++ b/scripts/audits/english_master_index_pkmncollectors_sm1_energy_acquisition_v1.mjs
@@ -12,15 +12,15 @@ const REPORT_DIR = 'docs/audits/english_master_index_source_exhaustion_v1/pkmnco
 const CACHE_DIR = path.join(REPORT_DIR, 'cache');
 
 const TARGETS = [
-  ['164', 'Grass Energy', 'https://www.pkmncollectors.com/cards/grass-energy-sun-moon-164-common'],
-  ['165', 'Fire Energy', 'https://www.pkmncollectors.com/cards/fire-energy-sun-moon-165-common'],
-  ['166', 'Water Energy', 'https://www.pkmncollectors.com/cards/water-energy-sun-moon-166-common'],
-  ['167', 'Lightning Energy', 'https://www.pkmncollectors.com/cards/lightning-energy-sun-moon-167-common'],
-  ['168', 'Psychic Energy', 'https://www.pkmncollectors.com/cards/psychic-energy-sun-moon-168-common'],
-  ['169', 'Fighting Energy', 'https://www.pkmncollectors.com/cards/fighting-energy-sun-moon-169-common'],
-  ['170', 'Darkness Energy', 'https://www.pkmncollectors.com/cards/darkness-energy-sun-moon-170-common'],
-  ['171', 'Metal Energy', 'https://www.pkmncollectors.com/cards/metal-energy-sun-moon-171-common'],
-  ['172', 'Fairy Energy', 'https://www.pkmncollectors.com/cards/fairy-energy-sun-moon-172-common'],
+  { cardNumber: '164', cardName: 'Grass Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/grass-energy-sun-moon-164-common' },
+  { cardNumber: '165', cardName: 'Fire Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/fire-energy-sun-moon-165-common' },
+  { cardNumber: '166', cardName: 'Water Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/water-energy-sun-moon-166-common' },
+  { cardNumber: '167', cardName: 'Lightning Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/lightning-energy-sun-moon-167-common' },
+  { cardNumber: '168', cardName: 'Psychic Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/psychic-energy-sun-moon-168-common' },
+  { cardNumber: '169', cardName: 'Fighting Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/fighting-energy-sun-moon-169-common' },
+  { cardNumber: '170', cardName: 'Darkness Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/darkness-energy-sun-moon-170-common' },
+  { cardNumber: '171', cardName: 'Metal Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/metal-energy-sun-moon-171-common' },
+  { cardNumber: '172', cardName: 'Fairy Energy', sourceUrl: 'https://www.pkmncollectors.com/cards/fairy-energy-sun-moon-172-common' },
 ];
 
 function parseArgs(argv) {
@@ -82,10 +82,9 @@ function hasExactLabel(html, label) {
 }
 
 function validateTarget(html, target) {
-  const [cardNumber, cardName] = target;
   const checks = {
-    card_name: hasExactLabel(html, cardName),
-    card_number: html.includes(`#${cardNumber} of 149`),
+    card_name: hasExactLabel(html, target.cardName),
+    card_number: html.includes(`#${target.cardNumber} of 149`),
     set_name: hasExactLabel(html, 'Sun & Moon') || hasExactLabel(html, 'Sun &amp; Moon'),
     rarity_common: hasExactLabel(html, 'Common'),
     available_variants_normal: /Available\s+variants[\s\S]{0,600}>\s*Normal\s*</i.test(html),
@@ -97,22 +96,21 @@ function validateTarget(html, target) {
 }
 
 function recordFromTarget(target, generatedAt) {
-  const [cardNumber, cardName, sourceUrl] = target;
   return {
     source_key: 'pkmncollectors_sm1_energy',
     source_kind: 'collector_reference',
-    source_url: sourceUrl,
+    source_url: target.sourceUrl,
     set_key: 'sm1',
     set_name: 'Sun & Moon',
-    card_number: cardNumber,
-    card_name: cardName,
+    card_number: target.cardNumber,
+    card_name: target.cardName,
     finish_key: 'normal',
     rarity: 'Common',
     evidence_type: 'finish_presence',
     evidence_label: 'PKMN Collectors card page lists Available variants: Normal',
     language: 'en',
     retrieved_at: generatedAt,
-    raw_snapshot_ref: `pkmncollectors_sm1_energy:${cardNumber}:${slugFromUrl(sourceUrl)}`,
+    raw_snapshot_ref: `pkmncollectors_sm1_energy:${target.cardNumber}:${slugFromUrl(target.sourceUrl)}`,
     notes: 'Exact card page match for Sun & Moon numbered basic energy with Available variants: Normal. Audit-only source evidence.',
   };
 }
@@ -133,12 +131,11 @@ async function main() {
   const records = [];
 
   for (const target of TARGETS) {
-    const [cardNumber, cardName, sourceUrl] = target;
     let status = 'source_unavailable';
     let validation = null;
     let error = null;
     try {
-      const html = await fetchHtmlCached(sourceUrl, options);
+      const html = await fetchHtmlCached(target.sourceUrl, options);
       validation = validateTarget(html, target);
       status = validation.ok ? 'generated' : 'validation_failed';
       if (validation.ok) records.push(recordFromTarget(target, generatedAt));
@@ -148,10 +145,10 @@ async function main() {
     results.push({
       set_key: 'sm1',
       set_name: 'Sun & Moon',
-      card_number: cardNumber,
-      card_name: cardName,
+      card_number: target.cardNumber,
+      card_name: target.cardName,
       finish_key: 'normal',
-      source_url: sourceUrl,
+      source_url: target.sourceUrl,
       status,
       validation,
       error,

--- a/scripts/audits/english_master_index_pkmncollectors_xya_acquisition_v1.mjs
+++ b/scripts/audits/english_master_index_pkmncollectors_xya_acquisition_v1.mjs
@@ -12,10 +12,10 @@ const REPORT_DIR = 'docs/audits/english_master_index_source_exhaustion_v1/pkmnco
 const CACHE_DIR = path.join(REPORT_DIR, 'cache');
 
 const TARGETS = [
-  ['24a', 'M Manectric-EX', 'https://www.pkmncollectors.com/cards/m-manectric-ex-yellow-a-alternate-24a-rare'],
-  ['28a', 'Jolteon-EX', 'https://www.pkmncollectors.com/cards/jolteon-ex-yellow-a-alternate-28a-rare'],
-  ['54a', 'Zygarde-EX', 'https://www.pkmncollectors.com/cards/zygarde-ex-yellow-a-alternate-54a-rare'],
-  ['55a', 'M Lucario-EX', 'https://www.pkmncollectors.com/cards/m-lucario-ex-yellow-a-alternate-55a-rare'],
+  { cardNumber: '24a', cardName: 'M Manectric-EX', sourceUrl: 'https://www.pkmncollectors.com/cards/m-manectric-ex-yellow-a-alternate-24a-rare' },
+  { cardNumber: '28a', cardName: 'Jolteon-EX', sourceUrl: 'https://www.pkmncollectors.com/cards/jolteon-ex-yellow-a-alternate-28a-rare' },
+  { cardNumber: '54a', cardName: 'Zygarde-EX', sourceUrl: 'https://www.pkmncollectors.com/cards/zygarde-ex-yellow-a-alternate-54a-rare' },
+  { cardNumber: '55a', cardName: 'M Lucario-EX', sourceUrl: 'https://www.pkmncollectors.com/cards/m-lucario-ex-yellow-a-alternate-55a-rare' },
 ];
 
 function parseArgs(argv) {
@@ -77,10 +77,9 @@ function hasExactLabel(html, label) {
 }
 
 function validateTarget(html, target) {
-  const [cardNumber, cardName] = target;
   const checks = {
-    card_name: hasExactLabel(html, cardName),
-    card_number: html.includes(`#${cardNumber} of 6`),
+    card_name: hasExactLabel(html, target.cardName),
+    card_number: html.includes(`#${target.cardNumber} of 6`),
     set_name: hasExactLabel(html, 'Yellow A Alternate'),
     rarity_rare: hasExactLabel(html, 'Rare'),
     available_variants_normal: /Available\s+variants[\s\S]{0,600}>\s*Normal\s*</i.test(html),
@@ -92,22 +91,21 @@ function validateTarget(html, target) {
 }
 
 function recordFromTarget(target, generatedAt) {
-  const [cardNumber, cardName, sourceUrl] = target;
   return {
     source_key: 'pkmncollectors_xya',
     source_kind: 'collector_reference',
-    source_url: sourceUrl,
+    source_url: target.sourceUrl,
     set_key: 'xya',
     set_name: 'Yellow A Alternate',
-    card_number: cardNumber,
-    card_name: cardName,
+    card_number: target.cardNumber,
+    card_name: target.cardName,
     finish_key: 'normal',
     rarity: 'Rare',
     evidence_type: 'finish_presence',
     evidence_label: 'PKMN Collectors card page lists Available variants: Normal',
     language: 'en',
     retrieved_at: generatedAt,
-    raw_snapshot_ref: `pkmncollectors_xya:${cardNumber}:${slugFromUrl(sourceUrl)}`,
+    raw_snapshot_ref: `pkmncollectors_xya:${target.cardNumber}:${slugFromUrl(target.sourceUrl)}`,
     notes: 'Exact Yellow A Alternate card page with Available variants: Normal. Audit-only source evidence.',
   };
 }
@@ -128,12 +126,11 @@ async function main() {
   const records = [];
 
   for (const target of TARGETS) {
-    const [cardNumber, cardName, sourceUrl] = target;
     let status = 'source_unavailable';
     let validation = null;
     let error = null;
     try {
-      const html = await fetchHtmlCached(sourceUrl, options);
+      const html = await fetchHtmlCached(target.sourceUrl, options);
       validation = validateTarget(html, target);
       status = validation.ok ? 'generated' : 'validation_failed';
       if (validation.ok) records.push(recordFromTarget(target, generatedAt));
@@ -143,10 +140,10 @@ async function main() {
     results.push({
       set_key: 'xya',
       set_name: 'Yellow A Alternate',
-      card_number: cardNumber,
-      card_name: cardName,
+      card_number: target.cardNumber,
+      card_name: target.cardName,
       finish_key: 'normal',
-      source_url: sourceUrl,
+      source_url: target.sourceUrl,
       status,
       validation,
       error,

--- a/scripts/audits/english_master_index_thepricedex_preservation_from_index_v1.mjs
+++ b/scripts/audits/english_master_index_thepricedex_preservation_from_index_v1.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { normalizeFinishKey, normalizeNumber, normalizeText } from './verified_master_set_index_v1/shared.mjs';
+import { isUrlFromHostname } from './lib/url_authority_v1.mjs';
 
 const INDEX_DIR = 'docs/audits/verified_master_set_index_v1/english_master_index_v1';
 const FIXTURE_DIR = 'docs/audits/verified_master_set_index_v1/source_fixtures/generated_thepricedex_preservation_v1';
@@ -29,11 +30,11 @@ async function readJson(file) {
 function hasPriceDexSupport(row) {
   return (row.sources ?? []).includes(SOURCE_KEY)
     || (row.source_authorities ?? []).includes(SOURCE_AUTHORITY)
-    || (row.evidence_urls ?? []).some((url) => String(url).includes(SOURCE_AUTHORITY));
+    || (row.evidence_urls ?? []).some((url) => isUrlFromHostname(url, SOURCE_AUTHORITY, { allowSubdomains: true }));
 }
 
 function priceDexUrl(row) {
-  return (row.evidence_urls ?? []).find((url) => String(url).includes(SOURCE_AUTHORITY))
+  return (row.evidence_urls ?? []).find((url) => isUrlFromHostname(url, SOURCE_AUTHORITY, { allowSubdomains: true }))
     ?? 'https://www.thepricedex.com/';
 }
 

--- a/scripts/audits/image_truth_v1_exact_variant_readiness.mjs
+++ b/scripts/audits/image_truth_v1_exact_variant_readiness.mjs
@@ -3,6 +3,8 @@ import path from 'node:path';
 import pg from 'pg';
 import dotenv from 'dotenv';
 
+import { isUrlFromHostname } from './lib/url_authority_v1.mjs';
+
 dotenv.config({ path: '.env.local', quiet: true });
 dotenv.config({ quiet: true });
 
@@ -198,36 +200,40 @@ async function loadSourceRecords() {
 
 function classifySource(record) {
   const key = String(record.source_key ?? '').toLowerCase();
-  const url = String(record.source_url ?? '').toLowerCase();
-  if (key.includes('pricecharting') || url.includes('pricecharting.com/game/')) {
+  const url = record.source_url;
+  const from = (hostname, options = {}) => isUrlFromHostname(url, hostname, {
+    allowSubdomains: true,
+    ...options,
+  });
+  if (key.includes('pricecharting') || from('pricecharting.com', { pathPrefix: '/game/' })) {
     return {
       readiness_lane: 'exact_asset_probe_candidate',
       image_truth_limit: 'potential_exact_if_page_image_alt_matches_exact_card_finish',
       reason: 'PriceCharting product pages can expose a product image with exact alt/title evidence, but each asset must be probed before promotion.',
     };
   }
-  if (key.includes('cardtrader') || url.includes('cardtrader.com/')) {
+  if (key.includes('cardtrader') || from('cardtrader.com')) {
     return {
       readiness_lane: 'representative_only_unless_visual_manually_verified',
       image_truth_limit: 'representative',
       reason: 'CardTrader blueprint images are useful display coverage, but visual finish texture is not automatically proven.',
     };
   }
-  if (key.includes('reverseholo') || url.includes('reverseholo.app/')) {
+  if (key.includes('reverseholo') || from('reverseholo.app')) {
     return {
       readiness_lane: 'representative_only_unless_rendered_overlay_captured',
       image_truth_limit: 'representative',
       reason: 'ReverseHolo proves checklist finish facts; raw linked images may not contain the rendered finish overlay.',
     };
   }
-  if (key.includes('tcgcsv') || key.includes('tcgplayer') || url.includes('tcgplayer.com/')) {
+  if (key.includes('tcgcsv') || key.includes('tcgplayer') || from('tcgplayer.com')) {
     return {
       readiness_lane: 'representative_only_unless_visual_manually_verified',
       image_truth_limit: 'representative',
       reason: 'TCGplayer catalog/product images are product-associated but not automatically exact finish visual proof.',
     };
   }
-  if (key.includes('official') || url.includes('pokemon.com/')) {
+  if (key.includes('official') || from('pokemon.com')) {
     return {
       readiness_lane: 'base_display_only_for_parallel_rows',
       image_truth_limit: 'representative',

--- a/scripts/audits/lib/url_authority_v1.mjs
+++ b/scripts/audits/lib/url_authority_v1.mjs
@@ -1,0 +1,50 @@
+const HTTP_PROTOCOLS = new Set(['http:', 'https:']);
+
+function normalizeHostname(value) {
+  return String(value ?? '').trim().toLowerCase().replace(/\.$/, '');
+}
+
+export function parseHttpUrl(value, baseUrl = undefined) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+
+  try {
+    const parsed = baseUrl === undefined ? new URL(raw) : new URL(raw, baseUrl);
+    return HTTP_PROTOCOLS.has(parsed.protocol) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isHttpUrl(value) {
+  return parseHttpUrl(value) !== null;
+}
+
+export function hostnameMatches(actualHostname, expectedHostname, options = {}) {
+  const actual = normalizeHostname(actualHostname);
+  const expected = normalizeHostname(expectedHostname);
+  if (!actual || !expected) return false;
+  if (actual === expected) return true;
+  return options.allowSubdomains === true && actual.endsWith(`.${expected}`);
+}
+
+export function isUrlFromHostname(value, expectedHostname, options = {}) {
+  const parsed = parseHttpUrl(value);
+  if (!parsed) return false;
+  if (options.httpsOnly === true && parsed.protocol !== 'https:') return false;
+  if (!hostnameMatches(parsed.hostname, expectedHostname, options)) return false;
+  if (options.pathPrefix !== undefined && !parsed.pathname.startsWith(options.pathPrefix)) return false;
+  return true;
+}
+
+export function resolveSameOriginHttpUrl(href, baseUrl, currentPathname = '/') {
+  const base = parseHttpUrl(baseUrl);
+  if (!base) return null;
+
+  const current = parseHttpUrl(currentPathname, base);
+  if (!current || current.origin !== base.origin) return null;
+
+  const resolved = parseHttpUrl(href, current);
+  if (!resolved || resolved.origin !== base.origin) return null;
+  return resolved;
+}

--- a/scripts/audits/self_hosted_images_wh01a_warehouse_storage_audit_dry_run.mjs
+++ b/scripts/audits/self_hosted_images_wh01a_warehouse_storage_audit_dry_run.mjs
@@ -6,6 +6,8 @@ import pg from 'pg';
 import dotenv from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 
+import { isHttpUrl, isUrlFromHostname } from './lib/url_authority_v1.mjs';
+
 dotenv.config({ path: '.env.local', quiet: true });
 dotenv.config({ quiet: true });
 
@@ -94,10 +96,6 @@ function normalizePathSegment(value, fallback = 'unknown') {
   return normalized || fallback;
 }
 
-function isHttpUrl(value) {
-  return /^https?:\/\//i.test(String(value ?? '').trim());
-}
-
 function storagePublicUrl(storagePath) {
   const base = clean(process.env.SUPABASE_URL);
   if (!base) return null;
@@ -115,25 +113,17 @@ function resolveImageUrl(value) {
   return storagePublicUrl(normalized);
 }
 
-function hostnameFor(url) {
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
 function sourceLane(value) {
   const normalized = clean(value);
   if (!normalized) return 'missing';
   if (!isHttpUrl(normalized)) return 'supabase_storage_path';
-  const host = hostnameFor(normalized);
-  if (host?.includes('supabase.co')) return 'supabase_public_url';
-  if (host?.includes('pokemontcg.io')) return 'external_pokemontcg';
-  if (host?.includes('tcgplayer')) return 'external_tcgplayer';
-  if (host?.includes('tcgcollector.com')) return 'external_tcgcollector';
-  if (host?.includes('malie.io')) return 'external_malie';
-  if (host?.includes('assets.tcgdex.net')) return 'external_tcgdex';
+  const from = (hostname) => isUrlFromHostname(normalized, hostname, { allowSubdomains: true });
+  if (from('supabase.co')) return 'supabase_public_url';
+  if (from('pokemontcg.io')) return 'external_pokemontcg';
+  if (from('tcgplayer.com')) return 'external_tcgplayer';
+  if (from('tcgcollector.com')) return 'external_tcgcollector';
+  if (from('malie.io')) return 'external_malie';
+  if (from('assets.tcgdex.net')) return 'external_tcgdex';
   return 'external_other';
 }
 

--- a/scripts/audits/self_hosted_images_wh05b_trainer_kit_runtime_storage_upload_apply.mjs
+++ b/scripts/audits/self_hosted_images_wh05b_trainer_kit_runtime_storage_upload_apply.mjs
@@ -2,8 +2,6 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import process from 'node:process';
-import http from 'node:http';
-import https from 'node:https';
 import dotenv from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 
@@ -68,14 +66,6 @@ function canonicalizeJson(value) {
 
 function proofHash(value) {
   return sha256Hex(JSON.stringify(canonicalizeJson(value)));
-}
-
-function hostnameFor(url) {
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
 }
 
 function createStorageClient() {
@@ -250,64 +240,20 @@ function renderPlanMarkdown(plan) {
 `;
 }
 
-async function fetchBufferWithNodeClient(url, timeoutMs, options = {}, redirectCount = 0) {
-  if (redirectCount > 5) throw new Error(`too_many_redirects:${url}`);
-  const parsed = new URL(url);
-  const client = parsed.protocol === 'http:' ? http : https;
-  return new Promise((resolve, reject) => {
-    const request = client.get(parsed, {
-      headers: { 'user-agent': USER_AGENT },
-      timeout: timeoutMs,
-      rejectUnauthorized: options.rejectUnauthorized,
-    }, (response) => {
-      const location = response.headers.location;
-      if (response.statusCode >= 300 && response.statusCode < 400 && location) {
-        response.resume();
-        const nextUrl = new URL(location, parsed).toString();
-        fetchBufferWithNodeClient(nextUrl, timeoutMs, options, redirectCount + 1).then(resolve, reject);
-        return;
-      }
-      const chunks = [];
-      response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
-      response.on('end', () => {
-        resolve({
-          ok: response.statusCode >= 200 && response.statusCode < 300,
-          status: response.statusCode,
-          final_url: url,
-          content_type: response.headers['content-type'] ?? null,
-          buffer: Buffer.concat(chunks),
-          transport_note: options.transportNote ?? null,
-        });
-      });
-    });
-    request.on('timeout', () => request.destroy(new Error(`request_timeout:${url}`)));
-    request.on('error', reject);
-  });
-}
-
 async function fetchBuffer(url, timeoutMs) {
-  try {
-    const response = await fetch(url, {
-      redirect: 'follow',
-      signal: AbortSignal.timeout(timeoutMs),
-      headers: { 'user-agent': USER_AGENT },
-    });
-    return {
-      ok: response.ok,
-      status: response.status,
-      final_url: response.url,
-      content_type: response.headers.get('content-type'),
-      buffer: Buffer.from(await response.arrayBuffer()),
-      transport_note: null,
-    };
-  } catch (error) {
-    const host = hostnameFor(url);
-    if (!host?.includes('malie.io') && !host?.includes('tcgcollector.com')) throw error;
-    return fetchBufferWithNodeClient(url, timeoutMs, {
-      rejectUnauthorized: false,
-      transportNote: `${host}_tls_verification_disabled_after_manifest_validation`,
-    });
-  }
+  const response = await fetch(url, {
+    redirect: 'follow',
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: { 'user-agent': USER_AGENT },
+  });
+  return {
+    ok: response.ok,
+    status: response.status,
+    final_url: response.url,
+    content_type: response.headers.get('content-type'),
+    buffer: Buffer.from(await response.arrayBuffer()),
+    transport_note: null,
+  };
 }
 
 async function storageObjectExists(supabase, bucket, storagePath) {

--- a/scripts/audits/web_cohesion_link_integrity_v1.mjs
+++ b/scripts/audits/web_cohesion_link_integrity_v1.mjs
@@ -5,6 +5,8 @@ import { performance } from "node:perf_hooks";
 import dotenv from "dotenv";
 import { createClient } from "@supabase/supabase-js";
 
+import { resolveSameOriginHttpUrl } from "./lib/url_authority_v1.mjs";
+
 const ROOT = process.cwd();
 const OUT_DIR = path.join(ROOT, "docs", "audits", "web_cohesion_link_integrity_v1");
 const OUT_JSON = path.join(OUT_DIR, "web_cohesion_link_integrity_v1.json");
@@ -267,16 +269,13 @@ function extractInternalLinks(html, baseUrl, currentPathname) {
   while ((match = linkPattern.exec(html))) {
     const rawHref = match[1] ?? match[2] ?? match[3] ?? "";
     const href = rawHref.trim();
-    if (!href || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:") || href.startsWith("javascript:")) {
+    if (!href || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) {
       continue;
     }
 
     try {
-      const url = new URL(href, `${baseUrl}${currentPathname}`);
-      const base = new URL(baseUrl);
-      if (url.origin !== base.origin) {
-        continue;
-      }
+      const url = resolveSameOriginHttpUrl(href, baseUrl, currentPathname);
+      if (!url) continue;
       links.push({
         href,
         pathname: normalizePathname(url.pathname),

--- a/tests/contracts/audit_https_certificate_validation_v1.test.mjs
+++ b/tests/contracts/audit_https_certificate_validation_v1.test.mjs
@@ -10,6 +10,7 @@ const ACQUISITION_FILES = [
   "scripts/audits/jpn_pikachu_promo_end_to_end_apply_v1.mjs",
   "scripts/audits/jpn_pikachu_promo_gap_audit_v1.mjs",
   "scripts/audits/self_hosted_images_wh05a_trainer_kit_runtime_upload_dry_run.mjs",
+  "scripts/audits/self_hosted_images_wh05b_trainer_kit_runtime_storage_upload_apply.mjs",
   "scripts/audits/self_hosted_images_wh06a_mcdonalds_runtime_upload_dry_run.mjs",
   "scripts/audits/self_hosted_images_wh06b_mcdonalds_dextcg_upload_dry_run.mjs",
   "scripts/audits/self_hosted_images_wh06c_mcdonalds_dextcg_storage_upload_apply.mjs",

--- a/tests/contracts/audit_url_authority_v1.test.mjs
+++ b/tests/contracts/audit_url_authority_v1.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+  hostnameMatches,
+  isHttpUrl,
+  isUrlFromHostname,
+  parseHttpUrl,
+  resolveSameOriginHttpUrl,
+} from '../../scripts/audits/lib/url_authority_v1.mjs';
+
+test('parseHttpUrl accepts only HTTP and HTTPS URLs', () => {
+  assert.equal(parseHttpUrl('https://example.com/path')?.hostname, 'example.com');
+  assert.equal(parseHttpUrl('http://example.com/path')?.hostname, 'example.com');
+  assert.equal(parseHttpUrl('data:text/html,hello'), null);
+  assert.equal(parseHttpUrl('javascript:alert(1)'), null);
+  assert.equal(parseHttpUrl('vbscript:msgbox(1)'), null);
+  assert.equal(parseHttpUrl('not a url'), null);
+  assert.equal(isHttpUrl('https://example.com'), true);
+  assert.equal(isHttpUrl('/relative'), false);
+});
+
+test('hostnameMatches distinguishes exact hosts, subdomains, and lookalikes', () => {
+  assert.equal(hostnameMatches('api.pokemontcg.io', 'api.pokemontcg.io'), true);
+  assert.equal(hostnameMatches('www.tcgplayer.com', 'tcgplayer.com'), false);
+  assert.equal(hostnameMatches('www.tcgplayer.com', 'tcgplayer.com', { allowSubdomains: true }), true);
+  assert.equal(hostnameMatches('tcgplayer.com.evil.test', 'tcgplayer.com', { allowSubdomains: true }), false);
+  assert.equal(hostnameMatches('eviltcgplayer.com', 'tcgplayer.com', { allowSubdomains: true }), false);
+  assert.equal(hostnameMatches('TCGPLAYER.COM.', 'tcgplayer.com'), true);
+});
+
+test('isUrlFromHostname does not leak authority to URL lookalikes', () => {
+  const secureOnly = { httpsOnly: true };
+  assert.equal(isUrlFromHostname('https://api.pokemontcg.io/v2/cards', 'api.pokemontcg.io', secureOnly), true);
+  assert.equal(isUrlFromHostname('http://api.pokemontcg.io/v2/cards', 'api.pokemontcg.io', secureOnly), false);
+  assert.equal(isUrlFromHostname('https://api.pokemontcg.io.evil.test/v2/cards', 'api.pokemontcg.io', secureOnly), false);
+  assert.equal(isUrlFromHostname('https://api.pokemontcg.io@evil.test/v2/cards', 'api.pokemontcg.io', secureOnly), false);
+  assert.equal(isUrlFromHostname('https://www.pricecharting.com/game/pokemon/test', 'pricecharting.com', {
+    allowSubdomains: true,
+    pathPrefix: '/game/',
+  }), true);
+  assert.equal(isUrlFromHostname('https://www.pricecharting.com/offers/test', 'pricecharting.com', {
+    allowSubdomains: true,
+    pathPrefix: '/game/',
+  }), false);
+});
+
+test('resolveSameOriginHttpUrl rejects dangerous and cross-origin links', () => {
+  const baseUrl = 'https://grookai.example';
+  assert.equal(resolveSameOriginHttpUrl('/cards/one', baseUrl, '/sets/base')?.href, 'https://grookai.example/cards/one');
+  assert.equal(resolveSameOriginHttpUrl('../cards/two', baseUrl, '/sets/base/')?.href, 'https://grookai.example/sets/cards/two');
+  assert.equal(resolveSameOriginHttpUrl('https://grookai.example/cards/three', baseUrl)?.pathname, '/cards/three');
+  assert.equal(resolveSameOriginHttpUrl('https://evil.test/cards/one', baseUrl), null);
+  assert.equal(resolveSameOriginHttpUrl('data:text/html,hello', baseUrl), null);
+  assert.equal(resolveSameOriginHttpUrl('javascript:alert(1)', baseUrl), null);
+  assert.equal(resolveSameOriginHttpUrl('vbscript:msgbox(1)', baseUrl), null);
+});
+
+test('repaired acquisition scripts retain explicit authority boundaries', () => {
+  const apiKeyFiles = [
+    'scripts/audits/card_row_enrichment_enrich11_source_mapped_trait_guarded_dry_run_v1.mjs',
+    'scripts/audits/card_row_enrichment_enrich12a_residual_trait_retry_guarded_dry_run_v1.mjs',
+  ];
+  for (const file of apiKeyFiles) {
+    const source = readFileSync(file, 'utf8');
+    assert.match(source, /isUrlFromHostname\(url, 'api\.pokemontcg\.io', \{ httpsOnly: true \}\)/, file);
+    assert.doesNotMatch(source, /url\.includes\('api\.pokemontcg\.io'\)/, file);
+  }
+
+  const pkmnCollectorsFiles = [
+    'scripts/audits/english_master_index_pkmncollectors_futsal_acquisition_v1.mjs',
+    'scripts/audits/english_master_index_pkmncollectors_sm1_energy_acquisition_v1.mjs',
+    'scripts/audits/english_master_index_pkmncollectors_xya_acquisition_v1.mjs',
+  ];
+  for (const file of pkmnCollectorsFiles) {
+    const source = readFileSync(file, 'utf8');
+    assert.match(source, /target\.cardName/, file);
+    assert.match(source, /target\.sourceUrl/, file);
+    assert.doesNotMatch(source, /const \[cardNumber, cardName(?:, sourceUrl)?\] = target/, file);
+  }
+
+  const linkAudit = readFileSync('scripts/audits/web_cohesion_link_integrity_v1.mjs', 'utf8');
+  assert.match(linkAudit, /resolveSameOriginHttpUrl\(href, baseUrl, currentPathname\)/);
+
+  const legacyUploader = readFileSync(
+    'scripts/audits/self_hosted_images_wh05b_trainer_kit_runtime_storage_upload_apply.mjs',
+    'utf8',
+  );
+  assert.doesNotMatch(legacyUploader, /rejectUnauthorized:\s*false/);
+  assert.doesNotMatch(legacyUploader, /tls_verification_disabled/);
+});


### PR DESCRIPTION
## Summary
- centralize parsed HTTP/HTTPS authority checks for owned audit tooling
- require exact HTTPS authority before forwarding the Pokemon TCG API key
- separate PKMNCollectors URL and regex-label fields, and reject non-web crawler schemes
- remove a legacy image-upload certificate-verification bypass
- checkpoint the 43-alert URL/hostname repair gate

## Verification
- 1240/1240 full contracts passed
- 7/7 targeted URL/TLS contracts passed
- syntax checks passed for every changed module
- release secret packaging guard passed
- git diff --check passed
- no database writes, deployments, or production configuration changes

## Source replay note
Sun & Moon Energy generated 9/9 and Yellow A Alternate generated 4/4. The Futsal worktree has no retained HTML cache and the current remote pages no longer satisfy the historical assertions; committed historical evidence was not rewritten.

## Hook note
The isolated worktree has no SUPABASE_DB_URL, so the repository's documented --no-verify path was used after independent verification. All GitHub checks, especially CodeQL, are required before merge.