### PR TITLE
fix(ios): upload Crashlytics release symbols

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				45A8DC11EE67A4129EBB6F70 /* [CP] Embed Pods Frameworks */,
+				D5A9C0E7B3F14A829D6E7101 /* [firebase_crashlytics] Upload Symbols */,
 			);
 			buildRules = (
 			);
@@ -380,6 +381,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D5A9C0E7B3F14A829D6E7101 /* [firebase_crashlytics] Upload Symbols */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "[firebase_crashlytics] Upload Symbols";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${CONFIGURATION}\" = \"Debug\" ]; then\n  echo \"Skipping Crashlytics symbol upload for Debug configuration.\"\n  exit 0\nfi\nif [ -z \"${FIREBASE_IOS_APP_ID:-}\" ]; then\n  echo \"error: FIREBASE_IOS_APP_ID is required for Crashlytics symbol upload.\" >&2\n  exit 1\nfi\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" --app-id \"${FIREBASE_IOS_APP_ID}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/scripts/write_ios_xcode_secrets.rb
+++ b/scripts/write_ios_xcode_secrets.rb
@@ -79,6 +79,17 @@ unless missing.empty?
   exit 1
 end
 
+firebase_options_path = File.join('lib', 'firebase_options.dart')
+firebase_options = File.read(firebase_options_path)
+ios_options = firebase_options.match(
+  /static const FirebaseOptions ios = FirebaseOptions\((.*?)\n\s*\);/m
+)&.[](1)
+firebase_ios_app_id = ios_options&.match(/appId:\s*'([^']+)'/)&.[](1)
+if firebase_ios_app_id.to_s.strip.empty?
+  warn "Missing iOS Firebase app ID in #{firebase_options_path}"
+  exit 1
+end
+
 encoded = (required_keys + ['GROOKAI_WEB_BASE_URL'] + binder_keys).map do |key|
   value = env[key].to_s
   value.empty? ? nil : Base64.strict_encode64("#{key}=#{value}")
@@ -87,6 +98,7 @@ end.compact.join(',')
 content = <<~XCCONFIG
   // Local generated file. Do not commit.
   DART_DEFINES=#{encoded}
+  FIREBASE_IOS_APP_ID=#{firebase_ios_app_id}
 XCCONFIG
 
 %w[DebugSecrets.xcconfig ReleaseSecrets.xcconfig].each do |name|

--- a/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
+++ b/tests/contracts/xcode_cloud_bootstrap_v1.test.mjs
@@ -95,6 +95,9 @@ test("Xcode Cloud injects required release configuration before archive", () => 
   assert.match(secretWriter, /value = ENV\[key\]\.to_s/);
   assert.match(secretWriter, /env\[key\] = value unless value\.strip\.empty\?/);
   assert.match(secretWriter, /DART_DEFINES=#\{encoded\}/);
+  assert.match(secretWriter, /firebase_options_path = File\.join\('lib', 'firebase_options\.dart'\)/);
+  assert.match(secretWriter, /firebase_ios_app_id = ios_options/);
+  assert.match(secretWriter, /FIREBASE_IOS_APP_ID=#\{firebase_ios_app_id\}/);
   assert.match(secretWriter, /binder_keys = %w\[/);
   for (const key of [
     "BINDERS_SCHEMA_V1",
@@ -165,4 +168,59 @@ test("Xcode Cloud uses a checked-in SwiftPM migration and resolution", () => {
     branch: "4.3.9",
     revision: "0bdfeacefa308545adde07bef86e349186335915",
   });
+});
+
+test("Xcode Cloud uploads release dSYMs to Firebase Crashlytics", () => {
+  const runnerTarget = project.match(
+    /97C146ED1CF9000F007C117D \/\* Runner \*\/ = \{[\s\S]*?\n\t\t\};/,
+  )?.[0];
+
+  assert.ok(runnerTarget, "Runner target must exist");
+  assert.match(
+    runnerTarget,
+    /45A8DC11EE67A4129EBB6F70 \/\* \[CP\] Embed Pods Frameworks \*\/,\s+D5A9C0E7B3F14A829D6E7101 \/\* \[firebase_crashlytics\] Upload Symbols \*\/,\s+\);/,
+    "Crashlytics symbol upload must be the final Runner build phase",
+  );
+
+  const uploadPhase = project.match(
+    /D5A9C0E7B3F14A829D6E7101 \/\* \[firebase_crashlytics\] Upload Symbols \*\/ = \{[\s\S]*?\n\t\t\};/,
+  )?.[0];
+
+  assert.ok(uploadPhase, "Crashlytics upload phase must exist");
+  assert.match(
+    uploadPhase,
+    /SourcePackages\/checkouts\/firebase-ios-sdk\/Crashlytics\/run/,
+  );
+  assert.match(
+    uploadPhase,
+    /\$\{DWARF_DSYM_FOLDER_PATH\}\/\$\{DWARF_DSYM_FILE_NAME\}/,
+  );
+  assert.match(
+    uploadPhase,
+    /Contents\/Resources\/DWARF\/\$\{PRODUCT_NAME\}/,
+  );
+  assert.match(
+    uploadPhase,
+    /Contents\/Resources\/DWARF\/\$\{PRODUCT_NAME\}\.debug\.dylib/,
+  );
+  assert.match(uploadPhase, /Contents\/Info\.plist/);
+  assert.match(
+    uploadPhase,
+    /\$\(TARGET_BUILD_DIR\)\/\$\(EXECUTABLE_PATH\)/,
+  );
+  assert.match(uploadPhase, /FIREBASE_IOS_APP_ID is required/);
+  assert.match(uploadPhase, /--app-id/);
+  assert.doesNotMatch(uploadPhase, /GoogleService-Info\.plist/);
+  assert.match(uploadPhase, /CONFIGURATION/);
+  assert.match(uploadPhase, /Debug/);
+  assert.match(uploadPhase, /Skipping Crashlytics symbol upload/);
+
+  const releaseDsymConfigs = project.match(
+    /DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";/g,
+  );
+  assert.equal(
+    releaseDsymConfigs?.length,
+    2,
+    "Profile and Release must both emit dSYMs",
+  );
 });


### PR DESCRIPTION
## Summary
- add the Firebase Crashlytics symbol upload as the final Runner build phase
- provide the iOS Firebase app ID to Xcode from the tracked FlutterFire options without packaging GoogleService-Info.plist
- lock the Xcode Cloud dSYM contract with tests

## Verification
- Xcode Cloud bootstrap contract: 8/8 passed
- release secret packaging guard: passed
- Ruby syntax: passed on macOS
- unsigned iOS Release build: passed on macOS
- generated arm64 Runner.app.dSYM: verified
- synchronous Firebase symbol upload: accepted
- full shipcheck reached Flutter tests; one unrelated existing failure remains in test/binders/binder_release_feature_flags_test.dart
- isolated world_championship_decklist_mobile_test.dart retry: passed

## Historical build 279
The exact dSYM UUID A6EB559F-F2C6-392A-8B4B-D70130FE16AB is not present in local Xcode archives. It still requires the Xcode Cloud archive to be downloaded and uploaded separately after App Store Connect authentication is restored.