### PR TITLE
fix(pricing): bound incremental assignment selection

### DIFF
--- a/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
+++ b/scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
@@ -159,7 +159,7 @@ async function selectMissingCandidateIds(client, acquisitionRunId, limit) {
            and existing.source_row_id = candidate.id
            and existing.variant_assignment_version = $2
        )
-     order by candidate.id
+     order by observation.id, candidate.id
      limit $3`,
     [acquisitionRunId, ASSIGNMENT_VERSION, limit],
   );

--- a/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
+++ b/tests/contracts/market_listing_variant_assignment_incremental_v1.test.mjs
@@ -17,6 +17,8 @@ test("incremental assignment worker is dry-run by default and acquisition-bounde
   assert.match(worker, /--max-candidates=/);
   assert.match(worker, /--batch-size=/);
   assert.match(worker, /limit \$3/);
+  assert.match(worker, /order by observation\.id, candidate\.id/);
+  assert.doesNotMatch(worker, /order by candidate\.id\s+limit \$3/);
   assert.doesNotMatch(worker, /\[1-5\]\[0-9a-f\]\{3\}/);
 });
 


### PR DESCRIPTION
## Summary
- preserve deterministic selection using the existing acquisition/observation index order
- avoid the candidate-ID-only sort that scanned the wider warehouse
- add contract coverage for the bounded index path

## Offline verification
- node --check scripts/workers/market_listing_variant_assignment_incremental_v1.mjs
- 13/13 targeted Market Intelligence contracts
- git diff --check

## Production dry/apply canary
- source commit: fee911873757f61124cbf4dc7006eb9807e4e3ef
- acquisition: 87aa84ce-2496-532d-5b68-45dabcdeacef
- 10,000-row ceiling
- dry-run completed in 15.7 seconds
- dry/apply selection SHA-256 matched: d34170f1d68375bb2d9a28314dd3773670f07501181532a50f62fbf4f3431bc1
- 10,000 rows reconciled, zero public-boundary leaks
- snapshot refresh passed: 3,227 rows, zero invalid/stale/duplicate rows

The apply reports partial only because the completed acquisition has additional rows beyond the approved 10,000-row canary ceiling. No remainder was processed and no unattended schedule was enabled.