### PR TITLE
fix(pricing): pluralize active ask counts

### DIFF
--- a/apps/web/src/components/pricing/CardPagePricingRail.tsx
+++ b/apps/web/src/components/pricing/CardPagePricingRail.tsx
@@ -182,8 +182,12 @@ function ActiveAskBlock({
             </div>
           </div>
           <p className="text-xs leading-5 text-slate-500">
-            {marketIntelligence.listing_count} active listings across{" "}
-            {marketIntelligence.seller_count} sellers · Lowest-to-median spread{" "}
+            {marketIntelligence.listing_count} active{" "}
+            {marketIntelligence.listing_count === 1 ? "listing" : "listings"}{" "}
+            across{" "}
+            {marketIntelligence.seller_count}{" "}
+            {marketIntelligence.seller_count === 1 ? "seller" : "sellers"}{" "}
+            · Lowest-to-median spread{" "}
             {formatUsdPrice(marketIntelligence.ask_spread)} ({marketIntelligence.ask_spread_pct.toFixed(2)}%)
           </p>
           <p className="text-[11px] leading-5 text-slate-400">

--- a/tests/contracts/market_intelligence_read_model_v1.test.mjs
+++ b/tests/contracts/market_intelligence_read_model_v1.test.mjs
@@ -76,7 +76,8 @@ test("card rail exposes evidence density without calling asks market value", () 
   assert.match(rail, /Available Today/);
   assert.match(rail, /Lowest exact-printing eBay active ask/);
   assert.match(rail, /Median ask/);
-  assert.match(rail, /active listings across/);
+  assert.match(rail, /listing_count === 1 \? "listing" : "listings"/);
+  assert.match(rail, /seller_count === 1 \? "seller" : "sellers"/);
   assert.match(rail, /Lowest-to-median spread/);
   assert.match(rail, /evidence_strength/);
   assert.match(rail, /not a sale or market close\. It is not a market value\./);


### PR DESCRIPTION
## Summary
- render singular listing/seller labels for exact-printing active-ask evidence
- preserve plural labels for larger evidence sets
- add source-level contract coverage

## Verification
- node --test tests/contracts/market_intelligence_read_model_v1.test.mjs
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run lint
- git diff --check

## Production smoke finding
The initial Market Intelligence V1 deployment passed exact-printing isolation. The Poké Ball lane exposed only this copy defect: one listing and one seller rendered with plural nouns.