### PR TITLE
fix(pricing): preserve live canary source coverage

### DIFF
--- a/scripts/workers/tcgplayer_market_publication_worker_v1.mjs
+++ b/scripts/workers/tcgplayer_market_publication_worker_v1.mjs
@@ -1432,7 +1432,7 @@ async function runDurable(client, args, sourceRun, runPlan) {
       return artifactRows(client, run.id);
     }
 
-    const stageResult = await runPhase(client, {
+    await runPhase(client, {
       run,
       sourceRun,
       phaseName: "prepare_variant_assignments",
@@ -1455,7 +1455,7 @@ async function runDurable(client, args, sourceRun, runPlan) {
       },
     });
 
-    await runPhase(client, {
+    const stageResult = await runPhase(client, {
       run,
       sourceRun,
       phaseName: "stage_candidates",

--- a/tests/contracts/tcgplayer_market_publication_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_publication_v1.test.mjs
@@ -754,6 +754,14 @@ test("canary publication reconciles bounded current-source gaps without substitu
   assert.match(WORKER, /canary_source_outcomes\.jsonl/);
   assert.match(WORKER, /canary_resolved_selected_count/);
   assert.match(WORKER, /canary_source_coverage_reconciled/);
+  assert.match(
+    WORKER,
+    /const stageResult = await runPhase\(client, \{[\s\S]*?phaseName: "stage_candidates"/,
+  );
+  assert.match(
+    WORKER,
+    /const canaryCoverage =\s*stageResult\.resumability_data\?\.canary_source_coverage \?\? null/,
+  );
 });
 
 test("all active web and Flutter pricing consumers use the shared read model", () => {


### PR DESCRIPTION
## Summary
- capture `stageResult` from the `stage_candidates` phase instead of `prepare_variant_assignments`
- preserve the live canary source-coverage object through reconciliation and saved artifacts
- add a regression assertion tying coverage extraction to the candidate-staging result

## Live evidence
The `REPAIR4` production activation safely published 100/100 current rows after TCGPlayer restored product 168245, but its coverage fields were null and `canary_source_outcomes.jsonl` was absent. The transaction reconciled and no incorrect price was published, but the run cannot serve as V3 observer provenance.

## Verification
- focused pricing/canary suite: 65/65 passed
- complete contract suite: 903/903 passed
- syntax and diff checks passed
- no schema change or migration

## Next gate
After merge, deploy the exact merge SHA and run one bounded canary activation with `--skip-ingest` against the fresh completed source snapshot. Require all 100 ordinal outcomes, non-null reconciled coverage, matching hashes, and a clean health readback before updating the observer window.