### PR TITLE
fix(pricing): tolerate bounded canary source gaps

### DIFF
--- a/backend/pricing/tcgplayer_market_canary_observation_policy_v1.mjs
+++ b/backend/pricing/tcgplayer_market_canary_observation_policy_v1.mjs
@@ -1,9 +1,11 @@
-export const TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2 =
-  "TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2";
+export const TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3 =
+  "TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3";
 
-// Preserve the original export name for callers pinned to the V1 module path.
+// Preserve historical export names for callers pinned to the V1 module path.
+export const TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2 =
+  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3;
 export const TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V1 =
-  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2;
+  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3;
 
 const HOUR_MS = 60 * 60 * 1000;
 const MINUTE_MS = 60 * 1000;
@@ -44,12 +46,72 @@ function reconciliationMismatches(run) {
     : [];
 }
 
-function runIsExact(run, expectedCount) {
+function canarySourceCoverage(run, expectedCount, maxSourceMissingCount) {
+  const reconciliation = run?.reconciliation ?? {};
+  const expected = integer(reconciliation.canary_expected_count);
+  const resolved = integer(reconciliation.canary_resolved_count);
+  const sourceMissing = integer(
+    reconciliation.canary_source_missing_count,
+  );
+  const outcomes = Array.isArray(reconciliation.canary_source_outcomes)
+    ? reconciliation.canary_source_outcomes
+    : [];
+  const resolvedOutcomes = outcomes.filter(
+    (outcome) => outcome?.outcome === "resolved",
+  ).length;
+  const missingOutcomes = outcomes.filter(
+    (outcome) => outcome?.outcome === "source_missing",
+  ).length;
+  const unknownOutcomes = outcomes.length - resolvedOutcomes - missingOutcomes;
+  const ordinals = outcomes.map((outcome) => integer(outcome?.ordinal));
+  const ordinalSet = new Set(ordinals);
+  const ordinalsAreComplete =
+    ordinalSet.size === expectedCount &&
+    Array.from({ length: expectedCount }, (_, index) => index + 1).every(
+      (ordinal) => ordinalSet.has(ordinal),
+    );
+  const outcomeEvidenceIsCoherent = outcomes.every((outcome) =>
+    outcome?.outcome === "resolved"
+      ? Boolean(string(outcome?.source_observation_id))
+      : outcome?.outcome === "source_missing"
+        ? outcome?.source_observation_id === null
+        : false,
+  );
+  const valid =
+    reconciliation.canary_source_coverage_policy_version ===
+      TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1 &&
+    reconciliation.canary_source_coverage_reconciled === true &&
+    expected === expectedCount &&
+    resolved !== null &&
+    sourceMissing !== null &&
+    sourceMissing >= 0 &&
+    sourceMissing <= maxSourceMissingCount &&
+    resolved + sourceMissing === expectedCount &&
+    outcomes.length === expectedCount &&
+    resolvedOutcomes === resolved &&
+    missingOutcomes === sourceMissing &&
+    unknownOutcomes === 0 &&
+    ordinalsAreComplete &&
+    outcomeEvidenceIsCoherent;
+  return { expected, resolved, sourceMissing, outcomes, valid };
+}
+
+function runIsExact(
+  run,
+  expectedCount,
+  maxSourceMissingCount,
+) {
+  const coverage = canarySourceCoverage(
+    run,
+    expectedCount,
+    maxSourceMissingCount,
+  );
   return (
-    integer(run?.selected_count) === expectedCount &&
-    integer(run?.mapped_count) === expectedCount &&
-    integer(run?.eligible_count) === expectedCount &&
-    integer(run?.snapshot_count) === expectedCount &&
+    coverage.valid &&
+    integer(run?.selected_count) === coverage.resolved &&
+    integer(run?.mapped_count) === coverage.resolved &&
+    integer(run?.eligible_count) === coverage.resolved &&
+    integer(run?.snapshot_count) === coverage.resolved &&
     integer(run?.delayed_count) === 0 &&
     integer(run?.suppressed_count) === 0 &&
     integer(run?.quarantined_count) === 0 &&
@@ -57,7 +119,10 @@ function runIsExact(run, expectedCount) {
   );
 }
 
-function runIsHealthy(run, { expectedCount, expectedCommitSha }) {
+function runIsHealthy(
+  run,
+  { expectedCount, expectedCommitSha, maxSourceMissingCount },
+) {
   return (
     run?.run_mode === "canary" &&
     run?.state === "verified" &&
@@ -68,7 +133,7 @@ function runIsHealthy(run, { expectedCount, expectedCommitSha }) {
     !run?.failed_at &&
     !run?.error &&
     reconciliationMismatches(run).length === 0 &&
-    runIsExact(run, expectedCount)
+    runIsExact(run, expectedCount, maxSourceMissingCount)
   );
 }
 
@@ -137,6 +202,7 @@ function evaluateScheduleEvidence({
   completionGraceMinutes,
   expectedCount,
   expectedCommitSha,
+  maxSourceMissingCount,
 }) {
   const endMs = asOf.getTime();
   const triggerToleranceMs = triggerToleranceMinutes * MINUTE_MS;
@@ -283,6 +349,7 @@ function evaluateScheduleEvidence({
       runIsHealthy(publicationRun, {
         expectedCount,
         expectedCommitSha,
+        maxSourceMissingCount,
       })
     ) {
       matched.push({
@@ -295,6 +362,8 @@ function evaluateScheduleEvidence({
         publication_run_key: keys.publication,
         publication_started_at: publicationRun.started_at ?? null,
         publication_completed_at: publicationRun.completed_at ?? null,
+        source_missing_count:
+          publicationRun.reconciliation?.canary_source_missing_count ?? null,
       });
       continue;
     }
@@ -363,6 +432,7 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
   scheduleToleranceMinutes = 90,
   scheduleCompletionGraceMinutes = 480,
   expectedCount = 100,
+  maxSourceMissingCount = 5,
   expectedCommitSha,
   activationRun,
   scheduledSourceRuns = [],
@@ -382,6 +452,15 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
   }
   if (!Number.isInteger(expectedCount) || expectedCount < 1) {
     throw new Error("expectedCount must be a positive integer");
+  }
+  if (
+    !Number.isInteger(maxSourceMissingCount) ||
+    maxSourceMissingCount < 0 ||
+    maxSourceMissingCount >= expectedCount
+  ) {
+    throw new Error(
+      "maxSourceMissingCount must be a non-negative integer below expectedCount",
+    );
   }
   if (
     !Number.isFinite(scheduleToleranceMinutes) ||
@@ -429,6 +508,7 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
     completionGraceMinutes: scheduleCompletionGraceMinutes,
     expectedCount,
     expectedCommitSha: commitSha,
+    maxSourceMissingCount,
   });
   const findings = [];
 
@@ -438,6 +518,7 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
     !runIsHealthy(activationRun, {
       expectedCount,
       expectedCommitSha: commitSha,
+      maxSourceMissingCount,
     })
   ) {
     findings.push("activation_run_not_exact_and_healthy");
@@ -463,10 +544,33 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
   }
   if (terminalAlerts.length) findings.push("terminal_operations_alert_in_window");
 
-  if (integer(current.exact_price_count) !== expectedCount) {
+  const healthyRuns = [activationRun, ...publicationRuns]
+    .filter(Boolean)
+    .filter((run) =>
+      runIsHealthy(run, {
+        expectedCount,
+        expectedCommitSha: commitSha,
+        maxSourceMissingCount,
+      }),
+    );
+  const latestHealthyRun = healthyRuns
+    .slice()
+    .sort(
+      (left, right) =>
+        new Date(right.completed_at).getTime() -
+        new Date(left.completed_at).getTime(),
+    )[0];
+  const expectedCurrentCount = latestHealthyRun
+    ? canarySourceCoverage(
+        latestHealthyRun,
+        expectedCount,
+        maxSourceMissingCount,
+      ).resolved
+    : expectedCount;
+  if (integer(current.exact_price_count) !== expectedCurrentCount) {
     findings.push("current_exact_price_count_mismatch");
   }
-  if (integer(current.positive_usd_count) !== expectedCount) {
+  if (integer(current.positive_usd_count) !== expectedCurrentCount) {
     findings.push("current_positive_usd_count_mismatch");
   }
   if (integer(current.missing_provenance_count) !== 0) {
@@ -478,22 +582,6 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
   if (integer(current.broken_trace_count) !== 0) {
     findings.push("broken_source_to_publication_trace");
   }
-
-  const healthyRuns = [activationRun, ...publicationRuns]
-    .filter(Boolean)
-    .filter((run) =>
-      runIsHealthy(run, {
-        expectedCount,
-        expectedCommitSha: commitSha,
-      }),
-    );
-  const latestHealthyRun = healthyRuns
-    .slice()
-    .sort(
-      (left, right) =>
-        new Date(right.completed_at).getTime() -
-        new Date(left.completed_at).getTime(),
-    )[0];
   if (
     latestHealthyRun &&
     string(current.current_publication_run_id) !== string(latestHealthyRun.id)
@@ -543,7 +631,7 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
       : "observing";
 
   return {
-    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2,
+    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3,
     status,
     window: {
       started_at: start.toISOString(),
@@ -575,6 +663,8 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
     run_evidence: {
       expected_commit_sha: commitSha,
       expected_count: expectedCount,
+      max_source_missing_count: maxSourceMissingCount,
+      expected_current_count: expectedCurrentCount,
       activation_run_key: activationRun?.run_key ?? null,
       scheduled_source_run_count: sourceRuns.length,
       scheduled_publication_run_count: publicationRuns.length,
@@ -590,3 +680,6 @@ export function evaluateTcgplayerMarketCanaryObservationV1({
     findings,
   };
 }
+import {
+  TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1,
+} from "./tcgplayer_market_canary_source_coverage_v1.mjs";

--- a/backend/pricing/tcgplayer_market_canary_source_coverage_v1.mjs
+++ b/backend/pricing/tcgplayer_market_canary_source_coverage_v1.mjs
@@ -1,0 +1,182 @@
+import {
+  tcgplayerMarketCanarySourceKeyV1,
+} from "./tcgplayer_market_canary_definition_v1.mjs";
+
+export const TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1 =
+  "TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1";
+
+function rawSourceKey(value) {
+  return [Number(value.source_product_id), value.source_subtype_name].join(":");
+}
+
+function indexRows(rows, keyFor) {
+  const index = new Map();
+  for (const row of rows) {
+    const key = keyFor(row);
+    const matches = index.get(key) ?? [];
+    matches.push(row);
+    index.set(key, matches);
+  }
+  return index;
+}
+
+function availableSourceIdentities(rawRows, sourceProductId) {
+  return rawRows
+    .filter((row) => Number(row.source_product_id) === Number(sourceProductId))
+    .map((row) => ({
+      source_observation_id: row.source_observation_id ?? null,
+      source_price_row_identity: row.source_price_row_identity ?? null,
+      source_product_id: Number(row.source_product_id),
+      source_subtype_name: row.source_subtype_name,
+    }))
+    .sort((left, right) =>
+      String(left.source_subtype_name).localeCompare(
+        String(right.source_subtype_name),
+      ),
+    );
+}
+
+function assertResolvedIdentity(printing, row, key) {
+  const mismatches = [
+    ["card_print_id", printing.card_print_id],
+    ["gv_id", printing.gv_id],
+    ["printing_gv_id", printing.printing_gv_id],
+    ["finish_key", printing.expected_finish],
+  ].filter(([field, expected]) => row[field] !== expected);
+  if (mismatches.length) {
+    throw new Error(
+      `canary identity ${key} drifted: ${mismatches
+        .map(
+          ([field, expected]) =>
+            `${field}=${row[field]} expected=${expected}`,
+        )
+        .join(",")}`,
+    );
+  }
+}
+
+export function resolveTcgplayerMarketCanarySourceCoverageV1({
+  canaryDefinition,
+  candidateRows,
+  currentSourceRows,
+  sourceRun,
+}) {
+  if (!canaryDefinition || !Array.isArray(canaryDefinition.printings)) {
+    throw new Error("canaryDefinition.printings is required");
+  }
+  if (!Array.isArray(candidateRows)) {
+    throw new Error("candidateRows must be an array");
+  }
+  if (!Array.isArray(currentSourceRows)) {
+    throw new Error("currentSourceRows must be an array");
+  }
+  if (!sourceRun?.id || !sourceRun?.observed_on) {
+    throw new Error("sourceRun id and observed_on are required");
+  }
+
+  const candidatesByKey = indexRows(
+    candidateRows,
+    tcgplayerMarketCanarySourceKeyV1,
+  );
+  const sourceRowsByKey = indexRows(currentSourceRows, rawSourceKey);
+  const resolvedRows = [];
+  const outcomes = [];
+
+  for (const printing of canaryDefinition.printings) {
+    const candidateKey = tcgplayerMarketCanarySourceKeyV1(printing);
+    const expectedRawKey = rawSourceKey(printing);
+    const candidates = candidatesByKey.get(candidateKey) ?? [];
+    const sourceRows = sourceRowsByKey.get(expectedRawKey) ?? [];
+    const baseOutcome = {
+      ordinal: printing.ordinal,
+      card_print_id: printing.card_print_id,
+      card_printing_id: printing.card_printing_id,
+      gv_id: printing.gv_id,
+      printing_gv_id: printing.printing_gv_id,
+      source_product_id: Number(printing.source_product_id),
+      source_subtype_name: printing.source_subtype_name,
+      expected_finish: printing.expected_finish,
+      source_sync_run_id: sourceRun.id,
+      source_observed_on: sourceRun.observed_on,
+      candidate_count: candidates.length,
+      current_source_row_count: sourceRows.length,
+      available_source_identities: availableSourceIdentities(
+        currentSourceRows,
+        printing.source_product_id,
+      ),
+    };
+
+    if (candidates.length > 1) {
+      throw new Error(
+        `canary source identity ${candidateKey} resolved ${candidates.length} candidate rows`,
+      );
+    }
+    if (sourceRows.length > 1) {
+      throw new Error(
+        `canary raw source identity ${expectedRawKey} resolved ${sourceRows.length} rows`,
+      );
+    }
+
+    if (candidates.length === 0) {
+      if (sourceRows.length === 1) {
+        throw new Error(
+          `canary source identity ${candidateKey} exists in the current source run but resolved 0 candidate rows`,
+        );
+      }
+      outcomes.push({
+        ...baseOutcome,
+        outcome: "source_missing",
+        source_observation_id: null,
+        reason: "exact_product_and_subtype_absent_from_current_source_run",
+      });
+      continue;
+    }
+
+    if (sourceRows.length !== 1) {
+      throw new Error(
+        `canary source identity ${candidateKey} resolved a candidate without exactly one current raw source row`,
+      );
+    }
+
+    const row = candidates[0];
+    const rawRow = sourceRows[0];
+    if (
+      row.source_observation_id !== rawRow.source_observation_id ||
+      row.source_sync_run_id !== sourceRun.id
+    ) {
+      throw new Error(
+        `canary source identity ${candidateKey} candidate/raw source provenance drifted`,
+      );
+    }
+    assertResolvedIdentity(printing, row, candidateKey);
+    resolvedRows.push(row);
+    outcomes.push({
+      ...baseOutcome,
+      outcome: "resolved",
+      source_observation_id: row.source_observation_id,
+      source_price_row_identity: row.source_price_row_identity,
+      reason: null,
+    });
+  }
+
+  const sourceMissingCount = outcomes.filter(
+    (outcome) => outcome.outcome === "source_missing",
+  ).length;
+  const coverage = {
+    policy_version: TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1,
+    expected_count: canaryDefinition.expected_count,
+    resolved_count: resolvedRows.length,
+    source_missing_count: sourceMissingCount,
+    reconciled:
+      outcomes.length === canaryDefinition.expected_count &&
+      resolvedRows.length + sourceMissingCount === canaryDefinition.expected_count,
+    outcomes,
+  };
+  if (!coverage.reconciled) {
+    throw new Error(
+      `canary source coverage mismatch expected=${coverage.expected_count} resolved=${coverage.resolved_count} source_missing=${coverage.source_missing_count} outcomes=${outcomes.length}`,
+    );
+  }
+
+  return { rows: resolvedRows, coverage };
+}

--- a/backend/pricing/tcgplayer_market_operations_policy_v1.mjs
+++ b/backend/pricing/tcgplayer_market_operations_policy_v1.mjs
@@ -16,7 +16,15 @@ const NON_RETRYABLE_PATTERNS = [
 
 const CANARY_DEFINITION_DRIFT_PATTERNS = [
   /canary source identity .* resolved \d+ rows/i,
+  /canary source identity .* resolved \d+ candidate rows/i,
+  /canary raw source identity .* resolved \d+ rows/i,
+  /canary source identity .* exists in the current source run but resolved \d+ candidate rows/i,
+  /canary source identity .* provenance drifted/i,
   /canary identity .* drifted/i,
+];
+
+const CANARY_SOURCE_DEGRADATION_PATTERNS = [
+  /canary source_missing ceiling exceeded/i,
 ];
 
 const RETRYABLE_PATTERNS = [
@@ -42,6 +50,12 @@ export function classifyMarketPipelineFailureV1({
   errorText = "",
 } = {}) {
   const text = String(errorText ?? "");
+  if (CANARY_SOURCE_DEGRADATION_PATTERNS.some((pattern) => pattern.test(text))) {
+    return {
+      classification: "non_retryable_canary_source_degradation",
+      retryable: false,
+    };
+  }
   if (CANARY_DEFINITION_DRIFT_PATTERNS.some((pattern) => pattern.test(text))) {
     return {
       classification: "non_retryable_canary_definition_drift",

--- a/docs/checkpoints/pricing/PRICING_CHECKPOINT_42_CANARY_SOURCE_GAP_POLICY_REPAIR.md
+++ b/docs/checkpoints/pricing/PRICING_CHECKPOINT_42_CANARY_SOURCE_GAP_POLICY_REPAIR.md
@@ -1,0 +1,244 @@
+# Pricing Checkpoint 42: Canary Source-Gap Policy Repair
+
+## Status
+
+Implementation and read-only proof complete. Deployment and canary restart are
+not complete.
+
+The July 31 replacement canary window is failed historical evidence. Its
+August 1 and August 2 unattended publication cycles could not resolve one of
+the 100 frozen exact source identities. The old worker aborted the entire
+publication when that single current source row disappeared.
+
+This checkpoint records a bounded source-gap policy that preserves all 100
+frozen canonical identities while allowing currently unavailable source rows
+to be accounted for explicitly. It does not declare the canary healthy, does
+not deploy the repair, and does not start a new 72-hour window.
+
+## Context
+
+Canary V2 froze 100 reviewed card-printing identities. Its ordinal 7 is:
+
+| Field | Value |
+| --- | --- |
+| Card | Alolan Ninetales SM128 |
+| GV-ID | `GV-PK-SM-SM128` |
+| Printing GV-ID | `GV-PK-SM-SM128-HOLO` |
+| Card printing ID | `69886a4a-0514-40ac-85f4-3a8aabac1750` |
+| TCGPlayer product ID | `168245` |
+| Source subtype | `Holofoil` |
+
+The exact identity was available when the July 31 replacement activation was
+created. It was absent from the subsequent current source runs. The source
+warehouse itself remained healthy; this was a current-feed availability
+change, not a failed warehouse acquisition.
+
+## Problem
+
+The publication worker treated the fixed canary as both:
+
+- a canonical denominator of 100 reviewed identities; and
+- a requirement that all 100 exact source rows exist in every daily feed.
+
+Those are different contracts. A source can temporarily remove an exact
+product/subtype row without invalidating the other 99 identities. Aborting the
+whole batch made all current prices age past the 36-hour publication window,
+so a single missing source identity reduced the governed current read model
+from 100 rows to zero.
+
+The failed production evidence is:
+
+| Evidence | Identifier |
+| --- | --- |
+| August 1 publication run | `157ed56d-f208-4680-8b3d-d0629b449dc1` |
+| August 2 publication run | `a883b18b-c398-4fad-891d-de7fea0fdcb8` |
+| Latest failed GitHub observer run | `30750934231` |
+
+## Risk
+
+Silently dropping the identity would mutate the frozen canary. Substituting a
+sibling subtype or a historical row would publish unsupported evidence.
+Continuing to abort all 100 would make the canary and current pricing read
+model operationally brittle whenever an upstream product/subtype disappears.
+
+A tolerant policy is safe only if it proves exact current-source absence,
+keeps the canonical denominator fixed, bounds the number of gaps, and treats
+mapping or provenance drift as fatal.
+
+## Decision
+
+### Preserve the fixed 100-identity denominator
+
+Every canary definition entry must resolve to exactly one outcome:
+
+- `resolved`: one exact current source candidate matches the frozen canonical
+  and source identity; or
+- `source_missing`: the exact product/subtype has zero rows in the same frozen
+  current source run.
+
+The 100 identities are not removed, replaced, or renumbered.
+
+### Permit only bounded, proven current-source gaps
+
+The maximum accepted source-missing count is five of 100. A sixth gap fails
+closed. The limit is explicit in the publication worker, pipeline, scheduled
+runner, run plan, artifacts, reconciliation, and observer policy.
+
+### Forbid substitution
+
+A missing exact source identity cannot be replaced by:
+
+- a sibling subtype;
+- a different finish;
+- a historical source observation;
+- a different canonical printing; or
+- a similarly named product.
+
+`source_missing` means not observed in the current exact source run. It does
+not mean the printing does not exist.
+
+### Keep mapping and provenance drift fatal
+
+If the raw exact source row exists but no candidate is produced, the condition
+is mapping drift, not source absence. Duplicate candidates, canonical identity
+drift, source identity drift, and provenance drift remain fatal.
+
+### Reconcile the active count to current availability
+
+The canary definition count remains 100. Publication decisions, snapshots,
+traces, and the governed current read-model count must reconcile to the latest
+healthy run's `resolved` count. The observer must also reconcile all 100
+ordinal outcomes and verify that each source-missing outcome contains current
+source-run evidence.
+
+## Alternatives Rejected
+
+### Replace Alolan Ninetales again
+
+Rejected because repeated membership replacement hides normal upstream
+availability changes and destroys the fixed-denominator audit trail.
+
+### Reuse the last known price
+
+Rejected because Production V1 requires fresh current TCGPlayer marketPrice
+evidence. Historical presence does not authorize current publication.
+
+### Substitute another product subtype
+
+Rejected because finish and subtype are part of the exact printing contract.
+
+### Ignore any number of missing rows
+
+Rejected because broad source degradation must still invalidate the run. The
+bounded ceiling separates isolated availability gaps from systemic failure.
+
+## Implementation
+
+The repair is committed on
+`agent/pricing-canary-source-gap-repair-v1` at:
+
+`4eb22a9ea10cb9aa841f969c10ed113c83ee7019`
+
+It adds the source-coverage resolver and carries the policy through the
+publication worker, pipeline, scheduled runner, operations classification,
+observer, contracts, and tests. Publication worker version is
+`TCGPLAYER_MARKET_PUBLICATION_WORKER_V1_4`; observer policy is V3.
+
+No database migration or schema change is required.
+
+## Frozen Read-Only Proof
+
+A dry run was executed from the exact clean commit above against source sync
+run `bd51c71b-951a-40ac-8933-9111e541b9a4`.
+
+| Measure | Result |
+| --- | --- |
+| Frozen identities | `100` |
+| Resolved | `99` |
+| Source missing | `1` |
+| Selected / eligible | `99 / 99` |
+| Delayed / suppressed / quarantined / excluded | `0 / 0 / 0 / 0` |
+| Reconciliation mismatches | `0` |
+| Coverage reconciled | `true` |
+| Publication-table writes | `false` |
+| Current-publication activation | `false` |
+| Canonical/Vault writes | `false` |
+
+The sole `source_missing` outcome is Alolan Ninetales SM128 Holofoil, product
+`168245`, with reason
+`exact_product_and_subtype_absent_from_current_source_run`. No alternate source
+identity was available or substituted.
+
+Local artifact directory:
+
+`.tmp/canary-source-gap-repair-frozen/TCGPLAYER-MARKET-CANARY-SOURCE-GAP-REPAIR-FROZEN-2026-08-02/`
+
+Recorded hashes were recomputed after the run and all five matched:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `run_plan.json` | `8f3dbde594049d29ac3f282340440ecc33c8904415f30432bf0ff806bee85725` |
+| `summary.json` | `cf2a545f8a9d731cb65769f0da96793b883d712b4cf05803012e80826646eef1` |
+| `qualification_decisions.jsonl` | `5f8ccc525c18ea27eb503618f91ff01c4e4f7b8892b71190fa28bd3e4ad0bb75` |
+| `reconciliation.json` | `eb8946207c2cac47b2a43307624faa1c3285b3b4dfa639c20538a2b54c1dab4f` |
+| `canary_source_outcomes.jsonl` | `7689ef4fd2550a6c74dbe00d0df859952df9d880be48a18d92fce199ce4b987e` |
+
+## Verification
+
+- focused pricing/canary suite: `60/60` passed
+- complete contract suite: `903/903` passed
+- syntax/import checks: passed
+- `git diff --check`: passed before the implementation commit
+- required shipcheck pricing, runtime, contract, and web stages: passed
+- full shipcheck: did not pass because two unrelated existing Flutter golden
+  comparisons failed (`lot ivory front renders and matches golden` and
+  `sale ivory front renders and matches golden`)
+
+No Flutter files are part of this repair.
+
+## Current Truths
+
+- The July 31 replacement window did not survive its unattended cycles and is
+  failed history.
+- The source warehouse is healthy.
+- One frozen canary source identity is currently unavailable.
+- The repair is committed locally but is not deployed to the production
+  runner.
+- The canary has not been restarted and has not passed.
+- No database row, publication pointer, approval, or migration changed during
+  this repair.
+- Post-canary migrations and broader signed-in rollout remain blocked.
+
+## Invariants
+
+The following must never be broken:
+
+- keep the frozen canonical denominator separate from current source
+  availability
+- require one reconciled outcome for every frozen canary ordinal
+- prove source absence against the exact frozen current source run
+- never substitute subtype, finish, product, printing, or historical evidence
+- fail when raw source evidence exists but candidate mapping is absent
+- fail on duplicates, identity drift, provenance drift, or more than five
+  source gaps
+- reconcile current publication and observer counts to the resolved count
+- preserve failed windows as immutable history
+- start a new 72-hour clock after any failed unattended cycle or runtime change
+- do not apply post-canary migrations before a terminal passing artifact
+- do not enable anonymous pricing before licensing and display authority pass
+
+## Exact Next Gate
+
+1. Push and review the exact repair commit.
+2. Integrate and deploy that exact code lineage to the production pricing
+   runner without unrelated changes.
+3. Run a fresh preflight and activate a new canary under a new repair run key.
+4. Prove the new activation writes exactly the current resolved count and
+   records all 100 source outcomes with zero reconciliation mismatches.
+5. Update the main-branch GitHub observer workflow to run the deployed V3
+   observer and preserve the bounded source-gap setting.
+6. Start a new uninterrupted 72-hour observation window. No time from the
+   failed July 31 window counts.
+7. Keep post-canary migrations, full signed-in rollout, and public access
+   blocked until the new window produces a terminal passing artifact.
+

--- a/docs/checkpoints/pricing/PRICING_CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/pricing/PRICING_CHECKPOINT_INDEX.md
@@ -33,6 +33,25 @@ That would make it too easy to preserve the code while accidentally forgetting t
 
 ## Checkpoint Sequence
 
+### `PRICING_CHECKPOINT_42_CANARY_SOURCE_GAP_POLICY_REPAIR.md`
+
+This checkpoint records the August 1 and August 2 canary failures caused by a
+single disappeared exact source identity and the bounded, evidence-backed
+source-gap policy that prevents one unavailable row from invalidating the
+other current prices.
+
+Decision locked there:
+
+- preserve all 100 frozen canonical identities, reconcile each to `resolved`
+  or proven `source_missing`, allow at most five current-source gaps, and
+  forbid subtype, finish, product, printing, or historical substitution
+
+Unresolved risk afterward:
+
+- the repair is not deployed and no replacement window is active; it must be
+  integrated into the production runner, activated under a new run key, and
+  prove a fresh uninterrupted 72-hour canary before post-canary release work
+
 ### `PRICING_CHECKPOINT_41_CANARY_OBSERVATION_AND_SOURCE_CONTINUITY_REPAIR.md`
 
 This checkpoint records the July 31 observer false alarm, the real current-feed

--- a/docs/contracts/MEE_PRICING_PLATFORM_PRODUCTION_V1_DEFINITION_OF_DONE.md
+++ b/docs/contracts/MEE_PRICING_PLATFORM_PRODUCTION_V1_DEFINITION_OF_DONE.md
@@ -44,6 +44,10 @@ Production V1 is releasable only when every applicable gate passes:
 
 1. The authenticated 100-printing canary completes an uninterrupted,
    reconciled 72-hour observation window.
+   The 100 printings remain the fixed identity denominator. Each daily cycle
+   must reconcile every identity as exactly `resolved` or `source_missing`;
+   bounded source absence may not be replaced with historical or sibling
+   pricing, and any resolved row must retain exact printing provenance.
 2. The frozen production migrations apply in their manifest order with zero
    schema, function, view, grant, RLS, or migration-ledger drift.
 3. Authenticated pricing access works and anonymous access remains denied

--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -180,15 +180,22 @@ pipeline shadow verification. Historical backfill remains independently
 governed and must continue to yield during the current-price window.
 
 The signed-in canary observation window is evaluated by
-`TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2`. The evaluator is read-only and
+`TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3`. The evaluator is read-only and
 must prove:
 
 - the activation run and every expected daily source trigger use the frozen
   producing commit
 - each expected source trigger begins inside the schedule tolerance and its
   exact publication run completes inside the bounded pipeline grace period
-- every run selects, maps, qualifies, snapshots, and traces the exact verified
-  canary count
+- every fixed canary identity reconciles to exactly one governed outcome:
+  `resolved` or `source_missing`
+- every resolved identity selects, maps, qualifies, snapshots, and traces
+  exactly once
+- every `source_missing` outcome proves that the exact product and subtype are
+  absent from the frozen current source run; an alternate subtype is evidence,
+  not a substitute
+- no more than five of the 100 fixed identities are `source_missing` in one
+  canary cycle
 - no delayed, suppressed, quarantined, or excluded canary row appears
 - no terminal pricing operations alert occurs inside the observation window
 - current prices remain fresh, positive USD values with complete provenance
@@ -202,15 +209,22 @@ discovery endpoint.
 
 An incomplete time window or an on-time pipeline still inside its completion
 grace is `observing`, not failed or passed. A missing source trigger after its
-tolerance, an incomplete publication after its completion grace, broken trace,
-stale value, access-boundary regression, terminal alert, or run mismatch fails
-the gate. Publication start time is not used as the schedule trigger because
-source acquisition legitimately precedes publication.
+tolerance, an incomplete publication after its completion grace, source gaps
+above the bounded ceiling, broken trace, stale value, access-boundary
+regression, terminal alert, or run mismatch fails the gate. The current read
+model must contain exactly the latest healthy run's resolved count, not stale
+rows carried forward from an earlier source day. Publication start time is not
+used as the schedule trigger because source acquisition legitimately precedes
+publication.
 
 The scheduled failure classifier must not interpret bare three-digit values in
-JavaScript stack locations as HTTP status codes. Exact canary source-identity
-absence or drift is non-retryable definition drift and must stop without
-repeating the paid or database-intensive cycle.
+JavaScript stack locations as HTTP status codes. A raw current source row that
+cannot resolve through the candidate view, duplicate source evidence,
+canonical identity drift, provenance drift, or source gaps above the bounded
+ceiling is non-retryable and must stop without repeating the paid or
+database-intensive cycle. Exact current-source absence inside the ceiling is a
+governed availability outcome, not permission to use historical or sibling
+evidence.
 
 The observer must create and hash its frozen run plan before connecting to the
 database. A connection or query failure must still preserve a machine-readable

--- a/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
+++ b/scripts/audits/tcgplayer_market_canary_observation_v1.mjs
@@ -8,7 +8,7 @@ import pg from "pg";
 import "../../backend/env.mjs";
 import {
   evaluateTcgplayerMarketCanaryObservationV1,
-  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2,
+  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3,
 } from "../../backend/pricing/tcgplayer_market_canary_observation_policy_v1.mjs";
 import {
   evaluateTcgplayerCurrentSourceHealthV1,
@@ -24,7 +24,7 @@ const DEFAULT_OUT_ROOT = path.join(
   "market_pricing_product_v1",
   "canary_observation",
 );
-const AUDIT_VERSION = "TCGPLAYER_MARKET_CANARY_OBSERVATION_AUDIT_V2";
+const AUDIT_VERSION = "TCGPLAYER_MARKET_CANARY_OBSERVATION_AUDIT_V3";
 
 function parseArgs(argv) {
   const args = {
@@ -36,6 +36,10 @@ function parseArgs(argv) {
     asOf: null,
     requiredHours: 72,
     expectedCount: 100,
+    maxSourceMissingCount: Number.parseInt(
+      process.env.TCGPLAYER_MARKET_CANARY_MAX_SOURCE_MISSING_COUNT || "5",
+      10,
+    ),
     scheduleToleranceMinutes: 90,
     scheduleCompletionGraceMinutes: 480,
     outRoot: DEFAULT_OUT_ROOT,
@@ -57,6 +61,11 @@ function parseArgs(argv) {
     } else if (arg.startsWith("--expected-count=")) {
       args.expectedCount = Number.parseInt(
         arg.slice("--expected-count=".length),
+        10,
+      );
+    } else if (arg.startsWith("--max-source-missing-count=")) {
+      args.maxSourceMissingCount = Number.parseInt(
+        arg.slice("--max-source-missing-count=".length),
         10,
       );
     } else if (arg.startsWith("--schedule-tolerance-minutes=")) {
@@ -89,6 +98,15 @@ function parseArgs(argv) {
   }
   if (!Number.isInteger(args.expectedCount) || args.expectedCount < 1) {
     throw new Error("--expected-count must be a positive integer");
+  }
+  if (
+    !Number.isInteger(args.maxSourceMissingCount) ||
+    args.maxSourceMissingCount < 0 ||
+    args.maxSourceMissingCount >= args.expectedCount
+  ) {
+    throw new Error(
+      "--max-source-missing-count must be a non-negative integer below expected-count",
+    );
   }
   if (
     !Number.isFinite(args.scheduleToleranceMinutes) ||
@@ -141,13 +159,14 @@ function serializeError(error) {
 export function buildTcgplayerMarketCanaryRunPlanV1(args, asOf) {
   return {
     audit_version: AUDIT_VERSION,
-    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2,
+    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3,
     window_start: args.windowStart,
     activation_run_id: args.activationRunId,
     expected_commit_sha: args.expectedCommitSha,
     as_of: asOf,
     required_hours: args.requiredHours,
     expected_count: args.expectedCount,
+    max_source_missing_count: args.maxSourceMissingCount,
     schedule_tolerance_minutes: args.scheduleToleranceMinutes,
     schedule_completion_grace_minutes:
       args.scheduleCompletionGraceMinutes,
@@ -186,7 +205,7 @@ export function buildTcgplayerMarketCanaryFailureArtifactsV1({
 }) {
   const failure = {
     audit_version: AUDIT_VERSION,
-    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2,
+    policy_version: TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3,
     status: "observer_error",
     failed_at: failedAt,
     stage,
@@ -475,13 +494,15 @@ function markdown(report) {
     "# TCGPlayer Market 72-Hour Canary Observation",
     "",
     `- Audit version: \`${AUDIT_VERSION}\``,
-    `- Policy version: \`${TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2}\``,
+    `- Policy version: \`${TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3}\``,
     `- Status: \`${report.status}\``,
     `- Window start: \`${report.window.started_at}\``,
     `- Required end: \`${report.window.required_end_at}\``,
     `- As of: \`${report.window.as_of}\``,
     `- Observed hours: \`${report.window.observed_hours}\``,
     `- Expected commit: \`${report.run_evidence.expected_commit_sha}\``,
+    `- Allowed source gaps: \`${report.run_evidence.max_source_missing_count}\``,
+    `- Expected current rows: \`${report.run_evidence.expected_current_count}\``,
     "",
     "## Schedule",
     "",
@@ -562,6 +583,7 @@ async function main() {
       scheduleCompletionGraceMinutes:
         args.scheduleCompletionGraceMinutes,
       expectedCount: args.expectedCount,
+      maxSourceMissingCount: args.maxSourceMissingCount,
       expectedCommitSha: args.expectedCommitSha,
       ...evidence,
     });

--- a/scripts/workers/tcgplayer_market_pipeline_v1.mjs
+++ b/scripts/workers/tcgplayer_market_pipeline_v1.mjs
@@ -23,6 +23,7 @@ const DEFAULT_PHASE_TIMEOUT_MINUTES = 120;
 const FULL_SYNC_MINIMUM_PHASE_TIMEOUT_MINUTES = 90;
 const DEFAULT_DATABASE_TIMEOUT_MINUTES = 20;
 const MINIMUM_WRITE_DATABASE_TIMEOUT_MINUTES = 10;
+const DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT = 5;
 
 function parseArgs(argv) {
   const args = {
@@ -44,6 +45,11 @@ function parseArgs(argv) {
     freshnessHours: 36,
     publicationLimit: null,
     canaryDefinitionPath: null,
+    maxCanarySourceMissingCount: Number.parseInt(
+      process.env.TCGPLAYER_MARKET_CANARY_MAX_SOURCE_MISSING_COUNT ||
+        String(DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT),
+      10,
+    ),
   };
 
   for (const arg of argv) {
@@ -88,6 +94,11 @@ function parseArgs(argv) {
       args.canaryDefinitionPath = path.resolve(
         arg.slice("--canary-definition=".length),
       );
+    } else if (arg.startsWith("--max-canary-source-missing-count=")) {
+      args.maxCanarySourceMissingCount = Number.parseInt(
+        arg.slice("--max-canary-source-missing-count=".length),
+        10,
+      );
     }
   }
 
@@ -123,6 +134,14 @@ function parseArgs(argv) {
   }
   if (!Number.isFinite(args.freshnessHours) || args.freshnessHours <= 0) {
     throw new Error("--freshness-hours must be positive");
+  }
+  if (
+    !Number.isInteger(args.maxCanarySourceMissingCount) ||
+    args.maxCanarySourceMissingCount < 0
+  ) {
+    throw new Error(
+      "--max-canary-source-missing-count must be a non-negative integer",
+    );
   }
   if (
     args.publicationLimit !== null &&
@@ -308,6 +327,8 @@ async function main() {
         ? relative(args.canaryDefinitionPath)
         : null,
       freshness_hours: args.freshnessHours,
+      max_canary_source_missing_count:
+        args.maxCanarySourceMissingCount,
       phase_state_authority: "database",
     },
     boundaries: {
@@ -402,6 +423,7 @@ async function main() {
     `--out-root=${path.join(runDir, "publication")}`,
     `--freshness-hours=${args.freshnessHours}`,
     `--database-timeout-minutes=${args.databaseTimeoutMinutes}`,
+    `--max-canary-source-missing-count=${args.maxCanarySourceMissingCount}`,
   ];
   if (args.publicationLimit !== null) {
     publicationArgs.push(`--limit=${args.publicationLimit}`);

--- a/scripts/workers/tcgplayer_market_publication_worker_v1.mjs
+++ b/scripts/workers/tcgplayer_market_publication_worker_v1.mjs
@@ -16,8 +16,10 @@ import {
 } from "../../backend/pricing/tcgplayer_market_publication_policy_v1.mjs";
 import {
   loadTcgplayerMarketCanaryDefinitionV1,
-  tcgplayerMarketCanarySourceKeyV1,
 } from "../../backend/pricing/tcgplayer_market_canary_definition_v1.mjs";
+import {
+  resolveTcgplayerMarketCanarySourceCoverageV1,
+} from "../../backend/pricing/tcgplayer_market_canary_source_coverage_v1.mjs";
 
 const { Client } = pg;
 const execFileAsync = promisify(execFile);
@@ -29,7 +31,7 @@ const DEFAULT_OUT_ROOT = path.join(
   "artifacts",
   "market_pricing_product_v1",
 );
-const WORKER_VERSION = "TCGPLAYER_MARKET_PUBLICATION_WORKER_V1_3";
+const WORKER_VERSION = "TCGPLAYER_MARKET_PUBLICATION_WORKER_V1_4";
 const PIPELINE_VERSION = "TCGPLAYER_MARKET_PIPELINE_V1";
 const SCHEMA_VERSION = "TCGPLAYER_MARKET_PUBLICATION_SCHEMA_V1";
 const SNAPSHOT_SCHEMA_VERSION = "MARKET_PRICE_PUBLICATION_SNAPSHOT_V1";
@@ -45,6 +47,7 @@ const WRITE_MODES = new Set(["shadow", "canary", "production"]);
 const ACTIVATION_MODES = new Set(["canary", "production"]);
 const DEFAULT_DATABASE_TIMEOUT_MINUTES = 20;
 const MINIMUM_WRITE_DATABASE_TIMEOUT_MINUTES = 10;
+const DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT = 5;
 
 function parseArgs(argv) {
   const args = {
@@ -56,6 +59,11 @@ function parseArgs(argv) {
     freshnessHours: TCGPLAYER_MARKET_FRESHNESS_HOURS_V1,
     suppressionHours: TCGPLAYER_MARKET_SUPPRESSION_HOURS_V1,
     batchSize: 500,
+    maxCanarySourceMissingCount: Number.parseInt(
+      process.env.TCGPLAYER_MARKET_CANARY_MAX_SOURCE_MISSING_COUNT ||
+        String(DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT),
+      10,
+    ),
     databaseTimeoutMinutes: Number.parseInt(
       process.env.TCGPLAYER_MARKET_DATABASE_TIMEOUT_MINUTES ||
         String(DEFAULT_DATABASE_TIMEOUT_MINUTES),
@@ -99,6 +107,11 @@ function parseArgs(argv) {
         arg.slice("--database-timeout-minutes=".length),
         10,
       );
+    } else if (arg.startsWith("--max-canary-source-missing-count=")) {
+      args.maxCanarySourceMissingCount = Number.parseInt(
+        arg.slice("--max-canary-source-missing-count=".length),
+        10,
+      );
     }
   }
 
@@ -130,6 +143,14 @@ function parseArgs(argv) {
     args.databaseTimeoutMinutes < 1
   ) {
     throw new Error("--database-timeout-minutes must be a positive integer");
+  }
+  if (
+    !Number.isInteger(args.maxCanarySourceMissingCount) ||
+    args.maxCanarySourceMissingCount < 0
+  ) {
+    throw new Error(
+      "--max-canary-source-missing-count must be a non-negative integer",
+    );
   }
   if (
     WRITE_MODES.has(args.runMode) &&
@@ -260,7 +281,37 @@ async function latestSourceRun(client) {
   return result.rows[0];
 }
 
-async function candidateRows(client, { limit, canaryDefinition }) {
+async function currentCanarySourceRows(client, sourceRun, canaryDefinition) {
+  const productIds = [
+    ...new Set(
+      canaryDefinition.printings.map((printing) =>
+        Number(printing.source_product_id),
+      ),
+    ),
+  ];
+  const result = await client.query(
+    `select
+       observation.id as source_observation_id,
+       observation.last_seen_run_id as source_sync_run_id,
+       observation.source_price_row_identity,
+       observation.product_id as source_product_id,
+       observation.subtype_name as source_subtype_name
+     from public.tcgcsv_source_price_daily_observations observation
+     where observation.last_seen_run_id = $1
+       and observation.observed_on = $2
+       and observation.category_id = 3
+       and observation.product_id = any($3::integer[])
+     order by observation.product_id, observation.subtype_name,
+              observation.source_price_row_identity`,
+    [sourceRun.id, sourceRun.observed_on, productIds],
+  );
+  return result.rows;
+}
+
+async function candidateRows(
+  client,
+  { limit, canaryDefinition, sourceRun, maxCanarySourceMissingCount },
+) {
   if (canaryDefinition) {
     const printingIds = canaryDefinition.printings.map(
       (printing) => printing.card_printing_id,
@@ -272,37 +323,25 @@ async function candidateRows(client, { limit, canaryDefinition }) {
         order by source_product_id, source_subtype_name, source_observation_id`,
       [printingIds],
     );
-    const rowsBySourceKey = new Map();
-    for (const row of result.rows) {
-      const key = tcgplayerMarketCanarySourceKeyV1(row);
-      const matches = rowsBySourceKey.get(key) ?? [];
-      matches.push(row);
-      rowsBySourceKey.set(key, matches);
-    }
-    return canaryDefinition.printings.map((printing) => {
-      const key = tcgplayerMarketCanarySourceKeyV1(printing);
-      const matches = rowsBySourceKey.get(key) ?? [];
-      if (matches.length !== 1) {
-        throw new Error(
-          `canary source identity ${key} resolved ${matches.length} rows`,
-        );
-      }
-      const row = matches[0];
-      const mismatches = [
-        ["card_print_id", printing.card_print_id],
-        ["gv_id", printing.gv_id],
-        ["printing_gv_id", printing.printing_gv_id],
-        ["finish_key", printing.expected_finish],
-      ].filter(([field, expected]) => row[field] !== expected);
-      if (mismatches.length) {
-        throw new Error(
-          `canary identity ${key} drifted: ${mismatches
-            .map(([field, expected]) => `${field}=${row[field]} expected=${expected}`)
-            .join(",")}`,
-        );
-      }
-      return row;
+    const rawSourceRows = await currentCanarySourceRows(
+      client,
+      sourceRun,
+      canaryDefinition,
+    );
+    const selection = resolveTcgplayerMarketCanarySourceCoverageV1({
+      canaryDefinition,
+      candidateRows: result.rows,
+      currentSourceRows: rawSourceRows,
+      sourceRun,
     });
+    if (
+      selection.coverage.source_missing_count > maxCanarySourceMissingCount
+    ) {
+      throw new Error(
+        `canary source_missing ceiling exceeded actual=${selection.coverage.source_missing_count} maximum=${maxCanarySourceMissingCount}`,
+      );
+    }
+    return selection;
   }
   const params = [];
   const limitSql = limit === null ? "" : "limit $1";
@@ -314,7 +353,7 @@ async function candidateRows(client, { limit, canaryDefinition }) {
       ${limitSql}`,
     params,
   );
-  return result.rows;
+  return { rows: result.rows, coverage: null };
 }
 
 function buildCandidate(row, runId) {
@@ -480,16 +519,16 @@ async function ensureRun(client, {
 
 async function completedPhase(client, runId, phaseName) {
   const result = await client.query(
-    `select exists (
-       select 1
+    `select resumability_data
        from public.market_price_pipeline_phase_attempts
-       where run_id = $1
-         and phase_name = $2
-         and state = 'succeeded'
-     ) as completed`,
+      where run_id = $1
+        and phase_name = $2
+        and state = 'succeeded'
+      order by attempt desc, completed_at desc, id desc
+      limit 1`,
     [runId, phaseName],
   );
-  return result.rows[0].completed === true;
+  return result.rows[0] ?? null;
 }
 
 async function nextPhaseAttempt(client, runId, phaseName) {
@@ -594,11 +633,15 @@ async function runPhase(client, {
   phaseName,
   operation,
 }) {
-  if (await completedPhase(client, run.id, phaseName)) {
+  const completed = await completedPhase(client, run.id, phaseName);
+  if (completed) {
     process.stdout.write(
       `[tcgplayer-market-publication] phase=${phaseName} status=resumed\n`,
     );
-    return { resumed: true };
+    return {
+      resumed: true,
+      resumability_data: completed.resumability_data ?? {},
+    };
   }
   const attempt = await nextPhaseAttempt(client, run.id, phaseName);
   const startedAt = new Date().toISOString();
@@ -1038,7 +1081,7 @@ async function decisionCounts(client, runId) {
   );
 }
 
-async function reconcileRun(client, runId) {
+async function reconcileRun(client, runId, canaryCoverage = null) {
   const result = await client.query(
     `with candidate_totals as (
        select
@@ -1104,7 +1147,39 @@ async function reconcileRun(client, runId) {
   ) {
     mismatches.push("decision_lane_count");
   }
-  return { ...reconciliation, mismatches };
+  if (canaryCoverage) {
+    if (!canaryCoverage.reconciled) {
+      mismatches.push("canary_source_coverage_not_reconciled");
+    }
+    if (
+      canaryCoverage.resolved_count +
+        canaryCoverage.source_missing_count !==
+      canaryCoverage.expected_count
+    ) {
+      mismatches.push("canary_expected_source_coverage_count");
+    }
+    if (reconciliation.selected_count !== canaryCoverage.resolved_count) {
+      mismatches.push("canary_resolved_selected_count");
+    }
+    if (
+      canaryCoverage.outcomes.length !== canaryCoverage.expected_count
+    ) {
+      mismatches.push("canary_source_outcome_count");
+    }
+  }
+  return {
+    ...reconciliation,
+    canary_source_coverage_policy_version:
+      canaryCoverage?.policy_version ?? null,
+    canary_source_coverage_reconciled:
+      canaryCoverage?.reconciled ?? null,
+    canary_expected_count: canaryCoverage?.expected_count ?? null,
+    canary_resolved_count: canaryCoverage?.resolved_count ?? null,
+    canary_source_missing_count:
+      canaryCoverage?.source_missing_count ?? null,
+    canary_source_outcomes: canaryCoverage?.outcomes ?? [],
+    mismatches,
+  };
 }
 
 async function persistReconciliation(client, runId, reconciliation) {
@@ -1242,6 +1317,15 @@ async function writeArtifacts(outDir, {
     decisions: path.join(outDir, "qualification_decisions.jsonl"),
     reconciliation: path.join(outDir, "reconciliation.json"),
   };
+  if (
+    reconciliation.canary_source_coverage_policy_version &&
+    Array.isArray(reconciliation.canary_source_outcomes)
+  ) {
+    files.canary_source_outcomes = path.join(
+      outDir,
+      "canary_source_outcomes.jsonl",
+    );
+  }
   await writeJson(files.run_plan, runPlan);
   await writeJson(files.summary, summary);
   await fs.writeFile(
@@ -1250,6 +1334,15 @@ async function writeArtifacts(outDir, {
       (decisions.length ? "\n" : ""),
   );
   await writeJson(files.reconciliation, reconciliation);
+  if (files.canary_source_outcomes) {
+    await fs.writeFile(
+      files.canary_source_outcomes,
+      reconciliation.canary_source_outcomes
+        .map((outcome) => JSON.stringify(outcome))
+        .join("\n") +
+        (reconciliation.canary_source_outcomes.length ? "\n" : ""),
+    );
+  }
   const hashes = {};
   for (const [name, filePath] of Object.entries(files)) {
     hashes[name] = sha256(await fs.readFile(filePath));
@@ -1281,10 +1374,13 @@ function decisionSummary(decisions) {
 }
 
 async function runDryRun(client, args, sourceRun, runPlan) {
-  const rows = await candidateRows(client, {
+  const selection = await candidateRows(client, {
     limit: args.limit,
     canaryDefinition: args.canaryDefinition,
+    sourceRun,
+    maxCanarySourceMissingCount: args.maxCanarySourceMissingCount,
   });
+  const { rows, coverage: canaryCoverage } = selection;
   const evaluatedAt = new Date().toISOString();
   const decisions = rows.map((row, index) =>
     buildDecision(
@@ -1302,7 +1398,17 @@ async function runDryRun(client, args, sourceRun, runPlan) {
   const counts = decisionSummary(decisions);
   const reconciliation = {
     ...counts,
+    mapped_count: counts.selected_count,
     source_sync_run_id: sourceRun.id,
+    canary_source_coverage_policy_version:
+      canaryCoverage?.policy_version ?? null,
+    canary_source_coverage_reconciled:
+      canaryCoverage?.reconciled ?? null,
+    canary_expected_count: canaryCoverage?.expected_count ?? null,
+    canary_resolved_count: canaryCoverage?.resolved_count ?? null,
+    canary_source_missing_count:
+      canaryCoverage?.source_missing_count ?? null,
+    canary_source_outcomes: canaryCoverage?.outcomes ?? [],
     writes: false,
     mismatches: [],
   };
@@ -1326,7 +1432,7 @@ async function runDurable(client, args, sourceRun, runPlan) {
       return artifactRows(client, run.id);
     }
 
-    await runPhase(client, {
+    const stageResult = await runPhase(client, {
       run,
       sourceRun,
       phaseName: "prepare_variant_assignments",
@@ -1354,10 +1460,13 @@ async function runDurable(client, args, sourceRun, runPlan) {
       sourceRun,
       phaseName: "stage_candidates",
       operation: async () => {
-        const rows = await candidateRows(client, {
+        const selection = await candidateRows(client, {
           limit: args.limit,
           canaryDefinition: args.canaryDefinition,
+          sourceRun,
+          maxCanarySourceMissingCount: args.maxCanarySourceMissingCount,
         });
+        const { rows, coverage: canaryCoverage } = selection;
         const candidates = rows.map((row) => buildCandidate(row, run.id));
         await insertCandidates(client, candidates, args.batchSize);
         const staged = await stagedCandidates(client, run.id);
@@ -1375,10 +1484,13 @@ async function runDurable(client, args, sourceRun, runPlan) {
               rows[0]?.source_observation_id ?? null,
             last_source_observation_id:
               rows.at(-1)?.source_observation_id ?? null,
+            canary_source_coverage: canaryCoverage,
           },
         };
       },
     });
+    const canaryCoverage =
+      stageResult.resumability_data?.canary_source_coverage ?? null;
 
     await runPhase(client, {
       run,
@@ -1465,7 +1577,11 @@ async function runDurable(client, args, sourceRun, runPlan) {
       sourceRun,
       phaseName: "reconcile",
       operation: async () => {
-        const reconciliation = await reconcileRun(client, run.id);
+        const reconciliation = await reconcileRun(
+          client,
+          run.id,
+          canaryCoverage,
+        );
         await persistReconciliation(client, run.id, reconciliation);
         if (reconciliation.mismatches.length) {
           throw new Error(
@@ -1518,6 +1634,13 @@ async function main() {
     loadedCanary = await loadTcgplayerMarketCanaryDefinitionV1(
       args.canaryDefinitionPath,
     );
+    if (
+      args.maxCanarySourceMissingCount >= loadedCanary.definition.expected_count
+    ) {
+      throw new Error(
+        "--max-canary-source-missing-count must be below canary expected_count",
+      );
+    }
     args.canaryDefinition = loadedCanary.definition;
   } else {
     args.canaryDefinition = null;
@@ -1583,6 +1706,8 @@ async function main() {
         canary_id: loadedCanary?.definition.canary_id ?? null,
         canary_expected_count:
           loadedCanary?.definition.expected_count ?? null,
+        max_canary_source_missing_count:
+          args.maxCanarySourceMissingCount,
         freshness_hours: args.freshnessHours,
         suppression_hours: args.suppressionHours,
         batch_size: args.batchSize,
@@ -1647,6 +1772,14 @@ async function main() {
       canary_definition_sha256: loadedCanary
         ? sha256(loadedCanary.raw)
         : null,
+      canary_expected_count:
+        reconciliation.canary_expected_count ?? null,
+      canary_resolved_count:
+        reconciliation.canary_resolved_count ?? null,
+      canary_source_missing_count:
+        reconciliation.canary_source_missing_count ?? null,
+      max_canary_source_missing_count:
+        args.maxCanarySourceMissingCount,
       writes_canonical_identity: false,
       writes_vault: false,
     };

--- a/scripts/workers/tcgplayer_market_scheduled_runner_v1.mjs
+++ b/scripts/workers/tcgplayer_market_scheduled_runner_v1.mjs
@@ -36,6 +36,7 @@ const DEFAULT_PHASE_TIMEOUT_MINUTES = 120;
 const FULL_SYNC_MINIMUM_PHASE_TIMEOUT_MINUTES = 90;
 const DEFAULT_DATABASE_TIMEOUT_MINUTES = 20;
 const MINIMUM_WRITE_DATABASE_TIMEOUT_MINUTES = 10;
+const DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT = 5;
 
 function parseArgs(argv) {
   const live = argv.includes("--run");
@@ -88,6 +89,17 @@ function parseArgs(argv) {
   );
   const freshnessHours = Number(
     process.env.TCGPLAYER_MARKET_SCHEDULE_FRESHNESS_HOURS || "36",
+  );
+  const maxCanarySourceMissingArg = argv.find((arg) =>
+    arg.startsWith("--max-canary-source-missing-count="),
+  );
+  const maxCanarySourceMissingCount = Number.parseInt(
+    maxCanarySourceMissingArg?.slice(
+      "--max-canary-source-missing-count=".length,
+    ) ||
+      process.env.TCGPLAYER_MARKET_CANARY_MAX_SOURCE_MISSING_COUNT ||
+      String(DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT),
+    10,
   );
   const expectedCommitSha =
     argv
@@ -149,6 +161,14 @@ function parseArgs(argv) {
     throw new Error("freshness hours must be positive");
   }
   if (
+    !Number.isInteger(maxCanarySourceMissingCount) ||
+    maxCanarySourceMissingCount < 0
+  ) {
+    throw new Error(
+      "scheduled max canary source missing count must be a non-negative integer",
+    );
+  }
+  if (
     publicationLimit !== null &&
     (!Number.isInteger(publicationLimit) || publicationLimit < 1)
   ) {
@@ -187,6 +207,7 @@ function parseArgs(argv) {
     phaseTimeoutMinutes,
     databaseTimeoutMinutes,
     freshnessHours,
+    maxCanarySourceMissingCount,
     expectedCommitSha,
   };
 }
@@ -272,6 +293,14 @@ async function main() {
         args.canaryDefinitionPath,
       )
     : null;
+  if (
+    loadedCanary &&
+    args.maxCanarySourceMissingCount >= loadedCanary.definition.expected_count
+  ) {
+    throw new Error(
+      "scheduled max canary source missing count must be below canary expected_count",
+    );
+  }
   const commitSha = await git(["rev-parse", "HEAD"]);
   const branch = await git(["branch", "--show-current"]);
   const trackedWorktreeClean =
@@ -319,6 +348,8 @@ async function main() {
     phase_timeout_minutes: args.phaseTimeoutMinutes,
     database_timeout_minutes: args.databaseTimeoutMinutes,
     freshness_hours: args.freshnessHours,
+    max_canary_source_missing_count:
+      args.maxCanarySourceMissingCount,
     publication_limit: args.publicationLimit,
     canary_definition_path: loadedCanary
       ? relative(loadedCanary.absolutePath)
@@ -353,6 +384,7 @@ async function main() {
       "request_ceiling",
       "phase_timeout_minutes",
       "freshness_hours",
+      "max_canary_source_missing_count",
       "publication_limit",
       "canary_definition_path",
       "canary_definition_sha256",
@@ -438,6 +470,7 @@ async function main() {
         `--phase-timeout-minutes=${args.phaseTimeoutMinutes}`,
         `--database-timeout-minutes=${args.databaseTimeoutMinutes}`,
         `--freshness-hours=${args.freshnessHours}`,
+        `--max-canary-source-missing-count=${args.maxCanarySourceMissingCount}`,
       ];
       if (args.publicationLimit !== null) {
         pipelineArgs.push(`--publication-limit=${args.publicationLimit}`);

--- a/tests/contracts/tcgplayer_market_canary_definition_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_definition_v1.test.mjs
@@ -155,7 +155,12 @@ test("canary runtime is exact-definition-only and records definition provenance"
   );
   assert.match(WORKER, /card_printing_id = any\(\$1::uuid\[\]\)/);
   assert.match(WORKER, /canary_definition_sha256/);
-  assert.match(WORKER, /resolved \$\{matches\.length\} rows/);
+  assert.match(WORKER, /resolveTcgplayerMarketCanarySourceCoverageV1/);
+  assert.match(
+    WORKER,
+    /observation\.last_seen_run_id = \$1[\s\S]*observation\.observed_on = \$2/,
+  );
+  assert.match(WORKER, /canary_source_outcomes\.jsonl/);
   assert.match(PIPELINE, /canary mode requires --canary-definition/);
   assert.match(
     PIPELINE,

--- a/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_observation_v1.test.mjs
@@ -7,8 +7,11 @@ import test from "node:test";
 import {
   evaluateTcgplayerMarketCanaryObservationV1,
   expectedTcgplayerMarketScheduleSlotsV1,
-  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2,
+  TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3,
 } from "../../backend/pricing/tcgplayer_market_canary_observation_policy_v1.mjs";
+import {
+  TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1,
+} from "../../backend/pricing/tcgplayer_market_canary_source_coverage_v1.mjs";
 import {
   buildTcgplayerMarketCanaryFailureArtifactsV1,
   buildTcgplayerMarketCanaryRunPlanV1,
@@ -31,17 +34,25 @@ function exactRun({
   startedAt,
   completedAt,
   commit = COMMIT,
+  sourceMissing = 0,
 } = {}) {
+  const resolved = 100 - sourceMissing;
+  const outcomes = Array.from({ length: 100 }, (_, index) => ({
+    ordinal: index + 1,
+    outcome: index < resolved ? "resolved" : "source_missing",
+    source_observation_id:
+      index < resolved ? `source-observation-${index + 1}` : null,
+  }));
   return {
     id,
     run_key: runKey,
     run_mode: "canary",
     state: "verified",
     reconciliation_state: "reconciled",
-    selected_count: 100,
-    mapped_count: 100,
-    eligible_count: 100,
-    snapshot_count: 100,
+    selected_count: resolved,
+    mapped_count: resolved,
+    eligible_count: resolved,
+    snapshot_count: resolved,
     delayed_count: 0,
     suppressed_count: 0,
     quarantined_count: 0,
@@ -53,7 +64,16 @@ function exactRun({
     completed_at: completedAt,
     failed_at: null,
     error: null,
-    reconciliation: { mismatches: [] },
+    reconciliation: {
+      canary_source_coverage_policy_version:
+        TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1,
+      canary_source_coverage_reconciled: true,
+      canary_expected_count: 100,
+      canary_resolved_count: resolved,
+      canary_source_missing_count: sourceMissing,
+      canary_source_outcomes: outcomes,
+      mismatches: [],
+    },
   };
 }
 
@@ -64,12 +84,13 @@ const activationRun = exactRun({
   completedAt: WINDOW_START,
 });
 
-function scheduledRun(day) {
+function scheduledRun(day, options = {}) {
   return exactRun({
     id: `run-${day}`,
     runKey: `TCGPLAYER-MARKET-SCHEDULE-CANARY-2026-07-${day}-publication`,
     startedAt: `2026-07-${day}T08:15:03.000Z`,
     completedAt: `2026-07-${day}T08:16:10.000Z`,
+    ...options,
   });
 }
 
@@ -142,7 +163,7 @@ test("a healthy incomplete window remains observing", () => {
   const result = evaluateTcgplayerMarketCanaryObservationV1(baseInput());
   assert.equal(
     result.policy_version,
-    TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V2,
+    TCGPLAYER_MARKET_CANARY_OBSERVATION_POLICY_V3,
   );
   assert.equal(result.status, "observing");
   assert.equal(result.window.elapsed, false);
@@ -256,6 +277,66 @@ test("the exact three scheduled slots pass after 72 hours", () => {
   assert.equal(result.window.elapsed, true);
   assert.equal(result.schedule.matched_slots.length, 3);
   assert.deepEqual(result.findings, []);
+});
+
+test("a bounded source gap reconciles and expects only resolved current rows", () => {
+  const activation = exactRun({
+    id: "activation-gap",
+    runKey: "TCGPLAYER-MARKET-SCHEDULE-CANARY-2026-07-28-GAP-publication",
+    startedAt: "2026-07-28T08:39:53.963Z",
+    completedAt: WINDOW_START,
+    sourceMissing: 1,
+  });
+  const result = evaluateTcgplayerMarketCanaryObservationV1(
+    baseInput({
+      activationRun: activation,
+      current: {
+        ...baseInput().current,
+        exact_price_count: 99,
+        positive_usd_count: 99,
+        current_publication_run_id: "activation-gap",
+      },
+    }),
+  );
+
+  assert.equal(result.status, "observing");
+  assert.deepEqual(result.findings, []);
+  assert.equal(result.run_evidence.expected_count, 100);
+  assert.equal(result.run_evidence.expected_current_count, 99);
+  assert.equal(result.run_evidence.max_source_missing_count, 5);
+});
+
+test("source gaps beyond the bounded ceiling fail the gate", () => {
+  const activation = exactRun({
+    id: "activation-too-many-gaps",
+    runKey: "TCGPLAYER-MARKET-SCHEDULE-CANARY-2026-07-28-GAP-publication",
+    startedAt: "2026-07-28T08:39:53.963Z",
+    completedAt: WINDOW_START,
+    sourceMissing: 6,
+  });
+  const result = evaluateTcgplayerMarketCanaryObservationV1(
+    baseInput({ activationRun: activation }),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.ok(result.findings.includes("activation_run_not_exact_and_healthy"));
+});
+
+test("missing source coverage reconciliation fails even when row counts align", () => {
+  const activation = exactRun({
+    id: "activation-bad-coverage",
+    runKey: "TCGPLAYER-MARKET-SCHEDULE-CANARY-2026-07-28-GAP-publication",
+    startedAt: "2026-07-28T08:39:53.963Z",
+    completedAt: WINDOW_START,
+    sourceMissing: 1,
+  });
+  activation.reconciliation.canary_source_outcomes.pop();
+  const result = evaluateTcgplayerMarketCanaryObservationV1(
+    baseInput({ activationRun: activation }),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.ok(result.findings.includes("activation_run_not_exact_and_healthy"));
 });
 
 test("a missing elapsed schedule slot fails the gate", () => {
@@ -375,6 +456,7 @@ test("observer query failures preserve a run plan, summary, failure, and hashes"
         expectedCommitSha: COMMIT,
         requiredHours: 72,
         expectedCount: 100,
+        maxSourceMissingCount: 5,
         scheduleToleranceMinutes: 90,
         scheduleCompletionGraceMinutes: 480,
       },
@@ -422,6 +504,7 @@ test("observer query failures preserve a run plan, summary, failure, and hashes"
     assert.equal(runPlan.boundaries.database_reads_only, true);
     assert.equal(runPlan.boundaries.database_writes, false);
     assert.equal(runPlan.schedule_completion_grace_minutes, 480);
+    assert.equal(runPlan.max_source_missing_count, 5);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/tests/contracts/tcgplayer_market_canary_source_coverage_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_canary_source_coverage_v1.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveTcgplayerMarketCanarySourceCoverageV1,
+  TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1,
+} from "../../backend/pricing/tcgplayer_market_canary_source_coverage_v1.mjs";
+
+const SOURCE_RUN = {
+  id: "source-run-1",
+  observed_on: "2026-08-02",
+};
+
+function printing(ordinal, overrides = {}) {
+  return {
+    ordinal,
+    card_print_id: `card-${ordinal}`,
+    card_printing_id: `printing-${ordinal}`,
+    gv_id: `GV-${ordinal}`,
+    printing_gv_id: `GV-${ordinal}-HOLO`,
+    source_product_id: 1000 + ordinal,
+    source_subtype_name: "Holofoil",
+    expected_finish: "holo",
+    ...overrides,
+  };
+}
+
+function candidate(expected, overrides = {}) {
+  return {
+    source_observation_id: `observation-${expected.ordinal}`,
+    source_sync_run_id: SOURCE_RUN.id,
+    source_price_row_identity: `price-${expected.ordinal}`,
+    source_product_id: expected.source_product_id,
+    source_subtype_name: expected.source_subtype_name,
+    card_print_id: expected.card_print_id,
+    card_printing_id: expected.card_printing_id,
+    gv_id: expected.gv_id,
+    printing_gv_id: expected.printing_gv_id,
+    finish_key: expected.expected_finish,
+    ...overrides,
+  };
+}
+
+function rawSource(expected, overrides = {}) {
+  return {
+    source_observation_id: `observation-${expected.ordinal}`,
+    source_sync_run_id: SOURCE_RUN.id,
+    source_price_row_identity: `price-${expected.ordinal}`,
+    source_product_id: expected.source_product_id,
+    source_subtype_name: expected.source_subtype_name,
+    ...overrides,
+  };
+}
+
+function definition(printings) {
+  return { expected_count: printings.length, printings };
+}
+
+test("all exact canary identities resolve with traceable coverage", () => {
+  const printings = [printing(1), printing(2), printing(3)];
+  const result = resolveTcgplayerMarketCanarySourceCoverageV1({
+    canaryDefinition: definition(printings),
+    candidateRows: printings.map(candidate),
+    currentSourceRows: printings.map(rawSource),
+    sourceRun: SOURCE_RUN,
+  });
+
+  assert.equal(result.rows.length, 3);
+  assert.equal(
+    result.coverage.policy_version,
+    TCGPLAYER_MARKET_CANARY_SOURCE_COVERAGE_V1,
+  );
+  assert.equal(result.coverage.expected_count, 3);
+  assert.equal(result.coverage.resolved_count, 3);
+  assert.equal(result.coverage.source_missing_count, 0);
+  assert.equal(result.coverage.reconciled, true);
+  assert.deepEqual(
+    result.coverage.outcomes.map((outcome) => outcome.outcome),
+    ["resolved", "resolved", "resolved"],
+  );
+});
+
+test("an exact identity absent from the current source run is source_missing", () => {
+  const printings = [printing(1), printing(2), printing(3)];
+  const result = resolveTcgplayerMarketCanarySourceCoverageV1({
+    canaryDefinition: definition(printings),
+    candidateRows: printings.slice(0, 2).map(candidate),
+    currentSourceRows: printings.slice(0, 2).map(rawSource),
+    sourceRun: SOURCE_RUN,
+  });
+
+  assert.equal(result.rows.length, 2);
+  assert.equal(result.coverage.resolved_count, 2);
+  assert.equal(result.coverage.source_missing_count, 1);
+  assert.equal(result.coverage.outcomes[2].outcome, "source_missing");
+  assert.equal(result.coverage.outcomes[2].source_observation_id, null);
+  assert.equal(
+    result.coverage.outcomes[2].reason,
+    "exact_product_and_subtype_absent_from_current_source_run",
+  );
+});
+
+test("a current source row that disappears from the candidate view is mapping drift", () => {
+  const expected = printing(1);
+  assert.throws(
+    () =>
+      resolveTcgplayerMarketCanarySourceCoverageV1({
+        canaryDefinition: definition([expected]),
+        candidateRows: [],
+        currentSourceRows: [rawSource(expected)],
+        sourceRun: SOURCE_RUN,
+      }),
+    /exists in the current source run but resolved 0 candidate rows/,
+  );
+});
+
+test("duplicate candidate and raw identities fail closed", () => {
+  const expected = printing(1);
+  const exactCandidate = candidate(expected);
+  const exactRaw = rawSource(expected);
+  assert.throws(
+    () =>
+      resolveTcgplayerMarketCanarySourceCoverageV1({
+        canaryDefinition: definition([expected]),
+        candidateRows: [exactCandidate, { ...exactCandidate }],
+        currentSourceRows: [exactRaw],
+        sourceRun: SOURCE_RUN,
+      }),
+    /resolved 2 candidate rows/,
+  );
+  assert.throws(
+    () =>
+      resolveTcgplayerMarketCanarySourceCoverageV1({
+        canaryDefinition: definition([expected]),
+        candidateRows: [exactCandidate],
+        currentSourceRows: [exactRaw, { ...exactRaw }],
+        sourceRun: SOURCE_RUN,
+      }),
+    /resolved 2 rows/,
+  );
+});
+
+test("canonical identity or finish drift remains fatal", () => {
+  const expected = printing(1);
+  assert.throws(
+    () =>
+      resolveTcgplayerMarketCanarySourceCoverageV1({
+        canaryDefinition: definition([expected]),
+        candidateRows: [candidate(expected, { finish_key: "normal" })],
+        currentSourceRows: [rawSource(expected)],
+        sourceRun: SOURCE_RUN,
+      }),
+    /finish_key=normal expected=holo/,
+  );
+});
+
+test("an available alternate subtype is evidence, not a substitute", () => {
+  const expected = printing(1);
+  const alternate = rawSource(expected, {
+    source_observation_id: "normal-observation",
+    source_price_row_identity: "normal-price",
+    source_subtype_name: "Normal",
+  });
+  const result = resolveTcgplayerMarketCanarySourceCoverageV1({
+    canaryDefinition: definition([expected]),
+    candidateRows: [],
+    currentSourceRows: [alternate],
+    sourceRun: SOURCE_RUN,
+  });
+
+  assert.equal(result.rows.length, 0);
+  assert.equal(result.coverage.outcomes[0].outcome, "source_missing");
+  assert.deepEqual(
+    result.coverage.outcomes[0].available_source_identities.map(
+      (identity) => identity.source_subtype_name,
+    ),
+    ["Normal"],
+  );
+});
+
+test("candidate provenance must match the frozen current source run", () => {
+  const expected = printing(1);
+  assert.throws(
+    () =>
+      resolveTcgplayerMarketCanarySourceCoverageV1({
+        canaryDefinition: definition([expected]),
+        candidateRows: [
+          candidate(expected, { source_observation_id: "wrong-observation" }),
+        ],
+        currentSourceRows: [rawSource(expected)],
+        sourceRun: SOURCE_RUN,
+      }),
+    /candidate\/raw source provenance drifted/,
+  );
+});

--- a/tests/contracts/tcgplayer_market_publication_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_publication_v1.test.mjs
@@ -743,6 +743,19 @@ test("worker is dry-run by default and writes only governed pricing tables in wr
   assert.doesNotMatch(WORKER, /insert\s+into\s+public\.vault/i);
 });
 
+test("canary publication reconciles bounded current-source gaps without substituting variants", () => {
+  assert.match(WORKER, /resolveTcgplayerMarketCanarySourceCoverageV1/);
+  assert.match(
+    WORKER,
+    /observation\.last_seen_run_id = \$1[\s\S]*observation\.observed_on = \$2/,
+  );
+  assert.match(WORKER, /DEFAULT_MAX_CANARY_SOURCE_MISSING_COUNT = 5/);
+  assert.match(WORKER, /canary source_missing ceiling exceeded/);
+  assert.match(WORKER, /canary_source_outcomes\.jsonl/);
+  assert.match(WORKER, /canary_resolved_selected_count/);
+  assert.match(WORKER, /canary_source_coverage_reconciled/);
+});
+
 test("all active web and Flutter pricing consumers use the shared read model", () => {
   assert.match(WEB_READ_MODEL, /get_market_pricing_read_model_v1/);
   assert.match(WEB_VAULT, /getExactMarketPricingByCardPrintingIds/);
@@ -897,6 +910,28 @@ test("scheduled failure policy retries source transport failures but stops invar
   );
   assert.deepEqual(
     classifyMarketPipelineFailureV1({
+      failedPhase: "publication",
+      errorText:
+        "canary source_missing ceiling exceeded actual=6 maximum=5",
+    }),
+    {
+      classification: "non_retryable_canary_source_degradation",
+      retryable: false,
+    },
+  );
+  assert.deepEqual(
+    classifyMarketPipelineFailureV1({
+      failedPhase: "publication",
+      errorText:
+        "canary source identity 168245:Holofoil:printing exists in the current source run but resolved 0 candidate rows",
+    }),
+    {
+      classification: "non_retryable_canary_definition_drift",
+      retryable: false,
+    },
+  );
+  assert.deepEqual(
+    classifyMarketPipelineFailureV1({
       failedPhase: "health",
       errorText: "eligible snapshot reconciliation mismatch",
     }),
@@ -962,6 +997,14 @@ test("scheduled runner is safe by default and preserves one durable run key acro
     /--canary-definition=\$\{loadedCanary\.absolutePath\}/,
   );
   assert.match(SCHEDULED_RUNNER, /canary_definition_sha256/);
+  assert.match(
+    SCHEDULED_RUNNER,
+    /--max-canary-source-missing-count=\$\{args\.maxCanarySourceMissingCount\}/,
+  );
+  assert.match(
+    PIPELINE,
+    /--max-canary-source-missing-count=\$\{args\.maxCanarySourceMissingCount\}/,
+  );
   assert.match(SCHEDULED_RUNNER, /classification\.retryable/);
   assert.match(SCHEDULED_RUNNER, /canonical_identity_writes:\s*false/);
   assert.match(SCHEDULED_RUNNER, /vault_writes:\s*false/);


### PR DESCRIPTION
## Summary
- keep the frozen 100-printing canary denominator while resolving each identity as `resolved` or proven `source_missing`
- tolerate at most five exact current-source gaps without subtype, finish, product, printing, or historical substitution
- reconcile publication and observer counts to the current resolved count while keeping mapping, identity, provenance, and duplicate drift fatal
- document the failed July 31 window and required fresh 72-hour restart

## Proof
- frozen-SHA dry run: 100 expected, 99 resolved, 1 source missing, 0 reconciliation mismatches
- focused pricing/canary tests: 60/60 passed
- complete contract suite: 903/903 passed
- syntax/import and diff checks passed
- no migration, database write, publication activation, canonical write, or Vault write

## Known unrelated suite state
The repository shipcheck completed pricing, runtime, contract, and web stages, then failed two existing Flutter golden comparisons:
- lot ivory front renders and matches golden
- sale ivory front renders and matches golden

No Flutter files are changed by this PR.

## Operational boundary
Merging this PR does not declare the canary healthy. Production must deploy the exact repaired lineage, activate a new run key, prove all 100 source outcomes reconcile, and start a fresh uninterrupted 72-hour window.