### PR TITLE
feat(pricing): expose exact active ask intelligence

### DIFF
--- a/apps/web/src/app/api/card-pricing/route.ts
+++ b/apps/web/src/app/api/card-pricing/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   getCardPricingUiRowsByCardPrintIdWithClient,
 } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import { getMarketIntelligenceReadModelV1 } from "@/lib/pricing/marketIntelligenceReadModelV1";
 import { createServerAdminClient } from "@/lib/supabase/admin";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 
@@ -49,13 +50,19 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const pricingRecords = await getCardPricingUiRowsByCardPrintIdWithClient(adminClient, cardPrintId);
+  const [pricingRecords, marketIntelligenceRecords] = await Promise.all([
+    getCardPricingUiRowsByCardPrintIdWithClient(adminClient, cardPrintId),
+    getMarketIntelligenceReadModelV1(adminClient, {
+      cardPrintIds: [cardPrintId],
+    }),
+  ]);
 
   return NextResponse.json(
     {
       ok: true,
       pricing: pricingRecords.find((record) => record.pricing_scope === "parent") ?? pricingRecords[0] ?? null,
       pricingRecords,
+      marketIntelligenceRecords,
     },
     { headers: { "Cache-Control": "private, no-store" } },
   );

--- a/apps/web/src/components/pricing/CardPagePricingRail.tsx
+++ b/apps/web/src/components/pricing/CardPagePricingRail.tsx
@@ -6,6 +6,7 @@ import { formatUsdPrice } from "@/lib/cards/formatUsdPrice";
 import { useClientViewer } from "@/lib/auth/useClientViewer";
 import { supabase } from "@/lib/supabaseClient";
 import type { CardPricingUiRecord } from "@/lib/pricing/getCardPricingUiByCardPrintId";
