### PR TITLE
CI: isolate platform-specific Flutter goldens

### DIFF
--- a/.github/workflows/flutter-build-apk.yml
+++ b/.github/workflows/flutter-build-apk.yml
@@ -56,7 +56,7 @@ jobs:
         run: flutter analyze
 
       - name: Test
-        run: flutter test --no-pub
+        run: flutter test --no-pub --concurrency=4 --exclude-tags golden
 
       - name: Build signed release APK
         run: |
@@ -69,3 +69,22 @@ jobs:
         with:
           name: signed-release-apk
           path: build/app/outputs/flutter-apk/app-release.apk
+
+  golden-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify renderer goldens
+        run: >-
+          flutter test --no-pub
+          test/grookai_objects/grookai_object_renderer_golden_test.dart

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,6 +1,7 @@
 name: Flutter CI
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'lib/**'

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "stable"
+          channel: "stable"
           cache: true
 
       - name: Flutter version
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "stable"
+          channel: "stable"
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -43,4 +43,25 @@ jobs:
         run: flutter analyze
 
       - name: Run tests
-        run: flutter test --no-pub
+        run: flutter test --no-pub --concurrency=4 --exclude-tags golden
+
+  golden-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "stable"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify renderer goldens
+        run: >-
+          flutter test --no-pub
+          test/grookai_objects/grookai_object_renderer_golden_test.dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: flutter analyze
 
       - name: Flutter tests
-        run: flutter test --no-pub
+        run: flutter test --no-pub --concurrency=4 --exclude-tags golden
 
       - name: Build signed Android app bundle
         run: |
@@ -118,3 +118,22 @@ jobs:
             build/app/outputs/bundle/release/app-release.aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  golden-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify renderer goldens
+        run: >-
+          flutter test --no-pub
+          test/grookai_objects/grookai_object_renderer_golden_test.dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build-release:
+    needs: golden-windows
     runs-on: ubuntu-latest
     env:
       ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/upload-keystore.jks

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  golden:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "preflight": "npm run grookai:preflight",
-    "shipcheck": "npm run release:secret-guard && npm run preflight && npm run contracts:test && npm run contracts:runtime-health && npm run contracts:quarantine-report && npm run contracts:deferred-report && npm --prefix apps/web run typecheck && npm --prefix apps/web run lint && npm run web:build:strict && flutter analyze && flutter test",
+    "shipcheck": "npm run release:secret-guard && npm run preflight && npm run contracts:test && npm run contracts:runtime-health && npm run contracts:quarantine-report && npm run contracts:deferred-report && npm --prefix apps/web run typecheck && npm --prefix apps/web run lint && npm run web:build:strict && flutter analyze && flutter test --concurrency=4",
     "jpn-master-index:baseline": "node scripts/audits/japanese_master_index_v4/baseline_export_v1.mjs",
     "jpn-master-index:reconcile": "node scripts/audits/japanese_master_index_v4/live_reconciliation_v1.mjs",
     "jpn-master-index:promotion-package": "node scripts/audits/japanese_master_index_v4/promotion_package_v1.mjs",

--- a/test/grookai_objects/grookai_object_renderer_golden_test.dart
+++ b/test/grookai_objects/grookai_object_renderer_golden_test.dart
@@ -1,3 +1,6 @@
+@Tags(['golden'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';


### PR DESCRIPTION
## Summary
- classify the Grookai Object renderer comparisons as golden tests
- run platform-independent Flutter tests on Linux with bounded concurrency
- run committed renderer goldens on Windows in CI, signed APK, and production Android release workflows
- bound local shipcheck Flutter concurrency to prevent compiler-process exhaustion

## Evidence
- full repository pre-commit shipcheck passed
- Flutter full suite: 570/570
- Flutter non-golden suite: 551/551
- Windows golden suite: 19/19
- diff check passed

## Failure repaired
The signed APK workflow on main SHA 7a074ac6 failed only because 18 Windows-authored golden baselines were compared on Linux (1.06%-4.35% pixel variance). The workflow did not reach APK assembly. This change keeps both test classes enforced on their deterministic runners.