### PR TITLE
Fix Vault set-count parity for release

### DIFF
--- a/apps/web/src/components/vault/VaultCollectionView.tsx
+++ b/apps/web/src/components/vault/VaultCollectionView.tsx
@@ -265,7 +265,9 @@ export function VaultCollectionView({
   const summary = useMemo(() => {
     const cards = items.reduce((sum, item) => sum + item.owned_count, 0);
     const uniqueCards = items.length;
-    const sets = new Set(items.map((item) => item.set_code.trim() || "Unknown set")).size;
+    const sets = new Set(
+      items.map((item) => item.set_name.trim() || item.set_code.trim() || "Unknown set"),
+    ).size;
     const latestTimestamp = items.reduce<string | null>((latest, item) => {
       if (!item.created_at) {
         return latest;

--- a/tests/contracts/release_vault_set_count_parity_v1.test.mjs
+++ b/tests/contracts/release_vault_set_count_parity_v1.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const webVaultPath = "apps/web/src/components/vault/VaultCollectionView.tsx";
+const flutterVaultPath = "lib/main_vault.dart";
+
+test("web and Flutter count Vault sets from canonical set names before legacy aliases", () => {
+  const webVault = fs.readFileSync(webVaultPath, "utf8");
+  const flutterVault = fs.readFileSync(flutterVaultPath, "utf8");
+
+  assert.match(
+    webVault,
+    /item\.set_name\.trim\(\) \|\| item\.set_code\.trim\(\) \|\| "Unknown set"/,
+  );
+  assert.doesNotMatch(
+    webVault,
+    /new Set\(items\.map\(\(item\) => item\.set_code\.trim\(\) \|\| "Unknown set"\)\)/,
+  );
+  assert.match(
+    flutterVault,
+    /row\['set_name'\] \?\? row\['set_code'\]/,
+  );
+});


### PR DESCRIPTION
## Summary
- count Vault sets by canonical set name before legacy set-code aliases
- keep Flutter and web collection summaries aligned
- add a release parity contract for the counting rule

## Verification
- pre-commit and pre-push `npm run shipcheck` passed
- 1,526 Node contract tests passed
- 570 Flutter tests passed
- web strict production build passed
- Flutter analyze passed

## Release evidence
Production data currently contains two legacy Paldean Fates codes (`sv04.5`, `sv4pt5`) for one canonical set name. Android already counts the canonical name; this makes web use the same governed identity.