+import type { MarketIntelligenceRecordV1 } from "@/lib/pricing/marketIntelligenceReadModelV1";
 
 type CardPagePricingRailProps = {
   isAuthenticated: boolean;
@@ -124,33 +125,74 @@ function MarketPriceBlock({
 }
 
 function ActiveAskBlock({
-  pricing,
+  marketIntelligence,
+  isLoading,
 }: {
-  pricing: CardPricingUiRecord | null;
+  marketIntelligence: MarketIntelligenceRecordV1 | null;
+  isLoading: boolean;
 }) {
+  const observedAt = marketIntelligence
+    ? formatObservedAt(marketIntelligence.observed_at)
+    : null;
+
   return (
-    <div className="space-y-1.5 border-t border-slate-200/70 pt-4 dark:border-slate-800">
+    <div
+      className="space-y-1.5 border-t border-slate-200/70 pt-4 dark:border-slate-800"
+      data-market-intelligence-proof="exact-printing-active-asks"
+      data-market-intelligence-status={marketIntelligence ? "available" : "unavailable"}
+      data-card-printing-id={marketIntelligence?.card_printing_id}
+      data-printing-gv-id={marketIntelligence?.printing_gv_id}
+      data-source-name={marketIntelligence?.source_name}
+      data-evidence-strength={marketIntelligence?.evidence_strength}
+      data-is-market-value={marketIntelligence?.is_market_value ? "true" : "false"}
+      data-is-completed-sale={marketIntelligence?.is_completed_sale ? "true" : "false"}
+    >
       <p className="text-[11px] font-semibold uppercase text-slate-500">
         Available Today
       </p>
-      {pricing && typeof pricing.lowest_active_ask === "number" ? (
+      {isLoading ? (
+        <p className="text-xs leading-5 text-slate-500">
+          Loading active asking prices...
+        </p>
+      ) : marketIntelligence ? (
         <>
           <p className="text-2xl font-semibold text-slate-950 dark:text-slate-100">
-            {formatUsdPrice(pricing.lowest_active_ask)}
+            {formatUsdPrice(marketIntelligence.lowest_active_ask)}
           </p>
           <p className="text-xs leading-5 text-slate-500">
             Lowest exact-printing eBay active ask
-            {pricing.active_ask_listing_count
-              ? ` · ${pricing.active_ask_listing_count} listings`
-              : ""}
+            {observedAt ? ` · Updated ${observedAt}` : ""}
+          </p>
+          <div className="mt-3 grid grid-cols-2 gap-3 border-t border-slate-200/70 pt-3 dark:border-slate-800">
+            <div>
+              <p className="text-[11px] font-semibold uppercase text-slate-400">
+                Median ask
+              </p>
+              <p className="mt-1 text-sm font-medium text-slate-900 dark:text-slate-100">
+                {formatUsdPrice(marketIntelligence.median_active_ask)}
+              </p>
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold uppercase text-slate-400">
+                Coverage
+              </p>
+              <p className="mt-1 text-sm font-medium capitalize text-slate-900 dark:text-slate-100">
+                {marketIntelligence.evidence_strength}
+              </p>
+            </div>
+          </div>
+          <p className="text-xs leading-5 text-slate-500">
+            {marketIntelligence.listing_count} active listings across{" "}
+            {marketIntelligence.seller_count} sellers · Lowest-to-median spread{" "}
+            {formatUsdPrice(marketIntelligence.ask_spread)} ({marketIntelligence.ask_spread_pct.toFixed(2)}%)
           </p>
           <p className="text-[11px] leading-5 text-slate-400">
-            Asking-price evidence, not a sale or market close.
+            Asking-price evidence, not a sale or market close. It is not a market value.
           </p>
         </>
       ) : (
         <p className="text-xs leading-5 text-slate-500">
-          No exact-printing active ask is available.
+          No fresh exact-printing active asks are available.
         </p>
       )}
     </div>
@@ -186,11 +228,15 @@ function LockedPricingState({ loginHref }: { loginHref: string }) {
 function AuthenticatedPricingState({
   gvId,
   pricing,
+  marketIntelligence,
   isLoading,
+  isLoadingMarketIntelligence,
 }: {
   gvId: string;
   pricing: CardPricingUiRecord | null;
+  marketIntelligence: MarketIntelligenceRecordV1 | null;
   isLoading: boolean;
+  isLoadingMarketIntelligence: boolean;
 }) {
   return (
     <div className="gv-card-pricing-panel px-1 py-1">
@@ -205,7 +251,12 @@ function AuthenticatedPricingState({
             <MarketPriceBlock pricing={pricing} />
           )}
         </div>
-        {!isLoading ? <ActiveAskBlock pricing={pricing} /> : null}
+        {!isLoading ? (
+          <ActiveAskBlock
+            marketIntelligence={marketIntelligence}
+            isLoading={isLoadingMarketIntelligence}
+          />
+        ) : null}
         {!isLoading ? (
           <Link
             href={`/card/${encodeURIComponent(gvId)}/market`}
@@ -254,6 +305,28 @@ function selectPricingRecord({
   );
 }
 
+function selectMarketIntelligenceRecord({
+  records,
+  selectedCardPrintingId,
+  selectedPrintingGvId,
+}: {
+  records: MarketIntelligenceRecordV1[];
+  selectedCardPrintingId?: string | null;
+  selectedPrintingGvId?: string | null;
+}) {
+  if (selectedCardPrintingId) {
+    return records.find(
+      (record) => record.card_printing_id === selectedCardPrintingId,
+    ) ?? null;
+  }
+  if (selectedPrintingGvId) {
+    return records.find(
+      (record) => record.printing_gv_id === selectedPrintingGvId,
+    ) ?? null;
+  }
+  return records[0] ?? null;
+}
+
 export default function CardPagePricingRail({
   isAuthenticated,
   loginHref,
@@ -268,8 +341,13 @@ export default function CardPagePricingRail({
   const effectiveIsAuthenticated = isAuthenticated || viewer.isAuthenticated;
   const [clientPricingRecords, setClientPricingRecords] =
     useState<CardPricingUiRecord[]>(pricingRecords);
+  const [clientMarketIntelligenceRecords, setClientMarketIntelligenceRecords] =
+    useState<MarketIntelligenceRecordV1[]>([]);
+  const [hasLoadedPricingBundle, setHasLoadedPricingBundle] = useState(
+    !cardPrintId,
+  );
   const [isLoadingPricing, setIsLoadingPricing] = useState(
-    effectiveIsAuthenticated && pricingRecords.length === 0 && Boolean(cardPrintId),
+    effectiveIsAuthenticated && Boolean(cardPrintId),
   );
   const selectedPricing = selectPricingRecord({
     records: clientPricingRecords,
@@ -277,11 +355,16 @@ export default function CardPagePricingRail({
     selectedPrintingGvId,
     fallbackPricing: pricing,
   });
+  const selectedMarketIntelligence = selectMarketIntelligenceRecord({
+    records: clientMarketIntelligenceRecords,
+    selectedCardPrintingId,
+    selectedPrintingGvId,
+  });
 
   useEffect(() => {
     if (
       !effectiveIsAuthenticated ||
-      clientPricingRecords.length > 0 ||
+      hasLoadedPricingBundle ||
       !cardPrintId
     ) {
       return;
@@ -309,18 +392,25 @@ export default function CardPagePricingRail({
         ? ((await response.json()) as {
             pricing?: CardPricingUiRecord | null;
             pricingRecords?: CardPricingUiRecord[];
+            marketIntelligenceRecords?: MarketIntelligenceRecordV1[];
           })
         : null;
-      setClientPricingRecords(
-        payload?.pricingRecords ??
-          (payload?.pricing ? [payload.pricing] : []),
-      );
+      if (payload) {
+        setClientPricingRecords(
+          payload.pricingRecords ??
+            (payload.pricing ? [payload.pricing] : []),
+        );
+        setClientMarketIntelligenceRecords(
+          payload.marketIntelligenceRecords ?? [],
+        );
+      }
+      setHasLoadedPricingBundle(true);
       setIsLoadingPricing(false);
     }
 
     loadPricing().catch(() => setIsLoadingPricing(false));
     return () => controller.abort();
-  }, [cardPrintId, clientPricingRecords.length, effectiveIsAuthenticated]);
+  }, [cardPrintId, effectiveIsAuthenticated, hasLoadedPricingBundle]);
 
   if (!effectiveIsAuthenticated) {
     return <LockedPricingState loginHref={loginHref} />;
@@ -329,7 +419,9 @@ export default function CardPagePricingRail({
     <AuthenticatedPricingState
       gvId={gvId}
       pricing={selectedPricing}
+      marketIntelligence={selectedMarketIntelligence}
       isLoading={isLoadingPricing && !selectedPricing}
+      isLoadingMarketIntelligence={isLoadingPricing}
     />
   );
 }

--- a/apps/web/src/lib/pricing/marketIntelligenceReadModelV1.ts
+++ b/apps/web/src/lib/pricing/marketIntelligenceReadModelV1.ts
@@ -1,0 +1,193 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type MarketIntelligenceEvidenceStrengthV1 =
+  | "limited"
+  | "moderate"
+  | "strong";
+
+type MarketIntelligenceReadRowV1 = {
+  market_intelligence_version: string | null;
+  card_print_id: string | null;
+  card_printing_id: string | null;
+  printing_gv_id: string | null;
+  finish_key: string | null;
+  status: string | null;
+  unavailable_reason: string | null;
+  currency: string | null;
+  lowest_active_ask: number | null;
+  median_active_ask: number | null;
+  listing_count: number | null;
+  seller_count: number | null;
+  ask_spread: number | null;
+  ask_spread_pct: number | null;
+  observed_at: string | null;
+  freshness: string | null;
+  evidence_strength: string | null;
+  source_name: string | null;
+  source_label: string | null;
+  evidence_kind: string | null;
+  is_market_value: boolean | null;
+  is_completed_sale: boolean | null;
+};
+
+export type MarketIntelligenceRecordV1 = {
+  market_intelligence_version: "MARKET_INTELLIGENCE_READ_MODEL_V1";
+  card_print_id: string;
+  card_printing_id: string;
+  printing_gv_id: string;
+  finish_key: string;
+  status: "available";
+  currency: "USD";
+  lowest_active_ask: number;
+  median_active_ask: number;
+  listing_count: number;
+  seller_count: number;
+  ask_spread: number;
+  ask_spread_pct: number;
+  observed_at: string;
+  freshness: "fresh";
+  evidence_strength: MarketIntelligenceEvidenceStrengthV1;
+  source_name: "ebay_active";
+  source_label: "eBay active asks";
+  evidence_kind: "active_listing_ask";
+  is_market_value: false;
+  is_completed_sale: false;
+};
+
+type MarketIntelligenceClient = Pick<SupabaseClient, "rpc">;
+
+function finite(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function validTimestamp(value: string | null | undefined) {
+  if (!value?.trim()) return undefined;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? value : undefined;
+}
+
+function mapRow(
+  row: MarketIntelligenceReadRowV1,
+): MarketIntelligenceRecordV1 | null {
+  const cardPrintId = row.card_print_id?.trim() ?? "";
+  const cardPrintingId = row.card_printing_id?.trim() ?? "";
+  const printingGvId = row.printing_gv_id?.trim() ?? "";
+  const finishKey = row.finish_key?.trim() ?? "";
+  const lowestActiveAsk = finite(row.lowest_active_ask);
+  const medianActiveAsk = finite(row.median_active_ask);
+  const listingCount = finite(row.listing_count);
+  const sellerCount = finite(row.seller_count);
+  const askSpread = finite(row.ask_spread);
+  const askSpreadPct = finite(row.ask_spread_pct);
+  const observedAt = validTimestamp(row.observed_at);
+  const evidenceStrength =
+    row.evidence_strength === "limited" ||
+    row.evidence_strength === "moderate" ||
+    row.evidence_strength === "strong"
+      ? row.evidence_strength
+      : null;
+
+  if (
+    row.market_intelligence_version !== "MARKET_INTELLIGENCE_READ_MODEL_V1" ||
+    row.status !== "available" ||
+    row.unavailable_reason !== null ||
+    row.currency !== "USD" ||
+    row.freshness !== "fresh" ||
+    row.source_name !== "ebay_active" ||
+    row.source_label !== "eBay active asks" ||
+    row.evidence_kind !== "active_listing_ask" ||
+    row.is_market_value !== false ||
+    row.is_completed_sale !== false ||
+    !cardPrintId ||
+    !cardPrintingId ||
+    !printingGvId ||
+    !finishKey ||
+    lowestActiveAsk === undefined ||
+    lowestActiveAsk < 0 ||
+    medianActiveAsk === undefined ||
+    medianActiveAsk < lowestActiveAsk ||
+    listingCount === undefined ||
+    !Number.isInteger(listingCount) ||
+    listingCount < 1 ||
+    sellerCount === undefined ||
+    !Number.isInteger(sellerCount) ||
+    sellerCount < 0 ||
+    askSpread === undefined ||
+    askSpread < 0 ||
+    askSpreadPct === undefined ||
+    askSpreadPct < 0 ||
+    !observedAt ||
+    !evidenceStrength
+  ) {
+    return null;
+  }
+
+  return {
+    market_intelligence_version: "MARKET_INTELLIGENCE_READ_MODEL_V1",
+    card_print_id: cardPrintId,
+    card_printing_id: cardPrintingId,
+    printing_gv_id: printingGvId,
+    finish_key: finishKey,
+    status: "available",
+    currency: "USD",
+    lowest_active_ask: lowestActiveAsk,
+    median_active_ask: medianActiveAsk,
+    listing_count: listingCount,
+    seller_count: sellerCount,
+    ask_spread: askSpread,
+    ask_spread_pct: askSpreadPct,
+    observed_at: observedAt,
+    freshness: "fresh",
+    evidence_strength: evidenceStrength,
+    source_name: "ebay_active",
+    source_label: "eBay active asks",
+    evidence_kind: "active_listing_ask",
+    is_market_value: false,
+    is_completed_sale: false,
+  };
+}
+
+export async function getMarketIntelligenceReadModelV1(
+  client: MarketIntelligenceClient,
+  {
+    cardPrintIds = [],
+    cardPrintingIds = [],
+    throwOnError = false,
+  }: {
+    cardPrintIds?: string[];
+    cardPrintingIds?: string[];
+    throwOnError?: boolean;
+  },
+): Promise<MarketIntelligenceRecordV1[]> {
+  const parentIds = Array.from(
+    new Set(cardPrintIds.map((id) => id.trim()).filter(Boolean)),
+  );
+  const printingIds = Array.from(
+    new Set(cardPrintingIds.map((id) => id.trim()).filter(Boolean)),
+  );
+  if (!parentIds.length && !printingIds.length) return [];
+
+  const { data, error } = await client.rpc(
+    "get_market_intelligence_read_model_v1",
+    {
+      p_card_print_ids: parentIds.length ? parentIds : null,
+      p_card_printing_ids: printingIds.length ? printingIds : null,
+    },
+  );
+  if (error) {
+    if (throwOnError) throw error;
+    console.error("[market-intelligence:v1] shared read model failed", {
+      code: error.code,
+      message: error.message,
+    });
+    return [];
+  }
+
+  return ((data ?? []) as MarketIntelligenceReadRowV1[])
+    .map(mapRow)
+    .filter((row): row is MarketIntelligenceRecordV1 => row !== null);
+}

--- a/docs/checkpoints/pricing/PRICING_CHECKPOINT_41_MARKET_INTELLIGENCE_READ_MODEL_V1.md
+++ b/docs/checkpoints/pricing/PRICING_CHECKPOINT_41_MARKET_INTELLIGENCE_READ_MODEL_V1.md
@@ -1,0 +1,234 @@
+# Pricing Checkpoint 41: Market Intelligence Read Model V1
+
+## Context
+
+The Market Evidence Engine held millions of active-listing observations and
+hundreds of thousands of deterministic printing assignments, but the collector
+product used only TCGPlayer Market. The active-ask materialized snapshot was
+empty, and the existing shared pricing RPC exposed only a lowest ask when a
+TCGPlayer Market row also existed.
+
+## Problem
+
+Existing evidence could not answer basic signed-in collector questions such as:
+
+- What is the lowest exact-printing active ask today?
+- What is the median ask?
+- How many listings and distinct sellers support the range?
+- How far is the lowest ask from the median?
+- How fresh and dense is the evidence?
+
+The newest acquisition runs also had no variant-assignment sidecars because the
+legacy backfill scanned the full warehouse and had not completed after recent
+ingestion.
+
+## Risk
+
+- Active asks could be mislabeled as completed sales or market value.
+- Parent-card evidence could be shown for the wrong printing or finish.
+- Product requests could scan the raw listing warehouse.
+- A broad backfill could create an unbounded production write.
+- Deferred pricing migrations could be applied accidentally by a broad push.
+- Currency floating-point artifacts could suppress otherwise valid rows.
+
+## Decision
+
+Production V1 keeps TCGPlayer `marketPrice` as the market-close authority.
+
+A separate authenticated interface,
+`get_market_intelligence_read_model_v1(uuid[], uuid[])`, exposes exact-printing
+eBay active asks from the replaceable materialized snapshot only. It reports
+lowest and median ask, listing and seller counts, spread, freshness, and evidence
+strength. Every returned row declares:
+
+```text
+source_name = ebay_active
+evidence_kind = active_listing_ask
+is_market_value = false
+is_completed_sale = false
+```
+
+The signed-in card-pricing API returns TCGPlayer Market and market intelligence
+as independent records. The card page labels the new lane `Available Today` and
+states that it is asking-price evidence, not a sale, market close, or market
+value.
+
+## Alternatives Rejected
+
+- Replacing TCGPlayer Market with an active ask.
+- Creating Grookai Value from listing evidence.
+- Reading raw warehouse tables inside a customer request.
+- Exposing the snapshot directly to anonymous or authenticated clients.
+- Applying all locally pending migrations with `--include-all`.
+- Running the legacy full-warehouse assignment backfill for the first proof.
+- Treating a zero-row snapshot as proof that no evidence existed.
+
+## Frozen Implementation
+
+Current-main integration branch:
+
+```text
+agent/market-intelligence-main-integration
+```
+
+Integrated implementation commit at checkpoint creation:
+
+```text
+eb76f08ac
+```
+
+The branch was created from current `origin/main` at:
+
+```text
+0cacd5fd89a46e88df1734da85badb478728ca0f
+```
+
+## Migrations Applied
+
+Production migration ledger now includes:
+
+| Migration | Purpose | Source commit | SHA-256 |
+| --- | --- | --- | --- |
+| `20260803183000` | authenticated exact-printing market-intelligence RPC | `159f6e548d29e575e0bdd4995b80e1febe8ab5f8` | `301ac9553692b181ec6dcc9e965244894d3f551e76e9aa261a6d65a630d222b3` |
+| `20260803190000` | normalize positive USD active asks to cents | `66528efc3e0759d02763264a3239383fec54c05f` | `deed156109c4c67dac696e5cefdea673c478241b62fb0effb81e43bf14b84c69` |
+
+Both were targeted, additive applies. Deferred older migrations remained
+untouched. No canonical identity, source evidence, price publication, Vault, or
+ownership rows were changed by either migration.
+
+## Assignment Proof
+
+The bounded proof used completed acquisition run:
+
+```text
+2f75dd94-8f1f-ec38-a66e-bd816965741d
+MEE-11L-DAILY-BATCH-b040d39fa851
+```
+
+Dry-run and apply reconciled the same frozen candidate selection:
+
+```text
+selected rows: 7,088
+selection SHA-256: 64fe9d5df5df2be205fcd930f36818fab5bb277c827d192a50f62fbf4f3431bc
+exact_child_finish: 4,478
+single_child_inferred: 321
+unknown_finish_needs_review: 2,145
+no_matching_child_finish: 144
+```
+
+Every inserted sidecar row remained:
+
+```text
+needs_review = true
+publishable = false
+app_visible = false
+market_truth = false
+```
+
+Boundary leak rows: `0`.
+
+Permanent operational artifacts on the MEE host:
+
+```text
+/var/lib/grookai/market-intelligence/variant-assignment/2026-08-03T18-40-43-537Z
+/var/lib/grookai/market-intelligence/variant-assignment/2026-08-03T18-41-08-221Z
+```
+
+## Snapshot And Read Model Proof
+
+The final cache refresh completed in `211.5` seconds under:
+
+```text
+statement_timeout = 20min
+enable_nestloop = off
+```
+
+Final production readback:
+
+```text
+snapshot rows: 527
+distinct parent cards: 377
+non-USD rows: 0
+invalid rows: 0
+stale rows: 0
+```
+
+The RPC returned `500/500` requested available rows with:
+
+```text
+market value claims: 0
+completed sale claims: 0
+authority mismatches: 0
+```
+
+A 25-printing direct production RPC proof completed in approximately `217 ms`.
+
+Final refresh artifact:
+
+```text
+/var/lib/grookai/market-intelligence/active-ask-refresh/2026-08-03T18-47-09-840Z
+```
+
+## Schema And Security Readback
+
+- Function exists with a hardened catalog-first search path.
+- `anon`: execute denied.
+- `authenticated`: execute granted.
+- `service_role`: execute granted.
+- Raw warehouse and snapshot reads remain service-only.
+- The RPC is bounded to `500` requested printings.
+- Stale, invalid, non-USD, and non-positive evidence is unavailable.
+
+## Verification
+
+Current-main integration verification passed:
+
+```text
+relevant pricing/MEE contracts: 749/749
+Node syntax checks: passed
+TypeScript: passed
+ESLint: passed
+Next.js production build: passed
+git diff --check: passed
+```
+
+The credential-dependent full pre-commit shipcheck was not run from the local
+clean worktree because it intentionally contains no production database secret.
+Production schema and data boundaries were verified separately through the
+protected MEE host environment.
+
+## Current Truths
+
+- The production database read model is functional and nonempty.
+- Existing source evidence was reused; no provider acquisition was purchased.
+- The first bounded data slice covers 527 exact printings across 377 cards.
+- TCGPlayer Market remains unchanged and authoritative for Production V1.
+- The web implementation is build-clean on current main.
+- The active MEE timer and its scheduled activation were not changed by this
+  work.
+- The incremental assignment worker is proven for one completed acquisition
+  run but is not yet installed as the authoritative nightly assignment step.
+
+## What Must Never Be Broken
+
+1. Active asks never become market value, completed sales, or TCGPlayer Market.
+2. Active asks are exact-printing and exact-finish only.
+3. Customer requests never scan raw listing warehouse tables.
+4. Anonymous users cannot execute the market-intelligence RPC.
+5. Sidecar assignment writes remain review-gated and non-public.
+6. Missing or stale evidence renders as unavailable, never zero or fabricated.
+7. Deferred migrations are not pulled into a broad apply.
+8. Canonical identity and existing pricing publication rows remain untouched.
+
+## Explicit Next Gate
+
+1. Push the current-main integration branch once.
+2. Let required GitHub checks and the Vercel preview complete.
+3. Merge through the governed repository path.
+4. Verify a signed-in production card with one of the 527 exact-printing rows.
+5. Confirm the selected finish changes the active-ask record without fallback to
+   another printing.
+6. Promote the incremental assignment worker into the post-ingest schedule only
+   after an offline and bounded latest-run canary.
+7. Expand assignment coverage in bounded acquisition-run batches; do not rerun
+   provider ingestion solely for market-intelligence population.

--- a/docs/checkpoints/pricing/PRICING_CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/pricing/PRICING_CHECKPOINT_INDEX.md
@@ -782,6 +782,12 @@ Recommended reading order for future maintainers:
       visible-text proof, read-only 100-row check, and frozen post-canary
       migration/deployment/rollback sequence
 
+39. `PRICING_CHECKPOINT_41_MARKET_INTELLIGENCE_READ_MODEL_V1.md`
+    - then read how existing exact-printing active-listing evidence became a
+      separate signed-in market-intelligence lane, including the bounded
+      assignment repair, production readback, authority boundaries, and the
+      remaining web and scheduler rollout gates
+
 After those checkpoints, read the supporting audits in this order:
 
 - `docs/audits/PRICING_READINESS_AUDIT_V1.md`

--- a/docs/contracts/MARKET_INTELLIGENCE_READ_MODEL_V1.md
+++ b/docs/contracts/MARKET_INTELLIGENCE_READ_MODEL_V1.md
@@ -1,0 +1,51 @@
+# Market Intelligence Read Model V1
+
+## Purpose
+
+Turn existing exact-printing MEE active-listing evidence into useful signed-in collector intelligence without redefining price authority.
+
+## Authority
+
+- TCGPlayer `marketPrice` remains the Production V1 market close.
+- eBay rows are active seller asks, not completed sales.
+- This contract does not create Grookai Value.
+- No active ask may overwrite, replace, or backfill a TCGPlayer Market value.
+
+## Interface
+
+`get_market_intelligence_read_model_v1(uuid[], uuid[])` returns one bounded exact-printing result per requested `card_printing_id`.
+
+The interface exposes:
+
+- lowest active ask;
+- median active ask;
+- active listing count;
+- distinct seller count;
+- distance between the lowest and median ask;
+- evidence freshness;
+- evidence-density strength;
+- exact printing identity;
+- source and authority labels.
+
+## Evidence Policy
+
+Only `mv_market_listing_active_ask_current_v1` may feed the product read. That snapshot is derived from exact-child raw-single assignments and refreshed outside the request path.
+
+Rows older than 72 hours are unavailable. Unavailable rows expose no prices. Evidence strength measures listing and seller coverage only; it is not price confidence, valuation confidence, or a recommendation.
+
+## Access
+
+- `authenticated`: execute only;
+- `service_role`: execute and source-snapshot read;
+- `anon` and `public`: no execute;
+- raw MEE warehouse tables remain service-only.
+
+## Invariants
+
+- Exact printing is mandatory.
+- Currency is USD for V1.
+- `is_market_value=false` for every row.
+- `is_completed_sale=false` for every row.
+- The function is read-only and bounded to 500 requested printings.
+- No canonical identity, vault, pricing publication, or evidence rows are written.
+- Product UI must label the lane `Available Today` and explain that asking prices are not sales or market value.

--- a/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
+++ b/docs/contracts/TCGPLAYER_MARKET_PRICING_PRODUCT_V1.md
@@ -340,4 +340,9 @@ The shared customer RPC must never aggregate the raw active-listing warehouse.
 Exact-printing eBay active asks are maintained in
 `mv_market_listing_active_ask_current_v1` by a separately governed refresh
 phase. Refresh failures fail the activation pipeline closed, while shadow and
-dry-run modes inspect the cache without changing it.
+dry-run modes inspect the cache without changing it. The refresh worker must
+set its database statement timeout explicitly on the live session and use the
+hash-plan path (`enable_nestloop = off`) so production-scale evidence joins do
+not inherit the platform's shorter default timeout or regress to pathological
+random index lookups. The effective session settings must be preserved in the
+refresh artifact.

--- a/docs/sql/market_intelligence_read_model_v1_readback.sql
+++ b/docs/sql/market_intelligence_read_model_v1_readback.sql
@@ -27,7 +27,7 @@ select
     where lowest_active_ask is null
        or median_active_ask is null
        or lowest_active_ask <= 0
-       or median_active_ask < lowest_active_ask
+       or round(median_active_ask, 2) < round(lowest_active_ask, 2)
        or listing_count < 1
        or seller_count < 0
   )::bigint as invalid_rows,

--- a/docs/sql/market_intelligence_read_model_v1_readback.sql
+++ b/docs/sql/market_intelligence_read_model_v1_readback.sql
@@ -1,0 +1,59 @@
+-- MARKET_INTELLIGENCE_READ_MODEL_V1 production readback.
+
+select
+  to_regprocedure(
+    'public.get_market_intelligence_read_model_v1(uuid[],uuid[])'
+  ) is not null as function_exists,
+  has_function_privilege(
+    'anon',
+    'public.get_market_intelligence_read_model_v1(uuid[],uuid[])',
+    'EXECUTE'
+  ) as anon_execute,
+  has_function_privilege(
+    'authenticated',
+    'public.get_market_intelligence_read_model_v1(uuid[],uuid[])',
+    'EXECUTE'
+  ) as authenticated_execute,
+  has_function_privilege(
+    'service_role',
+    'public.get_market_intelligence_read_model_v1(uuid[],uuid[])',
+    'EXECUTE'
+  ) as service_role_execute;
+
+select
+  count(*)::bigint as snapshot_rows,
+  count(*) filter (where currency <> 'USD')::bigint as non_usd_rows,
+  count(*) filter (
+    where lowest_active_ask is null
+       or median_active_ask is null
+       or lowest_active_ask <= 0
+       or median_active_ask < lowest_active_ask
+       or listing_count < 1
+       or seller_count < 0
+  )::bigint as invalid_rows,
+  count(*) filter (
+    where observed_at < now() - interval '72 hours'
+  )::bigint as stale_rows,
+  min(observed_at) as oldest_observed_at,
+  max(observed_at) as newest_observed_at
+from public.mv_market_listing_active_ask_current_v1;
+
+select
+  count(*)::bigint as available_rows,
+  count(*) filter (where is_market_value)::bigint as market_value_claim_rows,
+  count(*) filter (where is_completed_sale)::bigint as completed_sale_claim_rows,
+  count(*) filter (
+    where source_name <> 'ebay_active'
+       or source_label <> 'eBay active asks'
+       or evidence_kind <> 'active_listing_ask'
+  )::bigint as authority_mismatch_rows
+from public.get_market_intelligence_read_model_v1(
+  null,
+  array(
+    select card_printing_id
+    from public.mv_market_listing_active_ask_current_v1
+    order by observed_at desc, card_printing_id
+    limit 25
+  )
+)
+where status = 'available';

--- a/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
+++ b/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
@@ -1,0 +1,575 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import pg from "pg";
+
+import "../../backend/env.mjs";
+
+const { Client } = pg;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const WORKER_VERSION = "MARKET_LISTING_VARIANT_ASSIGNMENT_INCREMENTAL_V1";
+const ASSIGNMENT_VERSION = "MEE_VARIANT_ASSIGNMENT_RULES_V1";
+const DEFAULT_OUT_ROOT = path.join(
+  REPO_ROOT,
+  "artifacts",
+  "market_intelligence_v1",
+  "variant_assignment_incremental",
+);
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    acquisitionRunId: null,
+    maxCandidates: 10_000,
+    batchSize: 10_000,
+    timeoutMinutes: 10,
+    outRoot: DEFAULT_OUT_ROOT,
+  };
+  for (const arg of argv) {
+    if (arg === "--apply") args.apply = true;
+    else if (arg === "--dry-run") args.apply = false;
+    else if (arg.startsWith("--acquisition-run-id=")) {
+      args.acquisitionRunId = arg.slice("--acquisition-run-id=".length).trim();
+    } else if (arg.startsWith("--max-candidates=")) {
+      args.maxCandidates = Number(arg.slice("--max-candidates=".length));
+    } else if (arg.startsWith("--batch-size=")) {
+      args.batchSize = Number(arg.slice("--batch-size=".length));
+    } else if (arg.startsWith("--timeout-minutes=")) {
+      args.timeoutMinutes = Number(arg.slice("--timeout-minutes=".length));
+    } else if (arg.startsWith("--out-root=")) {
+      args.outRoot = path.resolve(arg.slice("--out-root=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (
+    args.acquisitionRunId &&
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      args.acquisitionRunId,
+    )
+  ) {
+    throw new Error("--acquisition-run-id must be a UUID");
+  }
+  if (
+    !Number.isInteger(args.maxCandidates) ||
+    args.maxCandidates < 1 ||
+    args.maxCandidates > 500_000
+  ) {
+    throw new Error("--max-candidates must be an integer from 1 through 500000");
+  }
+  if (
+    !Number.isInteger(args.batchSize) ||
+    args.batchSize < 1 ||
+    args.batchSize > 50_000 ||
+    args.batchSize > args.maxCandidates
+  ) {
+    throw new Error(
+      "--batch-size must be an integer from 1 through 50000 and no greater than --max-candidates",
+    );
+  }
+  if (
+    !Number.isInteger(args.timeoutMinutes) ||
+    args.timeoutMinutes < 1 ||
+    args.timeoutMinutes > 60
+  ) {
+    throw new Error("--timeout-minutes must be an integer from 1 through 60");
+  }
+  return args;
+}
+
+function databaseUrl() {
+  return (
+    process.env.SUPABASE_DB_URL ||
+    process.env.DATABASE_URL ||
+    process.env.POSTGRES_URL ||
+    ""
+  );
+}
+
+function sslConfig(url) {
+  return /localhost|127\.0\.0\.1|\[::1\]/i.test(url)
+    ? false
+    : { rejectUnauthorized: false };
+}
+
+function gitValue(args) {
+  return execFileSync("git", args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function countByStatus(rows) {
+  return Object.fromEntries(
+    rows.map((row) => [row.variant_assignment_status, Number(row.row_count)]),
+  );
+}
+
+async function selectAcquisitionRun(client, requestedId) {
+  const result = requestedId
+    ? await client.query(
+        `select id, run_key, status, observed_listing_count, started_at, finished_at
+         from public.market_listing_acquisition_runs
+         where id = $1`,
+        [requestedId],
+      )
+    : await client.query(
+        `select id, run_key, status, observed_listing_count, started_at, finished_at
+         from public.market_listing_acquisition_runs
+         where source = 'ebay_active'
+           and status = 'completed'
+         order by created_at desc
+         limit 1`,
+      );
+  if (result.rowCount !== 1) {
+    throw new Error("One completed acquisition run is required");
+  }
+  const row = result.rows[0];
+  if (row.status !== "completed") {
+    throw new Error(`Acquisition run ${row.id} is not completed`);
+  }
+  return row;
+}
+
+async function selectMissingCandidateIds(client, acquisitionRunId, limit) {
+  const result = await client.query(
+    `select candidate.id
+     from public.market_listing_observations observation
+     join public.market_listing_card_candidates candidate
+       on candidate.observation_id = observation.id
+     where observation.acquisition_run_id = $1
+       and not exists (
+         select 1
+         from public.market_evidence_variant_assignments existing
+         where existing.source_family = 'market_listing'
+           and existing.source_row_id = candidate.id
+           and existing.variant_assignment_version = $2
+       )
+     order by candidate.id
+     limit $3`,
+    [acquisitionRunId, ASSIGNMENT_VERSION, limit],
+  );
+  return result.rows.map((row) => row.id);
+}
+
+const PROJECTION_CTES = `
+  with target_candidates as materialized (
+    select candidate.*
+    from public.market_listing_card_candidates candidate
+    where candidate.id = any($1::uuid[])
+  ),
+  target_parents as materialized (
+    select distinct card_print_id
+    from target_candidates
+    where card_print_id is not null
+  ),
+  child_counts as materialized (
+    select
+      child.card_print_id,
+      count(*)::integer as child_count,
+      array_agg(distinct child.finish_key order by child.finish_key) as child_finish_keys
+    from public.card_printings child
+    join target_parents target on target.card_print_id = child.card_print_id
+    group by child.card_print_id
+  ),
+  source_rows as materialized (
+    select
+      'market_listing'::text as source_family,
+      'market_listing_card_candidates'::text as source_table,
+      candidate.id as source_row_id,
+      candidate.observation_id,
+      candidate.raw_snapshot_id,
+      candidate.card_print_id,
+      candidate.gv_id,
+      candidate.source,
+      candidate.source_listing_id,
+      coalesce(
+        observation.listing_title,
+        candidate.title_features ->> 'listing_title',
+        candidate.title_features ->> 'query_text'
+      ) as raw_title,
+      coalesce(
+        candidate.finish_features ->> 'finish_key',
+        candidate.finish_features ->> 'finish',
+        candidate.finish_features ->> 'finish_hint',
+        observation.listing_title,
+        candidate.title_features ->> 'listing_title',
+        candidate.title_features ->> 'query_text'
+      ) as source_finish_hint,
+      public.normalize_market_evidence_finish_key_v1(coalesce(
+        candidate.finish_features ->> 'finish_key',
+        candidate.finish_features ->> 'finish',
+        candidate.finish_features ->> 'finish_hint',
+        observation.listing_title,
+        candidate.title_features ->> 'listing_title',
+        candidate.title_features ->> 'query_text'
+      )) as normalized_finish_key,
+      child_counts.child_count,
+      child_counts.child_finish_keys,
+      candidate.title_features,
+      candidate.condition_features,
+      candidate.exclusion_flags
+    from target_candidates candidate
+    left join public.market_listing_observations observation
+      on observation.id = candidate.observation_id
+    left join child_counts on child_counts.card_print_id = candidate.card_print_id
+  ),
+  matched_child as materialized (
+    select
+      source_rows.source_row_id,
+      count(child.id)::integer as match_count,
+      (array_agg(child.id order by child.id))[1] as card_printing_id,
+      (array_agg(child.printing_gv_id order by child.id))[1] as printing_gv_id,
+      (array_agg(child.finish_key order by child.id))[1] as assigned_finish_key
+    from source_rows
+    left join public.card_printings child
+      on child.card_print_id = source_rows.card_print_id
+     and (
+       child.finish_key = source_rows.normalized_finish_key
+       or (
+         source_rows.normalized_finish_key = 'cosmos'
+         and child.finish_key = 'cracked_ice'
+         and not exists (
+           select 1
+           from public.card_printings exact_cosmos
+           where exact_cosmos.card_print_id = source_rows.card_print_id
+             and exact_cosmos.finish_key = 'cosmos'
+         )
+       )
+     )
+    group by source_rows.source_row_id
+  ),
+  single_child as materialized (
+    select
+      child.card_print_id,
+      child.id as card_printing_id,
+      child.printing_gv_id,
+      child.finish_key as assigned_finish_key
+    from public.card_printings child
+    join child_counts
+      on child_counts.card_print_id = child.card_print_id
+     and child_counts.child_count = 1
+  ),
+  projected as materialized (
+    select
+      source_rows.*,
+      case
+        when coalesce(source_rows.child_count, 0) = 0 then null::uuid
+        when matched_child.match_count = 1 then matched_child.card_printing_id
+        when source_rows.normalized_finish_key is null and source_rows.child_count = 1
+          then single_child.card_printing_id
+        else null::uuid
+      end as card_printing_id,
+      case
+        when coalesce(source_rows.child_count, 0) = 0 then null::text
+        when matched_child.match_count = 1 then matched_child.printing_gv_id
+        when source_rows.normalized_finish_key is null and source_rows.child_count = 1
+          then single_child.printing_gv_id
+        else null::text
+      end as printing_gv_id,
+      case
+        when coalesce(source_rows.child_count, 0) = 0 then null::text
+        when matched_child.match_count = 1 then matched_child.assigned_finish_key
+        when source_rows.normalized_finish_key is null and source_rows.child_count = 1
+          then single_child.assigned_finish_key
+        else null::text
+      end as assigned_finish_key,
+      case
+        when coalesce(source_rows.child_count, 0) = 0 then 'parent_has_no_child'
+        when matched_child.match_count = 1 then 'exact_child_finish'
+        when matched_child.match_count > 1 then 'ambiguous_finish_conflict'
+        when source_rows.normalized_finish_key is null and source_rows.child_count = 1
+          then 'single_child_inferred'
+        when source_rows.normalized_finish_key is null then 'unknown_finish_needs_review'
+        else 'no_matching_child_finish'
+      end as variant_assignment_status,
+      case
+        when coalesce(source_rows.child_count, 0) = 0 then 0.9900
+        when matched_child.match_count = 1 then 0.9000
+        when matched_child.match_count > 1 then 0.2000
+        when source_rows.normalized_finish_key is null and source_rows.child_count = 1 then 0.7000
+        when source_rows.normalized_finish_key is null then 0.1000
+        else 0.2000
+      end::numeric(5,4) as variant_assignment_confidence,
+      case
+        when coalesce(source_rows.child_count, 0) = 0 then 'parent identity has no child finish rows'
+        when matched_child.match_count = 1 then 'listing finish text matched one child finish row'
+        when matched_child.match_count > 1 then 'listing finish text matched multiple child finish rows'
+        when source_rows.normalized_finish_key is null and source_rows.child_count = 1
+          then 'single child finish inferred because parent has exactly one child row'
+        when source_rows.normalized_finish_key is null
+          then 'listing title or finish features did not identify a finish for multi-finish parent'
+        else 'listing finish text did not match any child finish row'
+      end as variant_assignment_reason,
+      array_remove(array[
+        case when source_rows.child_count > 1 then 'multi_finish_parent' end,
+        case when source_rows.normalized_finish_key is null then 'finish_text_unrecognized' end,
+        case when matched_child.match_count > 1 then 'duplicate_child_finish_match' end,
+        case when source_rows.normalized_finish_key is not null
+          and coalesce(matched_child.match_count, 0) = 0
+          and coalesce(source_rows.child_count, 0) > 0
+          then 'finish_text_without_child_lane' end,
+        case when coalesce(array_length(source_rows.exclusion_flags, 1), 0) > 0
+          then 'candidate_has_exclusion_flags' end
+      ]::text[], null) as variant_assignment_flags
+    from source_rows
+    left join matched_child on matched_child.source_row_id = source_rows.source_row_id
+    left join single_child on single_child.card_print_id = source_rows.card_print_id
+  )`;
+
+const INSERT_CTE = `,
+  inserted as (
+    insert into public.market_evidence_variant_assignments (
+      source_family, source_table, source_row_id, observation_id, raw_snapshot_id,
+      card_print_id, gv_id, card_printing_id, printing_gv_id, source_finish_hint,
+      normalized_finish_key, assigned_finish_key, variant_assignment_status,
+      variant_assignment_confidence, variant_assignment_version,
+      variant_assignment_reason, variant_assignment_flags, assignment_payload,
+      needs_review, publishable, app_visible, market_truth
+    )
+    select
+      projected.source_family,
+      projected.source_table,
+      projected.source_row_id,
+      projected.observation_id,
+      projected.raw_snapshot_id,
+      projected.card_print_id,
+      projected.gv_id,
+      projected.card_printing_id,
+      projected.printing_gv_id,
+      projected.source_finish_hint,
+      projected.normalized_finish_key,
+      projected.assigned_finish_key,
+      projected.variant_assignment_status,
+      projected.variant_assignment_confidence,
+      '${ASSIGNMENT_VERSION}',
+      projected.variant_assignment_reason,
+      projected.variant_assignment_flags,
+      jsonb_build_object(
+        'source', projected.source,
+        'source_listing_id', projected.source_listing_id,
+        'raw_title', projected.raw_title,
+        'child_count', coalesce(projected.child_count, 0),
+        'child_finish_keys', coalesce(to_jsonb(projected.child_finish_keys), '[]'::jsonb),
+        'title_features', coalesce(projected.title_features, '{}'::jsonb),
+        'condition_features', coalesce(projected.condition_features, '{}'::jsonb),
+        'exclusion_flags', coalesce(to_jsonb(projected.exclusion_flags), '[]'::jsonb),
+        'backfill_package', '${WORKER_VERSION}'
+      ),
+      true, false, false, false
+    from projected
+    on conflict (source_family, source_row_id, variant_assignment_version) do nothing
+    returning variant_assignment_status
+  )
+  select variant_assignment_status, count(*)::integer as row_count
+  from inserted
+  group by variant_assignment_status
+  order by variant_assignment_status`;
+
+const DRY_RUN_SELECT = `
+  select variant_assignment_status, count(*)::integer as row_count
+  from projected
+  group by variant_assignment_status
+  order by variant_assignment_status`;
+
+async function processBatch(client, candidateIds, apply) {
+  if (!apply) {
+    const result = await client.query(
+      `${PROJECTION_CTES}${DRY_RUN_SELECT}`,
+      [candidateIds],
+    );
+    return countByStatus(result.rows);
+  }
+
+  await client.query("begin");
+  try {
+    const result = await client.query(`${PROJECTION_CTES}${INSERT_CTE}`, [candidateIds]);
+    const inserted = result.rows.reduce(
+      (total, row) => total + Number(row.row_count),
+      0,
+    );
+    if (inserted !== candidateIds.length) {
+      throw new Error(
+        `Batch reconciliation failed: selected ${candidateIds.length}, inserted ${inserted}`,
+      );
+    }
+    await client.query("commit");
+    return countByStatus(result.rows);
+  } catch (error) {
+    await client.query("rollback").catch(() => {});
+    throw error;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const url = databaseUrl();
+  if (!url) throw new Error("SUPABASE_DB_URL is required");
+  const trackedChanges = gitValue([
+    "status",
+    "--porcelain",
+    "--untracked-files=no",
+  ]);
+  if (args.apply && trackedChanges) {
+    throw new Error("incremental assignment apply requires a clean tracked working tree");
+  }
+
+  const client = new Client({
+    connectionString: url,
+    ssl: sslConfig(url),
+    connectionTimeoutMillis: 15_000,
+    statement_timeout: args.timeoutMinutes * 60_000,
+    query_timeout: args.timeoutMinutes * 60_000 + 5_000,
+  });
+  await client.connect();
+  const runDir = path.join(args.outRoot, stamp());
+  await fs.mkdir(runDir, { recursive: true });
+
+  try {
+    await client.query(
+      "select set_config('statement_timeout', $1, false)",
+      [`${args.timeoutMinutes}min`],
+    );
+    const acquisitionRun = await selectAcquisitionRun(
+      client,
+      args.acquisitionRunId,
+    );
+    const runPlan = {
+      worker_version: WORKER_VERSION,
+      assignment_version: ASSIGNMENT_VERSION,
+      mode: args.apply ? "apply" : "dry_run",
+      commit_sha: gitValue(["rev-parse", "HEAD"]),
+      branch: gitValue(["branch", "--show-current"]),
+      created_at: new Date().toISOString(),
+      acquisition_run: acquisitionRun,
+      max_candidates: args.maxCandidates,
+      batch_size: args.batchSize,
+      timeout_minutes: args.timeoutMinutes,
+      boundaries: {
+        provider_calls: false,
+        source_evidence_updates: false,
+        canonical_identity_writes: false,
+        pricing_publication_writes: false,
+        variant_assignment_inserts: args.apply,
+        assignments_require_review: true,
+        assignments_publishable: false,
+        assignments_app_visible: false,
+        assignments_market_truth: false,
+      },
+    };
+    const runPlanContents = `${JSON.stringify(runPlan, null, 2)}\n`;
+    await fs.writeFile(path.join(runDir, "run_plan.json"), runPlanContents);
+
+    const startedAt = new Date().toISOString();
+    const batches = [];
+    let processed = 0;
+    let complete = false;
+    while (processed < args.maxCandidates) {
+      const batchLimit = Math.min(
+        args.batchSize,
+        args.maxCandidates - processed,
+      );
+      const candidateIds = await selectMissingCandidateIds(
+        client,
+        acquisitionRun.id,
+        batchLimit,
+      );
+      if (!candidateIds.length) {
+        complete = true;
+        break;
+      }
+
+      const batchNumber = batches.length + 1;
+      const selectionContents = candidateIds
+        .map((candidateId) => JSON.stringify({ candidate_id: candidateId }))
+        .join("\n") + "\n";
+      const selectionName = `selected_candidates_${String(batchNumber).padStart(3, "0")}.jsonl`;
+      await fs.writeFile(path.join(runDir, selectionName), selectionContents);
+      const byStatus = await processBatch(client, candidateIds, args.apply);
+      batches.push({
+        batch_number: batchNumber,
+        selected_count: candidateIds.length,
+        selected_sha256: sha256(selectionContents),
+        projected_or_inserted_by_status: byStatus,
+      });
+      processed += candidateIds.length;
+      if (!args.apply) break;
+    }
+
+    if (args.apply && !complete) {
+      const remaining = await selectMissingCandidateIds(
+        client,
+        acquisitionRun.id,
+        1,
+      );
+      complete = remaining.length === 0;
+    }
+
+    const summary = {
+      worker_version: WORKER_VERSION,
+      status: args.apply
+        ? complete
+          ? "passed"
+          : "partial"
+        : "planned",
+      mode: runPlan.mode,
+      acquisition_run_id: acquisitionRun.id,
+      selected_or_inserted_count: processed,
+      acquisition_run_complete: complete,
+      batches,
+      started_at: startedAt,
+      finished_at: new Date().toISOString(),
+    };
+    const summaryContents = `${JSON.stringify(summary, null, 2)}\n`;
+    await fs.writeFile(path.join(runDir, "summary.json"), summaryContents);
+    await fs.writeFile(
+      path.join(runDir, "artifact_hashes.json"),
+      `${JSON.stringify(
+        {
+          "run_plan.json": sha256(runPlanContents),
+          "summary.json": sha256(summaryContents),
+          ...Object.fromEntries(
+            batches.map((batch) => [
+              `selected_candidates_${String(batch.batch_number).padStart(3, "0")}.jsonl`,
+              batch.selected_sha256,
+            ]),
+          ),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          ...summary,
+          artifact_root: path.relative(REPO_ROOT, runDir).replace(/\\/g, "/"),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    if (args.apply && !complete) process.exitCode = 2;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(`[variant-assignment-incremental] ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
+++ b/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
@@ -507,7 +507,10 @@ async function main() {
         projected_or_inserted_by_status: byStatus,
       });
       processed += candidateIds.length;
-      if (!args.apply) break;
+      if (!args.apply) {
+        complete = candidateIds.length < batchLimit;
+        break;
+      }
     }
 
     if (args.apply && !complete) {

--- a/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
+++ b/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
@@ -50,7 +50,7 @@ function parseArgs(argv) {
 
   if (
     args.acquisitionRunId &&
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
       args.acquisitionRunId,
     )
   ) {

--- a/scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs
+++ b/scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs
@@ -85,7 +85,11 @@ async function readback(client) {
          count(*) filter (
            where currency <> 'USD'
               or lowest_active_ask is null
-              or lowest_active_ask < 0
+              or lowest_active_ask <= 0
+              or median_active_ask is null
+              or round(median_active_ask, 2) < round(lowest_active_ask, 2)
+              or listing_count < 1
+              or seller_count < 0
          )::integer as invalid_row_count,
          count(*) filter (
            where observed_at < now() - interval '72 hours'

--- a/scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs
+++ b/scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs
@@ -97,6 +97,23 @@ async function readback(client) {
   ).rows[0];
 }
 
+async function configureRefreshSession(client, timeoutMinutes) {
+  await client.query(
+    "select set_config('statement_timeout', $1, false)",
+    [`${timeoutMinutes}min`],
+  );
+  await client.query(
+    "select set_config('enable_nestloop', 'off', false)",
+  );
+  return (
+    await client.query(
+      `select
+         current_setting('statement_timeout') as statement_timeout,
+         current_setting('enable_nestloop') as enable_nestloop`,
+    )
+  ).rows[0];
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const url = databaseUrl();
@@ -121,6 +138,10 @@ async function main() {
     created_at: new Date().toISOString(),
     materialized_view: MATERIALIZED_VIEW,
     timeout_minutes: args.timeoutMinutes,
+    database_session_policy: {
+      statement_timeout: `${args.timeoutMinutes}min`,
+      enable_nestloop: "off",
+    },
     boundaries: {
       canonical_identity_writes: false,
       price_publication_writes: false,
@@ -140,6 +161,10 @@ async function main() {
   });
   await client.connect();
   try {
+    const databaseSession = await configureRefreshSession(
+      client,
+      args.timeoutMinutes,
+    );
     const before = await readback(client);
     const startedAt = new Date().toISOString();
     if (args.apply) {
@@ -158,6 +183,7 @@ async function main() {
       mode: runPlan.mode,
       started_at: startedAt,
       finished_at: new Date().toISOString(),
+      database_session: databaseSession,
       before,
       after,
       findings: [

--- a/supabase/migrations/20260803183000_market_intelligence_read_model_v1.sql
+++ b/supabase/migrations/20260803183000_market_intelligence_read_model_v1.sql
@@ -1,0 +1,153 @@
+-- MARKET_INTELLIGENCE_READ_MODEL_V1
+-- Signed-in, exact-printing active-ask intelligence.
+-- TCGPlayer Market remains the pricing authority. This function exposes no
+-- completed-sale or market-value claim and never reads the raw warehouse.
+
+begin;
+
+create or replace function public.get_market_intelligence_read_model_v1(
+  p_card_print_ids uuid[] default null,
+  p_card_printing_ids uuid[] default null
+)
+returns table (
+  market_intelligence_version text,
+  card_print_id uuid,
+  card_printing_id uuid,
+  printing_gv_id text,
+  finish_key text,
+  status text,
+  unavailable_reason text,
+  currency text,
+  lowest_active_ask numeric,
+  median_active_ask numeric,
+  listing_count integer,
+  seller_count integer,
+  ask_spread numeric,
+  ask_spread_pct numeric,
+  observed_at timestamptz,
+  freshness text,
+  evidence_strength text,
+  source_name text,
+  source_label text,
+  evidence_kind text,
+  is_market_value boolean,
+  is_completed_sale boolean
+)
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  with requested_printings as materialized (
+    select requested.card_printing_id
+    from (
+      select unnest(coalesce(p_card_printing_ids, '{}'::uuid[])) as card_printing_id
+
+      union
+
+      select printing.id
+      from unnest(coalesce(p_card_print_ids, '{}'::uuid[])) parent(card_print_id)
+      join public.card_printings printing
+        on printing.card_print_id = parent.card_print_id
+    ) requested
+    where requested.card_printing_id is not null
+    order by requested.card_printing_id
+    limit 500
+  ),
+  evidence as materialized (
+    select
+      requested.card_printing_id,
+      active_ask.card_print_id,
+      active_ask.printing_gv_id,
+      active_ask.finish_key,
+      active_ask.currency,
+      active_ask.lowest_active_ask,
+      active_ask.median_active_ask,
+      active_ask.listing_count,
+      active_ask.seller_count,
+      active_ask.observed_at,
+      active_ask.currency = 'USD'
+        and active_ask.lowest_active_ask > 0
+        and active_ask.median_active_ask >= active_ask.lowest_active_ask
+        and active_ask.listing_count >= 1
+        and active_ask.seller_count >= 0
+        and active_ask.observed_at >= now() - interval '72 hours' as is_usable
+    from requested_printings requested
+    left join public.mv_market_listing_active_ask_current_v1 active_ask
+      on active_ask.card_printing_id = requested.card_printing_id
+  )
+  select
+    'MARKET_INTELLIGENCE_READ_MODEL_V1'::text,
+    printing.card_print_id,
+    printing.id,
+    printing.printing_gv_id,
+    printing.finish_key,
+    case
+      when evidence.card_print_id is null then 'unavailable'
+      when evidence.is_usable is not true then 'unavailable'
+      else 'available'
+    end::text,
+    case
+      when evidence.card_print_id is null then 'no_exact_active_ask_evidence'
+      when evidence.observed_at < now() - interval '72 hours'
+        then 'stale_active_ask_snapshot'
+      when evidence.is_usable is not true then 'invalid_active_ask_evidence'
+      else null
+    end::text,
+    case when evidence.is_usable then evidence.currency else null end,
+    case when evidence.is_usable then evidence.lowest_active_ask else null end,
+    case when evidence.is_usable then evidence.median_active_ask else null end,
+    case when evidence.is_usable then evidence.listing_count else 0 end,
+    case when evidence.is_usable then evidence.seller_count else 0 end,
+    case
+      when evidence.is_usable then round(
+        greatest(evidence.median_active_ask - evidence.lowest_active_ask, 0),
+        2
+      )
+      else null
+    end,
+    case
+      when evidence.is_usable and evidence.median_active_ask > 0 then round(
+        greatest(
+          ((evidence.median_active_ask - evidence.lowest_active_ask)
+            / evidence.median_active_ask) * 100,
+          0
+        ),
+        2
+      )
+      else null
+    end,
+    case when evidence.is_usable then evidence.observed_at else null end,
+    case
+      when evidence.card_print_id is null then 'unavailable'
+      when evidence.is_usable then 'fresh'
+      else 'stale'
+    end::text,
+    case
+      when not coalesce(evidence.is_usable, false) then null
+      when evidence.listing_count >= 5 and evidence.seller_count >= 3 then 'strong'
+      when evidence.listing_count >= 2 and evidence.seller_count >= 2 then 'moderate'
+      else 'limited'
+    end::text,
+    'ebay_active'::text,
+    'eBay active asks'::text,
+    'active_listing_ask'::text,
+    false,
+    false
+  from requested_printings requested
+  join public.card_printings printing
+    on printing.id = requested.card_printing_id
+  left join evidence
+    on evidence.card_printing_id = requested.card_printing_id
+  order by printing.card_print_id, printing.finish_key, printing.id;
+$$;
+
+revoke all on function public.get_market_intelligence_read_model_v1(uuid[], uuid[])
+  from public, anon, authenticated, service_role;
+grant execute on function public.get_market_intelligence_read_model_v1(uuid[], uuid[])
+  to authenticated, service_role;
+
+comment on function public.get_market_intelligence_read_model_v1(uuid[], uuid[]) is
+  'Authenticated exact-printing eBay active-ask intelligence. Values are asking-price evidence, not TCGPlayer Market, completed sales, or Grookai Value.';
+
+commit;

--- a/supabase/migrations/20260803190000_active_ask_currency_precision_v1.sql
+++ b/supabase/migrations/20260803190000_active_ask_currency_precision_v1.sql
@@ -1,0 +1,56 @@
+-- ACTIVE_ASK_CURRENCY_PRECISION_V1
+-- Normalize USD active-listing evidence to cents before it reaches the
+-- materialized product snapshot. This changes no source evidence rows.
+
+begin;
+
+create or replace view public.v_market_listing_variant_active_ask_exact_v1 as
+with exact_listings as (
+  select
+    assignment.card_print_id,
+    assignment.card_printing_id,
+    assignment.printing_gv_id,
+    assignment.assigned_finish_key as finish_key,
+    observation.seller_key,
+    observation.total_ask_price::numeric as total_ask_price,
+    observation.currency,
+    observation.observed_at
+  from public.market_listing_card_candidates candidate
+  join public.market_evidence_variant_assignments assignment
+    on assignment.source_family = 'market_listing'
+   and assignment.source_table = 'market_listing_card_candidates'
+   and assignment.source_row_id = candidate.id
+   and assignment.variant_assignment_version = 'MEE_VARIANT_ASSIGNMENT_RULES_V1'
+   and assignment.variant_assignment_status = 'exact_child_finish'
+   and assignment.card_printing_id is not null
+  join public.market_listing_observations observation
+    on observation.id = candidate.observation_id
+  where observation.currency = 'USD'
+    and observation.total_ask_price > 0
+    and observation.observed_at >= now() - interval '72 hours'
+    and coalesce(
+      candidate.condition_features -> 'slab_features' ->> 'is_slab',
+      'false'
+    ) <> 'true'
+)
+select
+  card_print_id,
+  card_printing_id,
+  printing_gv_id,
+  finish_key,
+  'USD'::text as currency,
+  round(min(total_ask_price)::numeric, 2) as lowest_active_ask,
+  round(
+    (percentile_cont(0.5) within group (order by total_ask_price))::numeric,
+    2
+  ) as median_active_ask,
+  count(*)::integer as listing_count,
+  count(distinct seller_key)::integer as seller_count,
+  max(observed_at) as observed_at
+from exact_listings
+group by card_print_id, card_printing_id, printing_gv_id, finish_key;
+
+comment on view public.v_market_listing_variant_active_ask_exact_v1 is
+  'Exact-printing USD active asks normalized to currency precision. Internal evidence only; not completed sales or market value.';
+
+commit;

--- a/tests/contracts/market_intelligence_read_model_v1.test.mjs
+++ b/tests/contracts/market_intelligence_read_model_v1.test.mjs
@@ -9,6 +9,9 @@ function source(relativePath) {
 const migration = source(
   "supabase/migrations/20260803183000_market_intelligence_read_model_v1.sql",
 );
+const precisionMigration = source(
+  "supabase/migrations/20260803190000_active_ask_currency_precision_v1.sql",
+);
 const readback = source("docs/sql/market_intelligence_read_model_v1_readback.sql");
 const contract = source("docs/contracts/MARKET_INTELLIGENCE_READ_MODEL_V1.md");
 const helper = source(
@@ -95,4 +98,17 @@ test("active-ask snapshot refresh uses a bounded hardened database session", () 
   assert.match(refreshWorker, /statement_timeout/);
   assert.match(refreshWorker, /enable_nestloop/);
   assert.match(refreshWorker, /refresh materialized view concurrently public\.mv_market_listing_active_ask_current_v1/i);
+  assert.match(refreshWorker, /round\(median_active_ask, 2\) < round\(lowest_active_ask, 2\)/);
+});
+
+test("active asks are normalized to positive USD currency precision before snapshotting", () => {
+  assert.match(precisionMigration, /observation\.total_ask_price > 0/);
+  assert.match(
+    precisionMigration,
+    /round\(min\(total_active_ask_price\)|round\(min\(total_ask_price\)::numeric, 2\)/,
+  );
+  assert.match(precisionMigration, /round\([\s\S]*percentile_cont\(0\.5\)/);
+  assert.doesNotMatch(precisionMigration, /update public\./i);
+  assert.doesNotMatch(precisionMigration, /delete from public\./i);
+  assert.doesNotMatch(precisionMigration, /insert into public\./i);
 });

--- a/tests/contracts/market_intelligence_read_model_v1.test.mjs
+++ b/tests/contracts/market_intelligence_read_model_v1.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function source(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+}
+
+const migration = source(
+  "supabase/migrations/20260803183000_market_intelligence_read_model_v1.sql",
+);
+const readback = source("docs/sql/market_intelligence_read_model_v1_readback.sql");
+const contract = source("docs/contracts/MARKET_INTELLIGENCE_READ_MODEL_V1.md");
+const helper = source(
+  "apps/web/src/lib/pricing/marketIntelligenceReadModelV1.ts",
+);
+const route = source("apps/web/src/app/api/card-pricing/route.ts");
+const rail = source("apps/web/src/components/pricing/CardPagePricingRail.tsx");
+const refreshWorker = source(
+  "scripts/workers/tcgplayer_market_active_ask_refresh_v1.mjs",
+);
+
+test("read model is bounded, exact-printing, and snapshot-only", () => {
+  assert.match(migration, /get_market_intelligence_read_model_v1/);
+  assert.match(migration, /limit 500/i);
+  assert.match(migration, /card_printing_id/);
+  assert.match(migration, /mv_market_listing_active_ask_current_v1/);
+  assert.doesNotMatch(migration, /market_listing_candidates/);
+  assert.doesNotMatch(migration, /market_evidence_variant_assignments/);
+  assert.doesNotMatch(migration, /market_listing_observations/);
+});
+
+test("read model suppresses stale or invalid active-ask evidence", () => {
+  assert.match(migration, /interval '72 hours'/);
+  assert.match(migration, /invalid_active_ask_evidence/);
+  assert.match(migration, /stale_active_ask_snapshot/);
+  assert.match(migration, /case when evidence\.is_usable then evidence\.lowest_active_ask else null end/);
+  assert.match(migration, /case when evidence\.is_usable then evidence\.median_active_ask else null end/);
+  assert.match(migration, /active_ask\.currency = 'USD'/);
+  assert.match(migration, /evidence\.is_usable is not true/);
+});
+
+test("read model preserves authority and signed-in boundaries", () => {
+  assert.match(migration, /'ebay_active'::text/);
+  assert.match(migration, /'active_listing_ask'::text/);
+  assert.match(migration, /false,\s*false/);
+  assert.match(migration, /security definer/);
+  assert.match(migration, /set search_path = pg_catalog, public/);
+  assert.match(migration, /revoke all[\s\S]*from public, anon, authenticated, service_role/i);
+  assert.match(migration, /grant execute[\s\S]*to authenticated, service_role/i);
+  assert.doesNotMatch(migration, /grant execute[\s\S]*to (public|anon)/i);
+  assert.match(contract, /TCGPlayer `marketPrice` remains the Production V1 market close/);
+});
+
+test("web mapper accepts only fresh exact evidence with explicit non-price authority", () => {
+  assert.match(helper, /MARKET_INTELLIGENCE_READ_MODEL_V1/);
+  assert.match(helper, /row\.is_market_value !== false/);
+  assert.match(helper, /row\.is_completed_sale !== false/);
+  assert.match(helper, /row\.evidence_kind !== "active_listing_ask"/);
+  assert.match(helper, /row\.freshness !== "fresh"/);
+  assert.match(helper, /medianActiveAsk < lowestActiveAsk/);
+  assert.match(helper, /get_market_intelligence_read_model_v1/);
+});
+
+test("signed-in card pricing endpoint returns both governed lanes", () => {
+  assert.match(route, /getMarketIntelligenceReadModelV1/);
+  assert.match(route, /Promise\.all/);
+  assert.match(route, /marketIntelligenceRecords/);
+  assert.match(route, /Sign in required\./);
+});
+
+test("card rail exposes evidence density without calling asks market value", () => {
+  assert.match(rail, /Available Today/);
+  assert.match(rail, /Lowest exact-printing eBay active ask/);
+  assert.match(rail, /Median ask/);
+  assert.match(rail, /active listings across/);
+  assert.match(rail, /Lowest-to-median spread/);
+  assert.match(rail, /evidence_strength/);
+  assert.match(rail, /not a sale or market close\. It is not a market value\./);
+  assert.doesNotMatch(rail, /Grookai Value/);
+});
+
+test("production readback proves grants, authority, freshness, and snapshot validity", () => {
+  assert.match(readback, /anon_execute/);
+  assert.match(readback, /authenticated_execute/);
+  assert.match(readback, /service_role_execute/);
+  assert.match(readback, /invalid_rows/);
+  assert.match(readback, /stale_rows/);
+  assert.match(readback, /market_value_claim_rows/);
+  assert.match(readback, /completed_sale_claim_rows/);
+  assert.match(readback, /authority_mismatch_rows/);
+});
+
+test("active-ask snapshot refresh uses a bounded hardened database session", () => {
+  assert.match(refreshWorker, /statement_timeout/);
+  assert.match(refreshWorker, /enable_nestloop/);
+  assert.match(refreshWorker, /refresh materialized view concurrently public\.mv_market_listing_active_ask_current_v1/i);
+});

--- a/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
+++ b/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
@@ -39,6 +39,7 @@ test("incremental assignment worker is idempotent and reconciles every selected 
   assert.match(worker, /incremental assignment apply requires a clean tracked working tree/);
   assert.match(worker, /selected_candidates_/);
   assert.match(worker, /selected_sha256/);
+  assert.match(worker, /complete = candidateIds\.length < batchLimit/);
 });
 
 test("incremental assignment worker preserves the governed variant ontology", () => {

--- a/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
+++ b/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
@@ -17,6 +17,7 @@ test("incremental assignment worker is dry-run by default and acquisition-bounde
   assert.match(worker, /--max-candidates=/);
   assert.match(worker, /--batch-size=/);
   assert.match(worker, /limit \$3/);
+  assert.doesNotMatch(worker, /\[1-5\]\[0-9a-f\]\{3\}/);
 });
 
 test("incremental assignment worker preserves evidence and publication boundaries", () => {

--- a/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
+++ b/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const worker = readFileSync(
+  new URL(
+    "../../scripts/workers/market_listing_variant_assignment_incremental_v1.mjs",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("incremental assignment worker is dry-run by default and acquisition-bounded", () => {
+  assert.match(worker, /apply: false/);
+  assert.match(worker, /--acquisition-run-id=/);
+  assert.match(worker, /observation\.acquisition_run_id = \$1/);
+  assert.match(worker, /--max-candidates=/);
+  assert.match(worker, /--batch-size=/);
+  assert.match(worker, /limit \$3/);
+});
+
+test("incremental assignment worker preserves evidence and publication boundaries", () => {
+  assert.match(worker, /provider_calls: false/);
+  assert.match(worker, /source_evidence_updates: false/);
+  assert.match(worker, /canonical_identity_writes: false/);
+  assert.match(worker, /pricing_publication_writes: false/);
+  assert.match(worker, /true, false, false, false/);
+  assert.doesNotMatch(worker, /update public\.market_listing/i);
+  assert.doesNotMatch(worker, /delete from public\./i);
+});
+
+test("incremental assignment worker is idempotent and reconciles every selected row", () => {
+  assert.match(
+    worker,
+    /on conflict \(source_family, source_row_id, variant_assignment_version\) do nothing/,
+  );
+  assert.match(worker, /Batch reconciliation failed/);
+  assert.match(worker, /incremental assignment apply requires a clean tracked working tree/);
+  assert.match(worker, /selected_candidates_/);
+  assert.match(worker, /selected_sha256/);
+});
+
+test("incremental assignment worker preserves the governed variant ontology", () => {
+  assert.match(worker, /MEE_VARIANT_ASSIGNMENT_RULES_V1/);
+  assert.match(worker, /exact_child_finish/);
+  assert.match(worker, /single_child_inferred/);
+  assert.match(worker, /unknown_finish_needs_review/);
+  assert.match(worker, /no_matching_child_finish/);
+  assert.match(worker, /ambiguous_finish_conflict/);
+  assert.match(worker, /parent_has_no_child/);
+  assert.match(worker, /normalize_market_evidence_finish_key_v1/);
+});

--- a/tests/contracts/tcgplayer_market_read_model_performance_migration_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_read_model_performance_migration_v1.test.mjs
@@ -115,6 +115,30 @@ test("active asks refresh in the background and not inside product reads", () =>
   );
   assert.match(REFRESH_WORKER, /active-ask refresh apply requires a clean tracked working tree/i);
   assert.match(REFRESH_WORKER, /active_ask_cache_write:\s*args\.apply/i);
+  assert.match(
+    REFRESH_WORKER,
+    /select set_config\('statement_timeout', \$1, false\)/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /select set_config\('enable_nestloop', 'off', false\)/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /current_setting\('statement_timeout'\) as statement_timeout/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /current_setting\('enable_nestloop'\) as enable_nestloop/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /database_session_policy:\s*\{[\s\S]*statement_timeout:[\s\S]*enable_nestloop:\s*"off"/i,
+  );
+  assert.match(
+    REFRESH_WORKER,
+    /database_session:\s*databaseSession/i,
+  );
   assert.doesNotMatch(REFRESH_WORKER, /\b(insert|update|delete)\s+(?:into|from|public\.)/i);
   assert.match(PIPELINE, /phase:\s*"active_ask_refresh"/);
   assert.match(PIPELINE, /activationMode \? "--apply" : "--dry-run"/);


### PR DESCRIPTION
## Summary
- add a separate signed-in exact-printing active-ask read model
- show lowest/median ask, listing/seller coverage, spread, freshness, and evidence strength on card detail
- add bounded incremental variant assignment for fresh acquisition runs
- preserve TCGPlayer Market as the Production V1 market authority

## Production database proof
- 7,088 review-only sidecar assignments inserted from one frozen acquisition run
- 527 exact-printing snapshot rows across 377 cards
- 0 invalid, stale, non-USD, or authority-mismatch rows
- anon RPC execute denied; authenticated/service_role granted
- 25-printing direct RPC proof: about 217 ms

## Verification
- relevant pricing/MEE contracts: 749/749
- TypeScript: passed
- ESLint: passed
- Next.js production build: passed
- Contracts Drift Gate: passed
- Contracts Runtime Protection: passed

## Boundaries
- no canonical identity writes
- no source evidence mutation
- no pricing publication or Vault writes
- no provider acquisition
- no completed-sale, market-value, or Grookai Value claim

Checkpoint: docs/checkpoints/pricing/PRICING_CHECKPOINT_41_MARKET_INTELLIGENCE_READ_MODEL_V1.md