### PR TITLE
Fix current Want Match truth boundary

### DIFF
--- a/docs/audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
+++ b/docs/audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
@@ -1,0 +1,72 @@
+# Want Match Current-Want Truth Repair V1
+
+## Status
+
+`LOCAL_VERIFIED / PRODUCTION_APPLY_PENDING`
+
+## Release Finding
+
+Final-candidate Android testing exposed two old Want Match items in Pulse. Opening one card showed `Want this card`, proving the current app intent no longer agreed with the retained match and event rows.
+
+The production read-only preflight found:
+
+- 2 total durable Want Match rows;
+- 2 active rows;
+- 2 retained `want_match_available` event rows;
+- 2 active rows without an exact current `user_card_intents.want=true` row.
+
+The two affected cards are Piplup and Blastoise & Piplup-GX. User and row identifiers are excluded from this audit; stable truncated SHA-256 references are retained in `want_match_current_want_production_preflight_v1.json`.
+
+## Root Cause
+
+`user_card_intents` is the app's current intent authority, while durable matches and historical Pulse events intentionally outlive their initiating write. The database had no synchronous opt-out transition and no scheduled stale cleanup. Pulse eligibility also accepted historical Want Match events without proving the durable match was still active and backed by a current exact-card want.
+
+## Repair
+
+Migration `20260807043000_want_match_current_want_truth_boundary_v1.sql`:
+
+1. Defines exact current-want truth from `user_card_intents`.
+2. Replaces local-community wishlist signals with that same predicate.
+3. Marks active matches stale immediately when a want is disabled, deleted, or moved.
+4. Filters Want Match Pulse events unless the referenced match remains active and the current exact want still exists.
+5. Marks existing active/current-want mismatches stale without deleting rows.
+6. Schedules the existing bounded owner-availability cleanup every 15 minutes.
+
+Historical durable matches and card events remain stored. Re-enabling the exact want allows the deterministic engine to reactivate the same match row without creating duplicate rows or events.
+
+## Local Proof
+
+- Migration applied to the local Supabase history.
+- Six expected functions read back.
+- All six affected functions are `SECURITY DEFINER`; execute grants are limited to `postgres` and `service_role`, with zero `anon` or `authenticated` grants.
+- Opt-out trigger read back enabled.
+- Scheduled cleanup read back active at `*/15 * * * *`.
+- Active/current-want mismatch count read back as zero.
+- E3 rollback-only journey proved current event -> want off -> stale/hidden -> same-row reactivation.
+- E4 rollback-only Pulse journey proved valid Want Match evidence, pagination, privacy filtering, unread state, and cursor monotonicity.
+- Targeted contracts: 9 passed, 0 failed.
+- Full contract suite: 1,544 passed, 0 failed.
+- Complete repository shipcheck passed: secret guard, runtime preflight with zero critical failures, operations reports, web typecheck/lint/production build, Flutter analysis, and 571 Flutter tests.
+- `git diff --check`: passed.
+
+## Safety Boundaries
+
+- No historical match or event deletion.
+- No canonical identity, Vault, pricing, or ownership mutation.
+- No client privilege expansion.
+- Exact current intent comes only from `user_card_intents.want=true` for the same user and `card_print_id`.
+- Production remained read-only during discovery and local verification.
+
+## Exact Next Gate
+
+Merge the repair from a frozen commit, apply only migration `20260807043000`, and reconcile production before/after counts. Completion requires:
+
+- migration-history readback;
+- function, trigger, grant, and cron readback;
+- both existing rows retained and transitioned from active to stale;
+- both historical event rows retained;
+- zero active/current-want mismatches;
+- the founder Pulse no longer returns either stale event;
+- final-candidate Android re-smoke confirms the stale cards are absent.
+
+This closes one P0 data-truth defect. It does not complete Journey C or authorize the 72-hour soak.

--- a/docs/audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
+++ b/docs/audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
@@ -21,6 +21,8 @@ The two affected cards are Piplup and Blastoise & Piplup-GX. User and row identi
 
 `user_card_intents` is the app's current intent authority, while durable matches and historical Pulse events intentionally outlive their initiating write. The database had no synchronous opt-out transition and no scheduled stale cleanup. Pulse eligibility also accepted historical Want Match events without proving the durable match was still active and backed by a current exact-card want.
 
+PR review exposed two additional recurrence paths. A queued notification could remain deliverable after opt-out, and an engine activation based on a stale candidate snapshot could commit after the opt-out trigger had already run. The delivery worker also lacked a final evidence check immediately before its FCM point of no return.
+
 ## Repair
 
 Migration `20260807043000_want_match_current_want_truth_boundary_v1.sql`:
@@ -28,24 +30,30 @@ Migration `20260807043000_want_match_current_want_truth_boundary_v1.sql`:
 1. Defines exact current-want truth from `user_card_intents`.
 2. Replaces local-community wishlist signals with that same predicate.
 3. Marks active matches stale immediately when a want is disabled, deleted, or moved.
-4. Filters Want Match Pulse events unless the referenced match remains active and the current exact want still exists.
-5. Marks existing active/current-want mismatches stale without deleting rows.
-6. Schedules the existing bounded owner-availability cleanup every 15 minutes.
+4. Serializes every active insert/reactivation against the exact current intent and converts unsupported activation to retained stale history.
+5. Cancels queued, unstarted instant and daily Want Match delivery when current evidence is removed.
+6. Rechecks current evidence both while claiming an outbox row and at the final pre-FCM send-start boundary.
+7. Uses deterministic intent-to-outbox lock order and rejects duplicate send starts.
+8. Filters Want Match Pulse events unless the referenced match remains active and the current exact want still exists.
+9. Marks existing active/current-want and queued-delivery drift terminally stale/failed without deleting rows.
+10. Schedules the existing bounded owner-availability cleanup every 15 minutes.
 
 Historical durable matches and card events remain stored. Re-enabling the exact want allows the deterministic engine to reactivate the same match row without creating duplicate rows or events.
 
 ## Local Proof
 
-- Migration applied to the local Supabase history.
-- Six expected functions read back.
-- All six affected functions are `SECURITY DEFINER`; execute grants are limited to `postgres` and `service_role`, with zero `anon` or `authenticated` grants.
-- Opt-out trigger read back enabled.
-- Scheduled cleanup read back active at `*/15 * * * *`.
-- Active/current-want mismatch count read back as zero.
-- E3 rollback-only journey proved current event -> want off -> stale/hidden -> same-row reactivation.
-- E4 rollback-only Pulse journey proved valid Want Match evidence, pagination, privacy filtering, unread state, and cursor monotonicity.
-- Targeted contracts: 9 passed, 0 failed.
-- Full contract suite: 1,544 passed, 0 failed.
+- The full migration history replayed from an empty local Supabase database, including migration `20260807043000`.
+- Ten affected functions read back as `SECURITY DEFINER`; execute ACLs are limited to `postgres` and `service_role`, with zero `anon` or `authenticated` grants.
+- Both opt-out and activation-enforcement triggers read back enabled.
+- The migration retains the `*/15 * * * *` cleanup schedule. Local `pg_cron` is unavailable, so production cron readback remains required.
+- Active/current-want mismatch and deliverable-without-current-evidence counts both read back as zero.
+- E3 engine smoke proved current event -> want off -> queued alert cancelled -> stale/hidden -> unsupported activation rejected -> same-row reactivation.
+- E3 delivery smoke proved instant dedupe and the E4 standalone-digest cutover.
+- E4 read smoke proved valid evidence, pagination, privacy filtering, unread state, and cursor monotonicity.
+- E4 daily smoke proved mixed Pulse authorization before opt-out and terminal cancellation after opt-out.
+- The final send boundary rejected invalid evidence, accepted valid evidence once, and rejected a duplicate start.
+- Targeted contracts: 19 passed, 0 failed.
+- Full contract suite: 1,547 passed, 0 failed.
 - Complete repository shipcheck passed: secret guard, runtime preflight with zero critical failures, operations reports, web typecheck/lint/production build, Flutter analysis, and 571 Flutter tests.
 - `git diff --check`: passed.
 
@@ -55,6 +63,8 @@ Historical durable matches and card events remain stored. Re-enabling the exact 
 - No canonical identity, Vault, pricing, or ownership mutation.
 - No client privilege expansion.
 - Exact current intent comes only from `user_card_intents.want=true` for the same user and `card_print_id`.
+- A queued or claimed row cannot cross the FCM send boundary without current evidence.
+- Once send-start is recorded, it is an explicit point of no return; duplicate send starts are rejected.
 - Production remained read-only during discovery and local verification.
 
 ## Exact Next Gate

--- a/docs/audits/release_completion_v1/want_match_current_want_artifact_hashes_v1.json
+++ b/docs/audits/release_completion_v1/want_match_current_want_artifact_hashes_v1.json
@@ -4,7 +4,7 @@
   "artifacts": [
     {
       "path": "supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql",
-      "sha256": "f578b0c4daa8f5da46a1b7e455591943fe19d2a01259c0d336786e5cb8b229da"
+      "sha256": "279ff56334079fc8858faba53eafa6d98162c7bcecc30f08f23e59c1cdf19959"
     },
     {
       "path": "docs/audits/release_completion_v1/want_match_current_want_production_preflight_v1.json",
@@ -12,15 +12,15 @@
     },
     {
       "path": "docs/audits/release_completion_v1/want_match_current_want_local_verification_v1.json",
-      "sha256": "507e6e4a4730ebdde03d3b633b0115d6a9d93cc7095c8e1a2bbcab56f215ffe5"
+      "sha256": "5cd44ac755d810c731c0d7e2abe370f092798de7e63318df5574c8c0121c8c15"
     },
     {
       "path": "docs/audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md",
-      "sha256": "569f6ed524d8f5c82f8fb59bd8db787411c382f855385897f31bc8d00d4cfd6f"
+      "sha256": "1eef4d3a786d82a5f3e75fc1d909caabfd981743566300d8b8cc9e59be6d4292"
     },
     {
       "path": "docs/checkpoints/product/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md",
-      "sha256": "843d5ff1672194eb95c1cdb8bc1d04aa697869d5c923f796f7f59a50bc1d4137"
+      "sha256": "53826de3e2b2ff0daece58443f1d90a448da7b09d88eb31cf000a4b9dae733fd"
     }
   ]
 }

--- a/docs/audits/release_completion_v1/want_match_current_want_artifact_hashes_v1.json
+++ b/docs/audits/release_completion_v1/want_match_current_want_artifact_hashes_v1.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "WANT_MATCH_CURRENT_WANT_ARTIFACT_HASHES_V1",
+  "hash_algorithm": "sha256",
+  "artifacts": [
+    {
+      "path": "supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql",
+      "sha256": "f578b0c4daa8f5da46a1b7e455591943fe19d2a01259c0d336786e5cb8b229da"
+    },
+    {
+      "path": "docs/audits/release_completion_v1/want_match_current_want_production_preflight_v1.json",
+      "sha256": "5751223958bbcfd5c53ef1634f2d3eaee4e5f8ea208cfd834b739866c905e778"
+    },
+    {
+      "path": "docs/audits/release_completion_v1/want_match_current_want_local_verification_v1.json",
+      "sha256": "507e6e4a4730ebdde03d3b633b0115d6a9d93cc7095c8e1a2bbcab56f215ffe5"
+    },
+    {
+      "path": "docs/audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md",
+      "sha256": "569f6ed524d8f5c82f8fb59bd8db787411c382f855385897f31bc8d00d4cfd6f"
+    },
+    {
+      "path": "docs/checkpoints/product/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md",
+      "sha256": "843d5ff1672194eb95c1cdb8bc1d04aa697869d5c923f796f7f59a50bc1d4137"
+    }
+  ]
+}

--- a/docs/audits/release_completion_v1/want_match_current_want_local_verification_v1.json
+++ b/docs/audits/release_completion_v1/want_match_current_want_local_verification_v1.json
@@ -1,36 +1,51 @@
 {
   "schema_version": "WANT_MATCH_CURRENT_WANT_LOCAL_VERIFICATION_V1",
-  "verified_at": "2026-08-07T04:29:00Z",
+  "verified_at": "2026-08-07T05:23:30Z",
   "branch": "release/want-match-truth-boundary-v1",
   "source_candidate_sha": "33d7ff50bda428439c664c7c6db427b7a66abd9a",
   "migration": {
     "version": "20260807043000",
     "path": "supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql",
-    "sha256": "f578b0c4daa8f5da46a1b7e455591943fe19d2a01259c0d336786e5cb8b229da",
+    "sha256": "279ff56334079fc8858faba53eafa6d98162c7bcecc30f08f23e59c1cdf19959",
+    "full_local_history_replay": "PASS",
     "local_history_present": true
   },
   "schema_readback": {
-    "expected_function_count": 6,
-    "actual_function_count": 6,
+    "expected_function_count": 10,
+    "actual_function_count": 10,
     "functions": [
       "binder_pulse_base_eligible_events_for_viewer_v1",
+      "enforce_current_want_match_activation_v1",
       "legacy_binder_pulse_base_eligible_events_v1",
       "legacy_local_community_visible_source_cards_v1",
       "local_community_visible_source_cards_v1",
+      "notification_dispatcher_claim_batch_v1",
+      "notification_dispatcher_mark_send_started_if_current_v1",
+      "notification_outbox_has_current_want_truth_v1",
       "stale_want_matches_when_intent_removed_v1",
       "viewer_has_current_card_want_v1"
     ],
-    "trigger": {
-      "name": "trg_stale_want_matches_when_intent_removed_v1",
-      "enabled": true
-    },
+    "triggers": [
+      {
+        "name": "trg_stale_want_matches_when_intent_removed_v1",
+        "table": "user_card_intents",
+        "enabled": true
+      },
+      {
+        "name": "trg_enforce_current_want_match_activation_v1",
+        "table": "want_matches",
+        "enabled": true
+      }
+    ],
     "cron": {
       "name": "grookai-want-match-stale-cleanup-v1",
       "schedule": "*/15 * * * *",
-      "active": true
+      "migration_contract_present": true,
+      "local_runtime_readback": "UNAVAILABLE_PG_CRON_NOT_INSTALLED",
+      "production_readback_required": true
     },
     "security_readback": {
-      "security_definer_function_count": 6,
+      "security_definer_function_count": 10,
       "execute_grantees": [
         "postgres",
         "service_role"
@@ -38,29 +53,45 @@
       "anon_execute_grants": 0,
       "authenticated_execute_grants": 0
     },
-    "active_without_current_exact_want": 0
+    "active_without_current_exact_want": 0,
+    "deliverable_without_current_evidence": 0
   },
   "verification": {
     "targeted_contracts": {
-      "passed": 9,
+      "passed": 19,
       "failed": 0
     },
     "full_contract_suite": {
-      "passed": 1544,
+      "passed": 1547,
       "failed": 0
     },
-    "e3_rollback_only_smoke": {
+    "e3_engine_rollback_only_smoke": {
       "status": "PASS",
       "pulse_before_want_off": 1,
       "status_after_want_off": "stale",
+      "queued_alert_after_want_off": "cancelled_current_want_removed",
+      "queued_alert_claimed_after_want_off": 0,
+      "invalidated_send_started": false,
+      "unsupported_reactivation_status": "stale",
       "pulse_after_want_off": 0,
       "status_after_reactivation": "active",
       "pulse_after_reactivation": 1,
+      "valid_send_started": true,
+      "duplicate_send_started": false,
       "duplicate_match_rows": 0,
-      "notification_outbox_rows": 0,
+      "historical_event_rows_retained": 2,
       "rollback_only": true
     },
-    "e4_rollback_only_smoke": {
+    "e3_delivery_rollback_only_smoke": {
+      "status": "PASS",
+      "instant_rows": 1,
+      "duplicate_instant_rows": 0,
+      "owner_alert_rows": 0,
+      "standalone_digest_rows_after_e4_cutover": 0,
+      "pulse_dry_run_candidates": 1,
+      "rollback_only": true
+    },
+    "e4_read_rollback_only_smoke": {
       "status": "PASS",
       "muted_event_visible": false,
       "private_event_visible": false,
@@ -68,6 +99,16 @@
       "unread_before": 3,
       "unread_after": 0,
       "backwards_mark_seen_rejected": true,
+      "rollback_only": true
+    },
+    "e4_daily_rollback_only_smoke": {
+      "status": "PASS",
+      "pulse_rows": 1,
+      "pulse_item_count": 2,
+      "want_match_count": 1,
+      "current_evidence_before_opt_out": true,
+      "status_after_opt_out": "cancelled_current_want_removed",
+      "claimed_after_opt_out": 0,
       "rollback_only": true
     },
     "git_diff_check": "PASS",

--- a/docs/audits/release_completion_v1/want_match_current_want_local_verification_v1.json
+++ b/docs/audits/release_completion_v1/want_match_current_want_local_verification_v1.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "WANT_MATCH_CURRENT_WANT_LOCAL_VERIFICATION_V1",
+  "verified_at": "2026-08-07T04:29:00Z",
+  "branch": "release/want-match-truth-boundary-v1",
+  "source_candidate_sha": "33d7ff50bda428439c664c7c6db427b7a66abd9a",
+  "migration": {
+    "version": "20260807043000",
+    "path": "supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql",
+    "sha256": "f578b0c4daa8f5da46a1b7e455591943fe19d2a01259c0d336786e5cb8b229da",
+    "local_history_present": true
+  },
+  "schema_readback": {
+    "expected_function_count": 6,
+    "actual_function_count": 6,
+    "functions": [
+      "binder_pulse_base_eligible_events_for_viewer_v1",
+      "legacy_binder_pulse_base_eligible_events_v1",
+      "legacy_local_community_visible_source_cards_v1",
+      "local_community_visible_source_cards_v1",
+      "stale_want_matches_when_intent_removed_v1",
+      "viewer_has_current_card_want_v1"
+    ],
+    "trigger": {
+      "name": "trg_stale_want_matches_when_intent_removed_v1",
+      "enabled": true
+    },
+    "cron": {
+      "name": "grookai-want-match-stale-cleanup-v1",
+      "schedule": "*/15 * * * *",
+      "active": true
+    },
+    "security_readback": {
+      "security_definer_function_count": 6,
+      "execute_grantees": [
+        "postgres",
+        "service_role"
+      ],
+      "anon_execute_grants": 0,
+      "authenticated_execute_grants": 0
+    },
+    "active_without_current_exact_want": 0
+  },
+  "verification": {
+    "targeted_contracts": {
+      "passed": 9,
+      "failed": 0
+    },
+    "full_contract_suite": {
+      "passed": 1544,
+      "failed": 0
+    },
+    "e3_rollback_only_smoke": {
+      "status": "PASS",
+      "pulse_before_want_off": 1,
+      "status_after_want_off": "stale",
+      "pulse_after_want_off": 0,
+      "status_after_reactivation": "active",
+      "pulse_after_reactivation": 1,
+      "duplicate_match_rows": 0,
+      "notification_outbox_rows": 0,
+      "rollback_only": true
+    },
+    "e4_rollback_only_smoke": {
+      "status": "PASS",
+      "muted_event_visible": false,
+      "private_event_visible": false,
+      "pagination_overlap_count": 0,
+      "unread_before": 3,
+      "unread_after": 0,
+      "backwards_mark_seen_rejected": true,
+      "rollback_only": true
+    },
+    "git_diff_check": "PASS",
+    "repository_shipcheck": {
+      "status": "PASS",
+      "runtime_preflight_critical_failures": 0,
+      "secret_packaging_guard": "PASS",
+      "runtime_health": "PASS",
+      "quarantine_report": "PASS",
+      "deferred_report": "PASS_WITH_GOVERNED_DEBT",
+      "web_typecheck": "PASS",
+      "web_lint": "PASS",
+      "web_production_build": "PASS",
+      "flutter_analyze": "PASS",
+      "flutter_tests_passed": 571,
+      "flutter_tests_failed": 0
+    }
+  },
+  "boundaries": {
+    "production_writes": 0,
+    "historical_match_deletes": 0,
+    "historical_event_deletes": 0,
+    "canonical_identity_mutations": 0,
+    "vault_mutations": 0,
+    "pricing_mutations": 0
+  }
+}

--- a/docs/audits/release_completion_v1/want_match_current_want_production_preflight_v1.json
+++ b/docs/audits/release_completion_v1/want_match_current_want_production_preflight_v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "WANT_MATCH_CURRENT_WANT_PRODUCTION_PREFLIGHT_V1",
+  "captured_at": "2026-08-07T04:30:37.847Z",
+  "source_candidate_sha": "33d7ff50bda428439c664c7c6db427b7a66abd9a",
+  "mode": "production_read_only",
+  "write_operations": 0,
+  "counts": {
+    "total_match_rows": 2,
+    "active_match_rows": 2,
+    "stale_match_rows": 0,
+    "acted_match_rows": 0,
+    "want_match_event_rows": 2,
+    "active_without_current_exact_want": 2
+  },
+  "mismatch_evidence": [
+    {
+      "match_ref_sha256_16": "2fec9fd32cdf8e2e",
+      "card_print_ref_sha256_16": "bf1b8e4881a347c4",
+      "card_name": "Blastoise & Piplup-GX",
+      "status": "active"
+    },
+    {
+      "match_ref_sha256_16": "b829418a5778856a",
+      "card_print_ref_sha256_16": "dfb3e45f56286faf",
+      "card_name": "Piplup",
+      "status": "active"
+    }
+  ],
+  "finding": "Every active durable Want Match lacked a current exact user_card_intents.want=true row. Historical match and card-event rows must be retained while current eligibility is repaired."
+}

--- a/docs/checkpoints/product/CHECKPOINT_INDEX.md
+++ b/docs/checkpoints/product/CHECKPOINT_INDEX.md
@@ -2,6 +2,7 @@
 
 ## Checkpoints
 
+- `WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md` — `2026-08-07` — LOCAL VERIFIED / PRODUCTION APPLY PENDING — Records the final-candidate stale Want Match defect, exact current-intent authority, history-preserving migration, 1,544-contract and rollback-only database proof, and the controlled production apply/re-smoke gate.
 - `../../audits/release_completion_v1/RELEASE_COMPLETION_LEDGER_V1.md` — `2026-08-06` — ACTIVE RELEASE LEDGER — Reconciles the August 5 eight-week completion contract against merged implementation and names the remaining journey, state, operations, store, and 72-hour final-candidate evidence gates.
 - `RELEASE_CONVERGENCE_IMPLEMENTATION_20260806_V1.md` — `2026-08-06` — IMPLEMENTATION COMPLETE / EXTERNAL GATES — Records the frozen release-plan implementation, 1,506 Node and 566 Flutter tests, full web parity, signed-in Samsung proof, isolated iOS simulator proof, privacy-preserving evidence handling, and the remaining physical-iPhone and DB-capable release gates.
 - `P0_DESKTOP_APPLICATION_SHELL_HIGH_FIDELITY_20260805_V1.md` — `2026-08-05` — P0 IMPLEMENTED — Locks the native-order five-pillar desktop shell, secondary collection/account tools, cookie-verified private state, exact 900px handoff, unread/unavailable/pushed-route states, four visual baselines, and the bounded Binders and Invitations gate.

--- a/docs/checkpoints/product/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
+++ b/docs/checkpoints/product/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
@@ -6,18 +6,20 @@ The immutable release candidate was being exercised through Journey C on Android
 
 ## Problem
 
-Durable match/event history was treated as current product truth. Turning off an exact card want did not synchronously stale its active matches, and Pulse did not re-prove current intent before display.
+Durable match/event history was treated as current product truth. Turning off an exact card want did not synchronously stale its active matches, Pulse did not re-prove current intent before display, queued alerts remained deliverable, and concurrent engine activation could recreate an active mismatch after opt-out.
 
 ## Risk
 
 - Collectors could see a match for a card they no longer want.
+- Collectors could receive a queued push after opting out.
+- A stale engine snapshot could reactivate a row after the opt-out transition.
 - Current Pulse state could disagree with Card Detail.
 - Deleting history to hide the issue would destroy valuable audit and lifecycle evidence.
 - Treating `wishlist_items` as the current authority would preserve drift from the app's `user_card_intents` contract.
 
 ## Decision
 
-Use exact `user_card_intents.want=true` as the sole current-want authority. Retain durable matches and card events, transition unsupported active matches to `stale`, and require current intent at the Pulse read boundary.
+Use exact `user_card_intents.want=true` as the sole current-want authority. Retain durable matches and card events, transition unsupported active matches to `stale`, require current intent at Pulse and delivery boundaries, cancel queued unstarted alerts, serialize active transitions, and recheck evidence immediately before FCM send-start.
 
 ## Alternatives Rejected
 
@@ -25,12 +27,14 @@ Use exact `user_card_intents.want=true` as the sole current-want authority. Reta
 - **Hide only in the client:** rejected because unread counts and every client would still consume false database truth.
 - **Use `wishlist_items` as authority:** rejected because production contains legacy drift and the app writes `user_card_intents`.
 - **Wait for seven-day cleanup:** rejected because an explicit opt-out must take effect immediately.
+- **Check only when an alert is queued:** rejected because evidence can change during quiet hours, retries, or dispatch.
+- **Rely on PostgreSQL deadlock recovery:** rejected for the delivery boundary; final send now follows deterministic intent-to-outbox lock order.
 - **Patch only the two production rows:** rejected because it would not prevent recurrence.
 
 ## Migration
 
 - Path: `supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql`
-- SHA-256: `f578b0c4daa8f5da46a1b7e455591943fe19d2a01259c0d336786e5cb8b229da`
+- SHA-256: `279ff56334079fc8858faba53eafa6d98162c7bcecc30f08f23e59c1cdf19959`
 - Base candidate: `33d7ff50bda428439c664c7c6db427b7a66abd9a`
 - Production status: pending merge and controlled apply.
 
@@ -39,14 +43,17 @@ Use exact `user_card_intents.want=true` as the sole current-want authority. Reta
 - Production has two durable Want Match rows and two historical availability events.
 - Both rows are active without a current exact want and must become stale.
 - Local migration readback has zero active/current-want mismatches.
-- Local E3 and E4 rollback-only journeys pass.
-- The full Node contract suite passes 1,544/1,544.
+- Local E3 engine/delivery and E4 read/daily rollback-only journeys pass.
+- Current evidence is required at claim and final send-start, and duplicate send-start is rejected.
+- The full Node contract suite passes 1,547/1,547.
 
 ## Invariants
 
 - Current intent is exact user plus exact `card_print_id`.
 - Match and event history is retained.
 - An explicit want opt-out immediately removes candidate and Pulse eligibility.
+- Queued instant and daily delivery becomes terminal before FCM when current evidence is removed.
+- Active insertion/reactivation cannot remain current without the exact intent.
 - Reactivation reuses the durable row and does not duplicate events.
 - Private, muted, unrelated, and cursor-invalid Pulse data remains excluded.
 

--- a/docs/checkpoints/product/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
+++ b/docs/checkpoints/product/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md
@@ -1,0 +1,69 @@
+# Want Match Current-Want Truth Repair Checkpoint V1
+
+## Context
+
+The immutable release candidate was being exercised through Journey C on Android build 284. Pulse displayed historical Want Match cards that the viewer no longer wanted.
+
+## Problem
+
+Durable match/event history was treated as current product truth. Turning off an exact card want did not synchronously stale its active matches, and Pulse did not re-prove current intent before display.
+
+## Risk
+
+- Collectors could see a match for a card they no longer want.
+- Current Pulse state could disagree with Card Detail.
+- Deleting history to hide the issue would destroy valuable audit and lifecycle evidence.
+- Treating `wishlist_items` as the current authority would preserve drift from the app's `user_card_intents` contract.
+
+## Decision
+
+Use exact `user_card_intents.want=true` as the sole current-want authority. Retain durable matches and card events, transition unsupported active matches to `stale`, and require current intent at the Pulse read boundary.
+
+## Alternatives Rejected
+
+- **Delete old matches/events:** rejected because historical evidence must remain durable.
+- **Hide only in the client:** rejected because unread counts and every client would still consume false database truth.
+- **Use `wishlist_items` as authority:** rejected because production contains legacy drift and the app writes `user_card_intents`.
+- **Wait for seven-day cleanup:** rejected because an explicit opt-out must take effect immediately.
+- **Patch only the two production rows:** rejected because it would not prevent recurrence.
+
+## Migration
+
+- Path: `supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql`
+- SHA-256: `f578b0c4daa8f5da46a1b7e455591943fe19d2a01259c0d336786e5cb8b229da`
+- Base candidate: `33d7ff50bda428439c664c7c6db427b7a66abd9a`
+- Production status: pending merge and controlled apply.
+
+## Current Truths
+
+- Production has two durable Want Match rows and two historical availability events.
+- Both rows are active without a current exact want and must become stale.
+- Local migration readback has zero active/current-want mismatches.
+- Local E3 and E4 rollback-only journeys pass.
+- The full Node contract suite passes 1,544/1,544.
+
+## Invariants
+
+- Current intent is exact user plus exact `card_print_id`.
+- Match and event history is retained.
+- An explicit want opt-out immediately removes candidate and Pulse eligibility.
+- Reactivation reuses the durable row and does not duplicate events.
+- Private, muted, unrelated, and cursor-invalid Pulse data remains excluded.
+
+## What Must Never Be Broken
+
+- Never infer current intent from an old event or durable match.
+- Never delete match/event history to repair current visibility.
+- Never let client filtering substitute for the database eligibility boundary.
+- Never broaden anonymous, authenticated, or service privileges during this repair.
+- Never use this migration to mutate canonical identity, Vault, pricing, or ownership data.
+
+## Evidence
+
+- `../../audits/release_completion_v1/WANT_MATCH_CURRENT_WANT_TRUTH_REPAIR_20260807_V1.md`
+- `../../audits/release_completion_v1/want_match_current_want_production_preflight_v1.json`
+- `../../audits/release_completion_v1/want_match_current_want_local_verification_v1.json`
+
+## Explicit Next Gate
+
+Merge and apply the exact migration, reconcile retained row/event counts and stale transitions, then repeat the final-candidate Android Pulse read. Journey C remains partial until the clean-account exact Want-to-match-to-message journey is separately proven.

--- a/scripts/audits/e3_want_match_local_fixture_smoke_v1.mjs
+++ b/scripts/audits/e3_want_match_local_fixture_smoke_v1.mjs
@@ -448,6 +448,36 @@ async function main() {
       );
 
       await setServiceRole(client);
+      const queuedAlert = await client.query(
+        `
+          insert into public.notification_outbox (
+            recipient_user_id, event_type, tier, card_print_id,
+            actor_user_id, card_event_id, payload, dedupe_key,
+            available_at, next_attempt_at
+          ) values (
+            $1, 'want_match_available', 'instant', $2,
+            $3,
+            (
+              select id
+              from public.card_events
+              where dedupe_key = $4
+              limit 1
+            ),
+            jsonb_build_object('want_match_id', $5::text),
+            $4,
+            now() + interval '1 hour',
+            now() + interval '1 hour'
+          )
+          returning id
+        `,
+        [
+          FIXTURE.userA,
+          FIXTURE.cardId,
+          FIXTURE.userB,
+          `want_match_available:${matchId}`,
+          matchId,
+        ],
+      );
       await client.query(
         `
           update public.user_card_intents
@@ -462,6 +492,36 @@ async function main() {
         `
           select status, stale_marked_at is not null as has_stale_marker,
                  payload ->> 'stale_reason' as stale_reason
+          from public.want_matches
+          where id = $1
+        `,
+        [matchId],
+      );
+      const queuedAlertAfterWantOff = await client.query(
+        `
+          select failed_at is not null as failed,
+                 failure_reason,
+                 send_started_at is not null as send_started
+          from public.notification_outbox
+          where id = $1
+        `,
+        [queuedAlert.rows[0].id],
+      );
+      const claimAfterWantOff = await client.query(
+        'select id from public.notification_dispatcher_claim_batch_v1($1) where id = $2',
+        [100, queuedAlert.rows[0].id],
+      );
+      const invalidatedSendStart = await client.query(
+        'select public.notification_dispatcher_mark_send_started_if_current_v1($1) as started',
+        [queuedAlert.rows[0].id],
+      );
+      await client.query(
+        "update public.want_matches set status = 'active' where id = $1",
+        [matchId],
+      );
+      const unsupportedReactivation = await client.query(
+        `
+          select status, payload ->> 'stale_reason' as stale_reason
           from public.want_matches
           where id = $1
         `,
@@ -505,6 +565,44 @@ async function main() {
       const statusAfterReactivation = await client.query(
         'select status, stale_marked_at is null as stale_marker_cleared from public.want_matches where id = $1',
         [matchId],
+      );
+      const sendBoundaryAlert = await client.query(
+        `
+          insert into public.notification_outbox (
+            recipient_user_id, event_type, tier, card_print_id,
+            actor_user_id, payload, dedupe_key,
+            available_at, next_attempt_at
+          ) values (
+            $1, 'want_match_available', 'instant', $2,
+            $3, jsonb_build_object('want_match_id', $4::text), $5,
+            now(), now()
+          )
+          returning id
+        `,
+        [
+          FIXTURE.userA,
+          FIXTURE.cardId,
+          FIXTURE.userB,
+          matchId,
+          `want_match_send_boundary:${matchId}`,
+        ],
+      );
+      const validSendStart = await client.query(
+        'select public.notification_dispatcher_mark_send_started_if_current_v1($1) as started',
+        [sendBoundaryAlert.rows[0].id],
+      );
+      const duplicateSendStart = await client.query(
+        'select public.notification_dispatcher_mark_send_started_if_current_v1($1) as started',
+        [sendBoundaryAlert.rows[0].id],
+      );
+      const sendBoundaryReadback = await client.query(
+        `
+          select send_started_at is not null as send_started,
+                 failed_at is not null as failed
+          from public.notification_outbox
+          where id = $1
+        `,
+        [sendBoundaryAlert.rows[0].id],
       );
 
       await setAuthenticatedUser(client, FIXTURE.userA);
@@ -578,12 +676,23 @@ async function main() {
           && statusAfterWantOff.rows[0]?.status === 'stale'
           && statusAfterWantOff.rows[0]?.has_stale_marker === true
           && statusAfterWantOff.rows[0]?.stale_reason === 'canonical_want_removed'
+          && queuedAlertAfterWantOff.rows[0]?.failed === true
+          && queuedAlertAfterWantOff.rows[0]?.send_started === false
+          && queuedAlertAfterWantOff.rows[0]?.failure_reason === 'cancelled_current_want_removed'
+          && claimAfterWantOff.rows.length === 0
+          && invalidatedSendStart.rows[0]?.started === false
+          && unsupportedReactivation.rows[0]?.status === 'stale'
+          && unsupportedReactivation.rows[0]?.stale_reason === 'activation_without_current_want'
           && !candidatesAfterWantOff.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
           && Number(pulseAfterWantOff.rows[0]?.count ?? 0) === 0
           && reactivationRun.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
           && statusAfterReactivation.rows[0]?.status === 'active'
           && statusAfterReactivation.rows[0]?.stale_marker_cleared === true
           && Number(pulseAfterReactivation.rows[0]?.count ?? 0) === 1
+          && validSendStart.rows[0]?.started === true
+          && duplicateSendStart.rows[0]?.started === false
+          && sendBoundaryReadback.rows[0]?.send_started === true
+          && sendBoundaryReadback.rows[0]?.failed === false
           && !privateCandidates.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
           && !privateRun.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
           && staleRun.rows.length === 1
@@ -602,11 +711,18 @@ async function main() {
         event_count_after_second: Number(eventsAfterSecond.rows[0]?.count ?? 0),
         pulse_count_before_want_off: Number(pulseBeforeWantOff.rows[0]?.count ?? 0),
         status_after_want_off: statusAfterWantOff.rows[0] ?? null,
+        queued_alert_after_want_off: queuedAlertAfterWantOff.rows[0] ?? null,
+        queued_alert_claimed_after_want_off: claimAfterWantOff.rows.length,
+        invalidated_send_started: invalidatedSendStart.rows[0]?.started ?? null,
+        unsupported_reactivation: unsupportedReactivation.rows[0] ?? null,
         candidate_count_after_want_off: candidatesAfterWantOff.rows.length,
         pulse_count_after_want_off: Number(pulseAfterWantOff.rows[0]?.count ?? 0),
         reactivation_run: reactivationRun.rows,
         status_after_reactivation: statusAfterReactivation.rows[0] ?? null,
         pulse_count_after_reactivation: Number(pulseAfterReactivation.rows[0]?.count ?? 0),
+        valid_send_started: validSendStart.rows[0]?.started ?? null,
+        duplicate_send_started: duplicateSendStart.rows[0]?.started ?? null,
+        send_boundary_readback: sendBoundaryReadback.rows[0] ?? null,
         want_match_outbox_rows: Number(outboxAfterFirst.rows[0]?.count ?? 0),
         private_candidate_count: privateCandidates.rows.length,
         private_run_rows: privateRun.rows.length,
@@ -622,6 +738,22 @@ async function main() {
       const engineRun = await client.query(
         'select * from public.run_want_match_engine_v1($1, $2)',
         [FIXTURE.userA, 50],
+      );
+      const matchTruthBeforeDelivery = await client.query(
+        `
+          select wm.id,
+                 wm.card_print_id,
+                 wm.status,
+                 wm.recommended_tier,
+                 public.viewer_has_current_card_want_v1(
+                   wm.want_user_id,
+                   wm.card_print_id
+                 ) as has_current_want
+          from public.want_matches wm
+          where wm.want_user_id = $1
+          order by wm.card_print_id, wm.id
+        `,
+        [FIXTURE.userA],
       );
       const instantEnqueue = await client.query(
         'select * from public.enqueue_want_match_instant_notifications_v1($1, $2)',
@@ -649,11 +781,7 @@ async function main() {
         [FIXTURE.userB, FIXTURE.userC],
       );
 
-      const digestEnqueue = await client.query(
-        'select * from public.enqueue_want_match_digest_notifications_v1(current_date, $1, $2)',
-        [50, false],
-      );
-      const digestEnqueueSecond = await client.query(
+      const legacyDigestCutover = await client.query(
         'select * from public.enqueue_want_match_digest_notifications_v1(current_date, $1, $2)',
         [50, false],
       );
@@ -666,29 +794,12 @@ async function main() {
           order by created_at
         `,
       );
-      const digestId = digestRows.rows[0]?.id ?? null;
-      if (digestId) {
-        await client.query(
-          "select public.notification_dispatcher_reschedule_digest_fold_v1($1, 'daily_budget_exhausted', now() + interval '1 day')",
-          [digestId],
-        );
-      }
-      const digestAfterReschedule = await client.query(
-        `
-          select id, available_at > now() as rescheduled_future,
-                 folded_into_digest_at is null as not_terminal,
-                 failure_reason
-          from public.notification_outbox
-          where id = $1
-        `,
-        [digestId],
-      );
       const jobDryRun = await client.query(
         'select public.run_want_match_instant_candidate_pass_v1($1, $2, $3, $4, $5) as result',
         [5, 50, 50, 10, true],
       );
-      const digestDryRun = await client.query(
-        'select public.run_want_match_daily_digest_aggregation_v1(current_date, $1, $2, $3) as result',
+      const pulseDryRun = await client.query(
+        'select public.run_pulse_daily_aggregation_v1(current_date, $1, $2, $3) as result',
         [50, 10, true],
       );
       const deliveryFailures = await client.query(
@@ -709,41 +820,29 @@ async function main() {
           && instantEnqueue.rows.filter((row) => row.action === 'enqueued').length === 1
           && instantEnqueueSecond.rows.length === 0
       );
-      const digestPass = Boolean(
-        digestRows.rows.length === 1
-          && digestRows.rows[0].recipient_user_id === FIXTURE.userA
-          && digestRows.rows[0].tier === 'daily_pulse'
-          && String(digestRows.rows[0].dedupe_key ?? '').includes(`want_match_digest:${FIXTURE.userA}:`)
-          && Number(digestRows.rows[0].payload?.match_count ?? 0) === 1
-          && Array.isArray(digestRows.rows[0].payload?.compact_match_ids)
-          && digestEnqueue.rows.filter((row) => row.action === 'enqueued').length === 1
-          && digestEnqueueSecond.rows.length === 0
-      );
-      const reschedulePass = Boolean(
-        digestAfterReschedule.rows[0]?.rescheduled_future === true
-          && digestAfterReschedule.rows[0]?.not_terminal === true
-          && String(digestAfterReschedule.rows[0]?.failure_reason ?? '').includes('daily_budget_exhausted_rescheduled')
+      const digestCutoverPass = Boolean(
+        legacyDigestCutover.rows.length === 0
+          && digestRows.rows.length === 0
+          && Number(pulseDryRun.rows[0]?.result?.dry_run_candidates ?? 0) >= 1
       );
       const deliveryPass = Boolean(
         instantPass
-          && digestPass
-          && reschedulePass
+          && digestCutoverPass
           && ownerRows.rows.length === 0
       );
 
       result.delivery = {
         status: deliveryPass ? 'PASS' : 'FAIL',
         engine_run: engineRun.rows,
+        match_truth_before_delivery: matchTruthBeforeDelivery.rows,
         instant_enqueue: instantEnqueue.rows,
         instant_enqueue_second: instantEnqueueSecond.rows,
         instant_outbox_rows: instantRows.rows,
         owner_outbox_rows: ownerRows.rows,
-        digest_enqueue: digestEnqueue.rows,
-        digest_enqueue_second: digestEnqueueSecond.rows,
+        legacy_digest_cutover: legacyDigestCutover.rows,
         digest_outbox_rows: digestRows.rows,
-        digest_after_reschedule: digestAfterReschedule.rows[0] ?? null,
         instant_job_dry_run: jobDryRun.rows[0]?.result ?? null,
-        digest_job_dry_run: digestDryRun.rows[0]?.result ?? null,
+        pulse_job_dry_run: pulseDryRun.rows[0]?.result ?? null,
         delivery_failures: deliveryFailures.rows,
       };
       result.status = result.status === 'PASS' && deliveryPass ? 'PASS' : 'FAIL';

--- a/scripts/audits/e3_want_match_local_fixture_smoke_v1.mjs
+++ b/scripts/audits/e3_want_match_local_fixture_smoke_v1.mjs
@@ -286,20 +286,26 @@ async function seedFixture(client) {
 
   await client.query(
     `
-      insert into public.wishlist_items (user_id, card_id, note)
-      values ($1, $2, 'E3 local fixture want')
-      on conflict (user_id, card_id) do update
-      set note = excluded.note
+      insert into public.user_card_intents (
+        user_id, card_print_id, want, trade, sell, showcase, is_public, metadata
+      )
+      values ($1, $2, true, false, false, false, false, '{}'::jsonb)
+      on conflict (user_id, card_print_id) do update
+      set want = true,
+          updated_at = now()
     `,
     [FIXTURE.userA, FIXTURE.cardId],
   );
 
   await client.query(
     `
-      insert into public.wishlist_items (user_id, card_id, note)
-      values ($1, $2, 'E3 local fixture digest want')
-      on conflict (user_id, card_id) do update
-      set note = excluded.note
+      insert into public.user_card_intents (
+        user_id, card_print_id, want, trade, sell, showcase, is_public, metadata
+      )
+      values ($1, $2, true, false, false, false, false, '{}'::jsonb)
+      on conflict (user_id, card_print_id) do update
+      set want = true,
+          updated_at = now()
     `,
     [FIXTURE.userA, FIXTURE.digestCardId],
   );
@@ -426,6 +432,97 @@ async function main() {
         [`want_match_available:${matchId}`, `want_match_owner_count:${matchId}`],
       );
 
+      await setAuthenticatedUser(client, FIXTURE.userA);
+      const pulseBeforeWantOff = await client.query(
+        `
+          select count(*)::integer as count
+          from public.pulse_eligible_events_for_viewer_v1($1)
+          where card_event_id = (
+            select id
+            from public.card_events
+            where dedupe_key = $2
+            limit 1
+          )
+        `,
+        [FIXTURE.userA, `want_match_available:${matchId}`],
+      );
+
+      await setServiceRole(client);
+      await client.query(
+        `
+          update public.user_card_intents
+          set want = false,
+              updated_at = now()
+          where user_id = $1
+            and card_print_id = $2
+        `,
+        [FIXTURE.userA, FIXTURE.cardId],
+      );
+      const statusAfterWantOff = await client.query(
+        `
+          select status, stale_marked_at is not null as has_stale_marker,
+                 payload ->> 'stale_reason' as stale_reason
+          from public.want_matches
+          where id = $1
+        `,
+        [matchId],
+      );
+
+      await setAuthenticatedUser(client, FIXTURE.userA);
+      const candidatesAfterWantOff = await client.query(
+        'select * from public.local_community_want_match_candidates_v1($1, $2)',
+        [FIXTURE.userA, 100],
+      );
+      const pulseAfterWantOff = await client.query(
+        `
+          select count(*)::integer as count
+          from public.pulse_eligible_events_for_viewer_v1($1)
+          where card_event_id = (
+            select id
+            from public.card_events
+            where dedupe_key = $2
+            limit 1
+          )
+        `,
+        [FIXTURE.userA, `want_match_available:${matchId}`],
+      );
+
+      await setServiceRole(client);
+      await client.query(
+        `
+          update public.user_card_intents
+          set want = true,
+              updated_at = now()
+          where user_id = $1
+            and card_print_id = $2
+        `,
+        [FIXTURE.userA, FIXTURE.cardId],
+      );
+      const reactivationRun = await client.query(
+        'select * from public.run_want_match_engine_v1($1, $2)',
+        [FIXTURE.userA, 50],
+      );
+      const statusAfterReactivation = await client.query(
+        'select status, stale_marked_at is null as stale_marker_cleared from public.want_matches where id = $1',
+        [matchId],
+      );
+
+      await setAuthenticatedUser(client, FIXTURE.userA);
+      const pulseAfterReactivation = await client.query(
+        `
+          select count(*)::integer as count
+          from public.pulse_eligible_events_for_viewer_v1($1)
+          where card_event_id = (
+            select id
+            from public.card_events
+            where dedupe_key = $2
+            limit 1
+          )
+        `,
+        [FIXTURE.userA, `want_match_available:${matchId}`],
+      );
+
+      await setServiceRole(client);
       await client.query(
         `
           update public.public_profiles
@@ -477,6 +574,16 @@ async function main() {
           && Number(outboxAfterFirst.rows[0]?.count ?? 0) === 0
           && Number(matchRowsAfterSecond.rows[0]?.count ?? 0) === 1
           && Number(eventsAfterSecond.rows[0]?.count ?? 0) === 2
+          && Number(pulseBeforeWantOff.rows[0]?.count ?? 0) === 1
+          && statusAfterWantOff.rows[0]?.status === 'stale'
+          && statusAfterWantOff.rows[0]?.has_stale_marker === true
+          && statusAfterWantOff.rows[0]?.stale_reason === 'canonical_want_removed'
+          && !candidatesAfterWantOff.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
+          && Number(pulseAfterWantOff.rows[0]?.count ?? 0) === 0
+          && reactivationRun.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
+          && statusAfterReactivation.rows[0]?.status === 'active'
+          && statusAfterReactivation.rows[0]?.stale_marker_cleared === true
+          && Number(pulseAfterReactivation.rows[0]?.count ?? 0) === 1
           && !privateCandidates.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
           && !privateRun.rows.some((row) => clean(row.card_print_id) === FIXTURE.cardId)
           && staleRun.rows.length === 1
@@ -493,6 +600,13 @@ async function main() {
         match_row_count_after_second: Number(matchRowsAfterSecond.rows[0]?.count ?? 0),
         event_rows_after_first: eventsAfterFirst.rows,
         event_count_after_second: Number(eventsAfterSecond.rows[0]?.count ?? 0),
+        pulse_count_before_want_off: Number(pulseBeforeWantOff.rows[0]?.count ?? 0),
+        status_after_want_off: statusAfterWantOff.rows[0] ?? null,
+        candidate_count_after_want_off: candidatesAfterWantOff.rows.length,
+        pulse_count_after_want_off: Number(pulseAfterWantOff.rows[0]?.count ?? 0),
+        reactivation_run: reactivationRun.rows,
+        status_after_reactivation: statusAfterReactivation.rows[0] ?? null,
+        pulse_count_after_reactivation: Number(pulseAfterReactivation.rows[0]?.count ?? 0),
         want_match_outbox_rows: Number(outboxAfterFirst.rows[0]?.count ?? 0),
         private_candidate_count: privateCandidates.rows.length,
         private_run_rows: privateRun.rows.length,

--- a/scripts/audits/e4_pulse_daily_local_fixture_smoke_v1.mjs
+++ b/scripts/audits/e4_pulse_daily_local_fixture_smoke_v1.mjs
@@ -142,6 +142,19 @@ async function seedFixture(client) {
 
   await client.query(
     `
+      insert into public.user_card_intents (
+        user_id, card_print_id, want, trade, sell, showcase, is_public, metadata
+      )
+      values ($1, $2, true, false, false, false, false, '{}'::jsonb)
+      on conflict (user_id, card_print_id) do update
+      set want = true,
+          updated_at = now()
+    `,
+    [FIXTURE.viewerUserId, FIXTURE.digestCardId],
+  );
+
+  await client.query(
+    `
       insert into public.want_matches (
         id, want_user_id, owner_user_id, card_print_id,
         distance_bucket, locality_label, relationship_context, intent,
@@ -253,6 +266,22 @@ async function main() {
     summary.undelivered_legacy_digest_rows = undeliveredLegacy.rows[0].count;
 
     const pulseOutboxId = pulseRows.rows[0]?.id;
+    const pulseEvidenceBeforeOptOut = await client.query(
+      `
+        select public.notification_outbox_has_current_want_truth_v1(
+          event_type,
+          recipient_user_id,
+          card_print_id,
+          payload
+        ) as supported
+        from public.notification_outbox
+        where id = $1
+      `,
+      [pulseOutboxId],
+    );
+    summary.pulse_daily_evidence_before_opt_out =
+      pulseEvidenceBeforeOptOut.rows[0]?.supported ?? false;
+
     await client.query(
       "select public.notification_dispatcher_reschedule_digest_fold_v1($1, 'daily_budget_exhausted', '2026-07-09 09:00:00+00'::timestamptz)",
       [pulseOutboxId],
@@ -273,6 +302,33 @@ async function main() {
       reschedule_reason: rescheduled.rows[0].payload.reschedule_reason,
     };
 
+    await client.query(
+      `
+        update public.user_card_intents
+        set want = false,
+            updated_at = now()
+        where user_id = $1
+          and card_print_id = $2
+      `,
+      [FIXTURE.viewerUserId, FIXTURE.digestCardId],
+    );
+    const pulseAfterOptOut = await client.query(
+      `
+        select failed_at is not null as failed,
+               failure_reason,
+               send_started_at is not null as send_started
+        from public.notification_outbox
+        where id = $1
+      `,
+      [pulseOutboxId],
+    );
+    const claimedAfterOptOut = await client.query(
+      'select id from public.notification_dispatcher_claim_batch_v1($1) where id = $2',
+      [100, pulseOutboxId],
+    );
+    summary.pulse_daily_after_opt_out = pulseAfterOptOut.rows[0] ?? null;
+    summary.pulse_daily_claimed_after_opt_out = claimedAfterOptOut.rows.length;
+
     if (summary.cutover_digest_enqueue_returned_rows !== 0) {
       throw new Error('legacy digest enqueue returned rows after cutover');
     }
@@ -287,6 +343,10 @@ async function main() {
 
     if (!summary.pulse_daily_rows[0].counts_by_type?.want_match) {
       throw new Error('digest-tier want match was not folded into pulse_daily payload');
+    }
+
+    if (summary.pulse_daily_evidence_before_opt_out !== true) {
+      throw new Error('current digest-tier want evidence did not authorize pulse_daily delivery');
     }
 
     if (summary.zero_user_pulse_daily_rows !== 0) {
@@ -306,6 +366,13 @@ async function main() {
         summary.pulse_daily_after_budget_fold.failure_reason !== 'daily_budget_exhausted_rescheduled' ||
         summary.pulse_daily_after_budget_fold.reschedule_reason !== 'daily_budget_exhausted') {
       throw new Error('pulse_daily budget fold did not reschedule cleanly');
+    }
+
+    if (summary.pulse_daily_after_opt_out?.failed !== true ||
+        summary.pulse_daily_after_opt_out?.send_started !== false ||
+        summary.pulse_daily_after_opt_out?.failure_reason !== 'cancelled_current_want_removed' ||
+        summary.pulse_daily_claimed_after_opt_out !== 0) {
+      throw new Error('pulse_daily row remained deliverable after the exact want was removed');
     }
 
     await client.query('rollback');

--- a/scripts/audits/e4_pulse_local_fixture_smoke_v1.mjs
+++ b/scripts/audits/e4_pulse_local_fixture_smoke_v1.mjs
@@ -12,6 +12,7 @@ const FIXTURE = {
   cardWantId: '00000000-0000-4000-8000-00000000e402',
   cardCollectorId: '00000000-0000-4000-8000-00000000e403',
   cardMutedId: '00000000-0000-4000-8000-00000000e404',
+  wantMatchId: '00000000-0000-4000-8000-00000000e410',
   wantEventId: '00000000-0000-4000-8000-00000000e411',
   collectorEventId: '00000000-0000-4000-8000-00000000e412',
   completionEventId: '00000000-0000-4000-8000-00000000e413',
@@ -145,12 +146,51 @@ async function seedFixture(client) {
 
   await client.query(
     `
+      insert into public.user_card_intents (
+        user_id, card_print_id, want, trade, sell, showcase, is_public, metadata
+      )
+      values ($1, $2, true, false, false, false, false, '{}'::jsonb)
+      on conflict (user_id, card_print_id) do update
+      set want = true,
+          updated_at = now()
+    `,
+    [FIXTURE.viewerUserId, FIXTURE.cardWantId],
+  );
+
+  await client.query(
+    `
+      insert into public.want_matches (
+        id, want_user_id, owner_user_id, card_print_id,
+        distance_bucket, locality_label, relationship_context, intent,
+        source_type, match_strength, recommended_tier, status, payload
+      )
+      values (
+        $1, $2, $3, $4,
+        'nearby', 'Denver', 'not_following', 'trade',
+        'wall_card', 0.90, 'instant', 'active', '{}'::jsonb
+      )
+      on conflict (id) do update
+      set status = 'active',
+          stale_marked_at = null,
+          last_seen_available_at = now(),
+          updated_at = now()
+    `,
+    [
+      FIXTURE.wantMatchId,
+      FIXTURE.viewerUserId,
+      FIXTURE.ownerUserId,
+      FIXTURE.cardWantId,
+    ],
+  );
+
+  await client.query(
+    `
       insert into public.card_events (
         id, event_type, card_print_id, actor_user_id, subject_user_id,
         payload, visibility, dedupe_key, created_at
       )
       values
-        ($1, 'want_match_available', $6, $9, $8, '{"distance_bucket":"nearby","locality_label":"Denver","intent":"trade","display_image_url":"https://example.com/want.png"}'::jsonb, 'private', 'e4-pulse-smoke-want', '2026-07-08 10:00:00+00'),
+        ($1, 'want_match_available', $6, $9, $8, jsonb_build_object('want_match_id', $13::text, 'distance_bucket', 'nearby', 'locality_label', 'Denver', 'intent', 'trade', 'display_image_url', 'https://example.com/want.png'), 'private', 'e4-pulse-smoke-want', '2026-07-08 10:00:00+00'),
         ($2, 'vault_added', $7, $9, null, '{"intent":"trade","display_image_url":"https://example.com/collector.png"}'::jsonb, 'public', 'e4-pulse-smoke-collector', '2026-07-08 11:00:00+00'),
         ($3, 'set_completion_crossed', $7, $8, $8, jsonb_build_object('set_id', $10::text, 'subject_id', $10::text, 'subject_label', 'E4 Pulse Set', 'threshold', 50), 'private', 'e4-pulse-smoke-completion', '2026-07-08 12:00:00+00'),
         ($4, 'want_match_available', $11, $9, $8, '{"distance_bucket":"nearby","intent":"trade"}'::jsonb, 'private', 'e4-pulse-smoke-muted', '2026-07-08 13:00:00+00'),
@@ -170,6 +210,7 @@ async function seedFixture(client) {
       FIXTURE.setId,
       FIXTURE.cardMutedId,
       FIXTURE.privateOwnerUserId,
+      FIXTURE.wantMatchId,
     ],
   );
 }

--- a/supabase/functions/notification-dispatcher/index.ts
+++ b/supabase/functions/notification-dispatcher/index.ts
@@ -782,9 +782,27 @@ async function dispatchOne(
   const failures: FcmResult[] = [];
   let hasDeferredFallback = false;
   try {
-    await rpc(sb, "notification_dispatcher_mark_send_started_v1", {
-      p_outbox_id: row.id,
-    }, rowSignal);
+    const sendStarted = await rpc(
+      sb,
+      "notification_dispatcher_mark_send_started_if_current_v1",
+      {
+        p_outbox_id: row.id,
+      },
+      rowSignal,
+    );
+    if (sendStarted !== true) {
+      if (!isOperationsAlert) {
+        await rpc(sb, "notification_dispatcher_release_budget_v1", {
+          p_user_id: row.recipient_user_id,
+          p_budget_date: budgetDate,
+        }, invocationSignal).catch(() => null);
+      }
+      return {
+        id: row.id,
+        status: "skipped",
+        reason: "current_evidence_invalidated",
+      };
+    }
 
     const mock = shouldUseMockFcm(requestBody);
     const availableTokens = tokens as DeviceToken[];

--- a/supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql
+++ b/supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql
@@ -1,0 +1,305 @@
+begin;
+
+do $$
+begin
+  if to_regclass('public.user_card_intents') is null
+     or to_regclass('public.want_matches') is null
+     or to_regclass('public.card_events') is null then
+    raise exception 'Want Match truth repair requires user_card_intents, want_matches, and card_events';
+  end if;
+
+  if to_regprocedure('public.local_community_visible_source_cards_v1(uuid)') is null
+     or to_regprocedure('public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)') is null
+     or to_regprocedure('public.mark_stale_want_matches_v1(uuid,integer)') is null then
+    raise exception 'Want Match truth repair requires the E3/E4/E5 read contracts';
+  end if;
+end;
+$$;
+
+create or replace function public.viewer_has_current_card_want_v1(
+  p_user_id uuid,
+  p_card_print_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    p_user_id is not null
+    and p_card_print_id is not null
+    and exists (
+      select 1
+      from public.user_card_intents uci
+      where uci.user_id = p_user_id
+        and uci.card_print_id = p_card_print_id
+        and uci.want is true
+    );
+$$;
+
+comment on function public.viewer_has_current_card_want_v1(uuid, uuid) is
+'Canonical current-want truth boundary. A durable match, Pulse item, or local-community wishlist signal is current only while user_card_intents.want remains true for the exact card_print_id.';
+
+revoke all on function public.viewer_has_current_card_want_v1(uuid, uuid)
+from public, anon, authenticated;
+grant execute on function public.viewer_has_current_card_want_v1(uuid, uuid)
+to service_role;
+
+-- Preserve the existing source-card implementation, then replace its exposed
+-- wishlist boolean with the same current-want predicate used by the app.
+alter function public.local_community_visible_source_cards_v1(uuid)
+rename to legacy_local_community_visible_source_cards_v1;
+
+create or replace function public.local_community_visible_source_cards_v1(
+  p_viewer_user_id uuid
+)
+returns table (
+  source_type text,
+  owner_user_id uuid,
+  owner_slug text,
+  owner_display_name text,
+  owner_avatar_path text,
+  card_print_id uuid,
+  gv_id text,
+  card_name text,
+  set_code text,
+  set_name text,
+  card_number text,
+  intent text,
+  image_url text,
+  display_image_kind text,
+  locality_label text,
+  distance_bucket text,
+  relationship_context text,
+  viewer_wishlist_match boolean,
+  created_at timestamptz,
+  route_target text,
+  vault_item_id uuid,
+  instance_id uuid,
+  score double precision,
+  match_strength double precision,
+  recommended_tier text,
+  dedupe_key text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    src.source_type,
+    src.owner_user_id,
+    src.owner_slug,
+    src.owner_display_name,
+    src.owner_avatar_path,
+    src.card_print_id,
+    src.gv_id,
+    src.card_name,
+    src.set_code,
+    src.set_name,
+    src.card_number,
+    src.intent,
+    src.image_url,
+    src.display_image_kind,
+    src.locality_label,
+    src.distance_bucket,
+    src.relationship_context,
+    public.viewer_has_current_card_want_v1(
+      p_viewer_user_id,
+      src.card_print_id
+    ) as viewer_wishlist_match,
+    src.created_at,
+    src.route_target,
+    src.vault_item_id,
+    src.instance_id,
+    src.score,
+    src.match_strength,
+    src.recommended_tier,
+    src.dedupe_key
+  from public.legacy_local_community_visible_source_cards_v1(
+    p_viewer_user_id
+  ) src;
+$$;
+
+comment on function public.local_community_visible_source_cards_v1(uuid) is
+'Current-want truth wrapper around the preserved E5 local-community source implementation. viewer_wishlist_match is derived only from user_card_intents.want for the exact card print.';
+
+revoke all on function public.legacy_local_community_visible_source_cards_v1(uuid)
+from public, anon, authenticated;
+revoke all on function public.local_community_visible_source_cards_v1(uuid)
+from public, anon, authenticated;
+
+create or replace function public.stale_want_matches_when_intent_removed_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_should_stale boolean := false;
+begin
+  if tg_op = 'DELETE' then
+    v_should_stale := old.want is true;
+  elsif tg_op = 'UPDATE' then
+    v_should_stale := old.want is true and (
+      new.want is not true
+      or new.user_id is distinct from old.user_id
+      or new.card_print_id is distinct from old.card_print_id
+    );
+  end if;
+
+  if v_should_stale then
+    update public.want_matches wm
+    set status = 'stale',
+        stale_marked_at = coalesce(wm.stale_marked_at, now()),
+        payload = wm.payload || jsonb_build_object(
+          'stale_reason', 'canonical_want_removed',
+          'stale_policy_version', 'WANT_MATCH_CURRENT_WANT_TRUTH_V1'
+        )
+    where wm.want_user_id = old.user_id
+      and wm.card_print_id = old.card_print_id
+      and wm.status = 'active';
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_stale_want_matches_when_intent_removed_v1
+on public.user_card_intents;
+create trigger trg_stale_want_matches_when_intent_removed_v1
+after update or delete on public.user_card_intents
+for each row execute function public.stale_want_matches_when_intent_removed_v1();
+
+comment on function public.stale_want_matches_when_intent_removed_v1() is
+'Immediately marks active durable matches stale when the exact canonical want is turned off, deleted, or moved. Match and event history is retained.';
+
+revoke all on function public.stale_want_matches_when_intent_removed_v1()
+from public, anon, authenticated;
+
+-- The Binder migration preserved the original card/watch Pulse function under
+-- this name. Wrap it so every Pulse consumer, including unread and mark-seen,
+-- excludes a Want Match that is not backed by a current exact-card want.
+alter function public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)
+rename to legacy_binder_pulse_base_eligible_events_v1;
+
+create or replace function public.binder_pulse_base_eligible_events_for_viewer_v1(
+  p_viewer_user_id uuid
+)
+returns table (
+  card_event_id uuid,
+  event_type text,
+  rank_bucket text,
+  bucket_rank integer,
+  created_at timestamptz,
+  actor_user_id uuid,
+  actor_slug text,
+  actor_display_name text,
+  actor_avatar_path text,
+  subject_user_id uuid,
+  subject_slug text,
+  subject_display_name text,
+  card_print_id uuid,
+  gv_id text,
+  card_name text,
+  set_code text,
+  set_name text,
+  card_number text,
+  display_image_url text,
+  display_image_kind text,
+  ownership_context text,
+  distance_bucket text,
+  locality_label text,
+  value_delta_amount numeric,
+  value_delta_percent numeric,
+  completion_subject_type text,
+  completion_subject_label text,
+  completion_threshold numeric,
+  primary_action text,
+  primary_action_label text,
+  primary_action_route text,
+  payload jsonb,
+  visibility text,
+  watch_subject_type text,
+  watch_subject_id uuid,
+  watch_strength double precision
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select eligible.*
+  from public.legacy_binder_pulse_base_eligible_events_v1(
+    p_viewer_user_id
+  ) eligible
+  where eligible.event_type <> 'want_match_available'
+     or exists (
+       select 1
+       from public.want_matches wm
+       where wm.id = public.pulse_jsonb_uuid_v1(
+           eligible.payload ->> 'want_match_id'
+         )
+         and wm.want_user_id = p_viewer_user_id
+         and wm.card_print_id = eligible.card_print_id
+         and wm.status = 'active'
+         and public.viewer_has_current_card_want_v1(
+           p_viewer_user_id,
+           wm.card_print_id
+         )
+     );
+$$;
+
+comment on function public.binder_pulse_base_eligible_events_for_viewer_v1(uuid) is
+'Pulse current-want truth wrapper. Historical Want Match events remain stored but are ineligible when the durable match is not active or the exact canonical want no longer exists.';
+
+revoke all on function public.legacy_binder_pulse_base_eligible_events_v1(uuid)
+from public, anon, authenticated;
+revoke all on function public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)
+from public, anon, authenticated;
+grant execute on function public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)
+to service_role;
+
+-- Repair current drift without deleting any durable match or event rows.
+update public.want_matches wm
+set status = 'stale',
+    stale_marked_at = coalesce(wm.stale_marked_at, now()),
+    payload = wm.payload || jsonb_build_object(
+      'stale_reason', 'canonical_want_not_current_at_truth_repair',
+      'stale_policy_version', 'WANT_MATCH_CURRENT_WANT_TRUTH_V1'
+    )
+where wm.status = 'active'
+  and not public.viewer_has_current_card_want_v1(
+    wm.want_user_id,
+    wm.card_print_id
+  );
+
+-- Existing cleanup covers owner-side availability changes after its seven-day
+-- grace period. Schedule it as defense in depth; opt-outs are synchronous.
+do $$
+declare
+  v_job_id bigint;
+begin
+  if to_regclass('cron.job') is not null then
+    for v_job_id in
+      select jobid
+      from cron.job
+      where jobname = 'grookai-want-match-stale-cleanup-v1'
+    loop
+      perform cron.unschedule(v_job_id);
+    end loop;
+
+    perform cron.schedule(
+      'grookai-want-match-stale-cleanup-v1',
+      '*/15 * * * *',
+      'select count(*) from public.mark_stale_want_matches_v1(null, 1000);'
+    );
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql
+++ b/supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql
@@ -4,14 +4,18 @@ do $$
 begin
   if to_regclass('public.user_card_intents') is null
      or to_regclass('public.want_matches') is null
-     or to_regclass('public.card_events') is null then
-    raise exception 'Want Match truth repair requires user_card_intents, want_matches, and card_events';
+     or to_regclass('public.card_events') is null
+     or to_regclass('public.notification_outbox') is null then
+    raise exception 'Want Match truth repair requires user_card_intents, want_matches, card_events, and notification_outbox';
   end if;
 
   if to_regprocedure('public.local_community_visible_source_cards_v1(uuid)') is null
      or to_regprocedure('public.binder_pulse_base_eligible_events_for_viewer_v1(uuid)') is null
-     or to_regprocedure('public.mark_stale_want_matches_v1(uuid,integer)') is null then
-    raise exception 'Want Match truth repair requires the E3/E4/E5 read contracts';
+     or to_regprocedure('public.mark_stale_want_matches_v1(uuid,integer)') is null
+     or to_regprocedure('public.notification_dispatcher_claim_batch_v1(integer)') is null
+     or to_regprocedure('public.notification_dispatcher_mark_send_started_v1(uuid)') is null
+     or to_regprocedure('public.pulse_jsonb_uuid_v1(text)') is null then
+    raise exception 'Want Match truth repair requires the E2/E3/E4/E5 delivery and read contracts';
   end if;
 end;
 $$;
@@ -45,6 +49,172 @@ revoke all on function public.viewer_has_current_card_want_v1(uuid, uuid)
 from public, anon, authenticated;
 grant execute on function public.viewer_has_current_card_want_v1(uuid, uuid)
 to service_role;
+
+create or replace function public.notification_outbox_has_current_want_truth_v1(
+  p_event_type text,
+  p_recipient_user_id uuid,
+  p_card_print_id uuid,
+  p_payload jsonb
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with normalized as (
+    select
+      coalesce(p_payload, '{}'::jsonb) as payload,
+      case
+        when coalesce(p_payload #>> '{counts_by_type,want_match}', '') ~ '^[0-9]+$'
+          then (p_payload #>> '{counts_by_type,want_match}')::integer
+        else 0
+      end as pulse_want_count,
+      case
+        when coalesce(p_payload ->> 'match_count', '') ~ '^[0-9]+$'
+          then (p_payload ->> 'match_count')::integer
+        else 0
+      end as legacy_digest_match_count
+  ),
+  pulse_items as (
+    select item.value
+    from normalized n
+    cross join lateral jsonb_array_elements(
+      case
+        when jsonb_typeof(n.payload -> 'compact_item_ids') = 'array'
+          then n.payload -> 'compact_item_ids'
+        else '[]'::jsonb
+      end
+    ) item(value)
+  ),
+  pulse_refs as (
+    select public.pulse_jsonb_uuid_v1(item.value ->> 'want_match_id') as want_match_id
+    from pulse_items item
+    where public.pulse_jsonb_uuid_v1(item.value ->> 'want_match_id') is not null
+    union all
+    select public.pulse_jsonb_uuid_v1(ce.payload ->> 'want_match_id') as want_match_id
+    from pulse_items item
+    join public.card_events ce
+      on ce.id = public.pulse_jsonb_uuid_v1(item.value ->> 'card_event_id')
+     and ce.event_type = 'want_match_available'
+    where public.pulse_jsonb_uuid_v1(ce.payload ->> 'want_match_id') is not null
+  ),
+  legacy_digest_refs as (
+    select public.pulse_jsonb_uuid_v1(item.value) as want_match_id
+    from normalized n
+    cross join lateral jsonb_array_elements_text(
+      case
+        when jsonb_typeof(n.payload -> 'compact_match_ids') = 'array'
+          then n.payload -> 'compact_match_ids'
+        else '[]'::jsonb
+      end
+    ) item(value)
+    where public.pulse_jsonb_uuid_v1(item.value) is not null
+  ),
+  relevant_refs as (
+    select want_match_id from pulse_refs where p_event_type = 'pulse_daily'
+    union all
+    select want_match_id from legacy_digest_refs where p_event_type = 'want_match_digest'
+  ),
+  ref_truth as (
+    select
+      count(*)::integer as reference_count,
+      count(*) filter (
+        where wm.id is null
+           or wm.want_user_id is distinct from p_recipient_user_id
+           or wm.status is distinct from 'active'
+           or not public.viewer_has_current_card_want_v1(
+             p_recipient_user_id,
+             wm.card_print_id
+           )
+      )::integer as invalid_reference_count
+    from relevant_refs refs
+    left join public.want_matches wm on wm.id = refs.want_match_id
+  )
+  select case
+    when p_event_type = 'want_match_available' then exists (
+      select 1
+      from public.want_matches wm
+      where wm.id = public.pulse_jsonb_uuid_v1(
+          coalesce(p_payload, '{}'::jsonb) ->> 'want_match_id'
+        )
+        and wm.want_user_id = p_recipient_user_id
+        and wm.card_print_id = p_card_print_id
+        and wm.status = 'active'
+        and public.viewer_has_current_card_want_v1(
+          p_recipient_user_id,
+          wm.card_print_id
+        )
+    )
+    when p_event_type = 'pulse_daily'
+         and (select pulse_want_count from normalized) > 0 then
+      (select reference_count from ref_truth) =
+        (select pulse_want_count from normalized)
+      and (select invalid_reference_count from ref_truth) = 0
+    when p_event_type = 'want_match_digest' then
+      (select legacy_digest_match_count from normalized) > 0
+      and (select reference_count from ref_truth) =
+        (select legacy_digest_match_count from normalized)
+      and (select invalid_reference_count from ref_truth) = 0
+    else true
+  end;
+$$;
+
+comment on function public.notification_outbox_has_current_want_truth_v1(text, uuid, uuid, jsonb) is
+'Final delivery evidence gate for Want Match instant and digest-bearing outbox rows. Every represented durable match must remain active and backed by the recipient current exact-card want; incomplete compact evidence fails closed.';
+
+revoke all on function public.notification_outbox_has_current_want_truth_v1(text, uuid, uuid, jsonb)
+from public, anon, authenticated;
+grant execute on function public.notification_outbox_has_current_want_truth_v1(text, uuid, uuid, jsonb)
+to service_role;
+
+create or replace function public.enforce_current_want_match_activation_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_current_want boolean;
+begin
+  if new.status <> 'active' then
+    return new;
+  end if;
+
+  select uci.want
+  into v_current_want
+  from public.user_card_intents uci
+  where uci.user_id = new.want_user_id
+    and uci.card_print_id = new.card_print_id
+  for update;
+
+  if not found or v_current_want is not true then
+    update public.want_matches wm
+    set status = 'stale',
+        stale_marked_at = coalesce(wm.stale_marked_at, now()),
+        payload = wm.payload || jsonb_build_object(
+          'stale_reason', 'activation_without_current_want',
+          'stale_policy_version', 'WANT_MATCH_CURRENT_WANT_TRUTH_V1'
+        )
+    where wm.id = new.id
+      and wm.status = 'active';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_enforce_current_want_match_activation_v1
+on public.want_matches;
+create trigger trg_enforce_current_want_match_activation_v1
+after insert or update of status on public.want_matches
+for each row execute function public.enforce_current_want_match_activation_v1();
+
+comment on function public.enforce_current_want_match_activation_v1() is
+'Serializes every active Want Match insert/reactivation against the exact user_card_intents row. Unsupported activation is converted to retained stale history before the transaction commits.';
+
+revoke all on function public.enforce_current_want_match_activation_v1()
+from public, anon, authenticated;
 
 -- Preserve the existing source-card implementation, then replace its exposed
 -- wishlist boolean with the same current-want predicate used by the app.
@@ -160,6 +330,26 @@ begin
     where wm.want_user_id = old.user_id
       and wm.card_print_id = old.card_print_id
       and wm.status = 'active';
+
+    update public.notification_outbox outbox
+    set failed_at = now(),
+        failure_reason = 'cancelled_current_want_removed',
+        claimed_at = null,
+        claim_expires_at = null
+    where outbox.recipient_user_id = old.user_id
+      and outbox.sent_at is null
+      and outbox.folded_into_digest_at is null
+      and outbox.failed_at is null
+      and outbox.send_started_at is null
+      and (
+        (
+          outbox.event_type = 'want_match_available'
+          and outbox.card_print_id = old.card_print_id
+        )
+        or outbox.event_type = any (
+          array['want_match_digest'::text, 'pulse_daily'::text]
+        )
+      );
   end if;
 
   if tg_op = 'DELETE' then
@@ -180,6 +370,211 @@ comment on function public.stale_want_matches_when_intent_removed_v1() is
 
 revoke all on function public.stale_want_matches_when_intent_removed_v1()
 from public, anon, authenticated;
+
+create or replace function public.notification_dispatcher_claim_batch_v1(
+  p_limit integer default 25
+)
+returns setof public.notification_outbox
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.notification_outbox outbox
+  set failed_at = now(),
+      failure_reason = 'cancelled_current_want_not_supported',
+      claimed_at = null,
+      claim_expires_at = null
+  where outbox.sent_at is null
+    and outbox.failed_at is null
+    and outbox.folded_into_digest_at is null
+    and outbox.send_started_at is null
+    and outbox.event_type = any (
+      array[
+        'want_match_available'::text,
+        'want_match_digest'::text,
+        'pulse_daily'::text
+      ]
+    )
+    and not public.notification_outbox_has_current_want_truth_v1(
+      outbox.event_type,
+      outbox.recipient_user_id,
+      outbox.card_print_id,
+      outbox.payload
+    );
+
+  return query
+  with candidate_rows as (
+    select outbox.id
+    from public.notification_outbox outbox
+    where outbox.sent_at is null
+      and outbox.failed_at is null
+      and outbox.folded_into_digest_at is null
+      and outbox.available_at <= now()
+      and outbox.next_attempt_at <= now()
+      and public.notification_outbox_has_current_want_truth_v1(
+        outbox.event_type,
+        outbox.recipient_user_id,
+        outbox.card_print_id,
+        outbox.payload
+      )
+      and (
+        outbox.claimed_at is null
+        or (
+          outbox.claim_expires_at < now()
+          and outbox.send_started_at is null
+        )
+      )
+    order by outbox.available_at asc, outbox.created_at asc
+    limit greatest(1, least(coalesce(p_limit, 25), 100))
+    for update skip locked
+  )
+  update public.notification_outbox outbox
+  set claimed_at = now(),
+      claim_expires_at = now() + interval '5 minutes',
+      attempts = outbox.attempts + 1
+  from candidate_rows candidates
+  where outbox.id = candidates.id
+  returning outbox.*;
+end;
+$$;
+
+comment on function public.notification_dispatcher_claim_batch_v1(integer) is
+'Claims only current delivery evidence. Unsupported Want Match instant and digest-bearing rows are terminally cancelled before dispatch.';
+
+revoke all on function public.notification_dispatcher_claim_batch_v1(integer)
+from public, anon, authenticated;
+grant execute on function public.notification_dispatcher_claim_batch_v1(integer)
+to service_role;
+
+create or replace function public.notification_dispatcher_mark_send_started_if_current_v1(
+  p_outbox_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_outbox public.notification_outbox%rowtype;
+  v_card_print_id uuid;
+begin
+  -- Read routing fields first without taking an outbox lock. Intent writes take
+  -- their row lock before the opt-out trigger touches outbox rows, so the send
+  -- boundary must use that same intent -> outbox lock order.
+  select *
+  into v_outbox
+  from public.notification_outbox
+  where id = p_outbox_id;
+
+  if not found
+     or v_outbox.sent_at is not null
+     or v_outbox.failed_at is not null
+     or v_outbox.folded_into_digest_at is not null
+     or v_outbox.send_started_at is not null then
+    return false;
+  end if;
+
+  if v_outbox.event_type = 'want_match_available' then
+    perform 1
+    from public.user_card_intents uci
+    where uci.user_id = v_outbox.recipient_user_id
+      and uci.card_print_id = v_outbox.card_print_id
+    for update;
+  elsif v_outbox.event_type = any (
+    array['want_match_digest'::text, 'pulse_daily'::text]
+  ) then
+    for v_card_print_id in
+      with pulse_items as (
+        select item.value
+        from jsonb_array_elements(
+          case
+            when jsonb_typeof(v_outbox.payload -> 'compact_item_ids') = 'array'
+              then v_outbox.payload -> 'compact_item_ids'
+            else '[]'::jsonb
+          end
+        ) item(value)
+      ),
+      referenced_matches as (
+        select public.pulse_jsonb_uuid_v1(item.value ->> 'want_match_id') as want_match_id
+        from pulse_items item
+        where public.pulse_jsonb_uuid_v1(item.value ->> 'want_match_id') is not null
+        union
+        select public.pulse_jsonb_uuid_v1(ce.payload ->> 'want_match_id') as want_match_id
+        from pulse_items item
+        join public.card_events ce
+          on ce.id = public.pulse_jsonb_uuid_v1(item.value ->> 'card_event_id')
+         and ce.event_type = 'want_match_available'
+        where public.pulse_jsonb_uuid_v1(ce.payload ->> 'want_match_id') is not null
+        union
+        select public.pulse_jsonb_uuid_v1(item.value) as want_match_id
+        from jsonb_array_elements_text(
+          case
+            when jsonb_typeof(v_outbox.payload -> 'compact_match_ids') = 'array'
+              then v_outbox.payload -> 'compact_match_ids'
+            else '[]'::jsonb
+          end
+        ) item(value)
+        where public.pulse_jsonb_uuid_v1(item.value) is not null
+      )
+      select distinct wm.card_print_id
+      from referenced_matches refs
+      join public.want_matches wm on wm.id = refs.want_match_id
+      where wm.want_user_id = v_outbox.recipient_user_id
+      order by wm.card_print_id
+    loop
+      perform 1
+      from public.user_card_intents uci
+      where uci.user_id = v_outbox.recipient_user_id
+        and uci.card_print_id = v_card_print_id
+      for update;
+    end loop;
+  end if;
+
+  select *
+  into v_outbox
+  from public.notification_outbox
+  where id = p_outbox_id
+  for update;
+
+  if not found
+     or v_outbox.sent_at is not null
+     or v_outbox.failed_at is not null
+     or v_outbox.folded_into_digest_at is not null
+     or v_outbox.send_started_at is not null then
+    return false;
+  end if;
+
+  if not public.notification_outbox_has_current_want_truth_v1(
+    v_outbox.event_type,
+    v_outbox.recipient_user_id,
+    v_outbox.card_print_id,
+    v_outbox.payload
+  ) then
+    update public.notification_outbox
+    set failed_at = now(),
+        failure_reason = 'cancelled_current_want_not_supported',
+        claimed_at = null,
+        claim_expires_at = null
+    where id = p_outbox_id;
+    return false;
+  end if;
+
+  update public.notification_outbox
+  set send_started_at = coalesce(send_started_at, now())
+  where id = p_outbox_id;
+
+  return true;
+end;
+$$;
+
+comment on function public.notification_dispatcher_mark_send_started_if_current_v1(uuid) is
+'Atomic final pre-FCM gate. Locks the outbox row, rechecks current Want Match evidence, and starts delivery only when that evidence still holds.';
+
+revoke all on function public.notification_dispatcher_mark_send_started_if_current_v1(uuid)
+from public, anon, authenticated;
+grant execute on function public.notification_dispatcher_mark_send_started_if_current_v1(uuid)
+to service_role;
 
 -- The Binder migration preserved the original card/watch Pulse function under
 -- this name. Wrap it so every Pulse consumer, including unread and mark-seen,
@@ -276,6 +671,32 @@ where wm.status = 'active'
   and not public.viewer_has_current_card_want_v1(
     wm.want_user_id,
     wm.card_print_id
+  );
+
+-- Cancel any pre-existing unsent alert whose current evidence was invalidated
+-- by the status repair. Daily rows are cancelled as one immutable payload so
+-- their counts and top-card copy cannot retain an opted-out match.
+update public.notification_outbox outbox
+set failed_at = now(),
+    failure_reason = 'cancelled_current_want_not_supported',
+    claimed_at = null,
+    claim_expires_at = null
+where outbox.sent_at is null
+  and outbox.folded_into_digest_at is null
+  and outbox.failed_at is null
+  and outbox.send_started_at is null
+  and outbox.event_type = any (
+    array[
+      'want_match_available'::text,
+      'want_match_digest'::text,
+      'pulse_daily'::text
+    ]
+  )
+  and not public.notification_outbox_has_current_want_truth_v1(
+    outbox.event_type,
+    outbox.recipient_user_id,
+    outbox.card_print_id,
+    outbox.payload
   );
 
 -- Existing cleanup covers owner-side availability changes after its seven-day

--- a/tests/contracts/e3_want_match_delivery_contract_v1.test.mjs
+++ b/tests/contracts/e3_want_match_delivery_contract_v1.test.mjs
@@ -79,7 +79,7 @@ test("E3 dispatcher formats want-match notifications and reschedules digest budg
   assert.match(dispatcher, /reason === "daily_budget_exhausted"/);
 });
 
-test("E3 local smoke has delivery gates for instant, digest, owner-zero, and reschedule", () => {
+test("E3 local smoke proves instant delivery and the E4 digest cutover", () => {
   const script = readSource("scripts/audits/e3_want_match_local_fixture_smoke_v1.mjs");
 
   assert.match(script, /--include-delivery/);
@@ -87,6 +87,7 @@ test("E3 local smoke has delivery gates for instant, digest, owner-zero, and res
   assert.match(script, /instant_enqueue_second/);
   assert.match(script, /owner_outbox_rows/);
   assert.match(script, /enqueue_want_match_digest_notifications_v1/);
-  assert.match(script, /notification_dispatcher_reschedule_digest_fold_v1/);
+  assert.match(script, /legacy_digest_cutover/);
+  assert.match(script, /run_pulse_daily_aggregation_v1/);
   assert.match(script, /delivery_failures/);
 });

--- a/tests/contracts/e4_pulse_daily_delivery_contract_v1.test.mjs
+++ b/tests/contracts/e4_pulse_daily_delivery_contract_v1.test.mjs
@@ -88,5 +88,8 @@ test("E4 Pulse daily local smoke covers PR2 gate", () => {
   assert.match(script, /legacy_digest_after_cutover/);
   assert.match(script, /undelivered_legacy_digest_rows/);
   assert.match(script, /notification_dispatcher_reschedule_digest_fold_v1/);
+  assert.match(script, /notification_outbox_has_current_want_truth_v1/);
+  assert.match(script, /cancelled_current_want_removed/);
+  assert.match(script, /pulse_daily_claimed_after_opt_out/);
   assert.match(script, /rollback_only/);
 });

--- a/tests/contracts/want_match_current_want_truth_boundary_v1.test.mjs
+++ b/tests/contracts/want_match_current_want_truth_boundary_v1.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const migrationPath =
+  "supabase/migrations/20260807043000_want_match_current_want_truth_boundary_v1.sql";
+
+function readSource(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+test("current Want Match truth is the exact user_card_intents row", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(sql, /create or replace function public\.viewer_has_current_card_want_v1/i);
+  assert.match(sql, /from public\.user_card_intents uci/i);
+  assert.match(sql, /uci\.user_id = p_user_id/i);
+  assert.match(sql, /uci\.card_print_id = p_card_print_id/i);
+  assert.match(sql, /uci\.want is true/i);
+  assert.doesNotMatch(
+    sql,
+    /create or replace function public\.viewer_has_current_card_want_v1[\s\S]*?from public\.wishlist_items/i,
+  );
+});
+
+test("local-community wishlist signals use the same current-want boundary", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(
+    sql,
+    /alter function public\.local_community_visible_source_cards_v1\(uuid\)[\s\S]*rename to legacy_local_community_visible_source_cards_v1/i,
+  );
+  assert.match(
+    sql,
+    /public\.viewer_has_current_card_want_v1\(\s*p_viewer_user_id,\s*src\.card_print_id\s*\) as viewer_wishlist_match/i,
+  );
+});
+
+test("turning off or deleting a want stales matches without deleting history", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(sql, /create or replace function public\.stale_want_matches_when_intent_removed_v1/i);
+  assert.match(sql, /after update or delete on public\.user_card_intents/i);
+  assert.match(sql, /old\.want is true/i);
+  assert.match(sql, /new\.want is not true/i);
+  assert.match(sql, /update public\.want_matches wm/i);
+  assert.match(sql, /set status = 'stale'/i);
+  assert.match(sql, /where wm\.want_user_id = old\.user_id/i);
+  assert.match(sql, /and wm\.card_print_id = old\.card_print_id/i);
+  assert.doesNotMatch(sql, /delete from public\.want_matches/i);
+  assert.doesNotMatch(sql, /delete from public\.card_events/i);
+});
+
+test("Pulse eligibility rejects inactive or unsupported Want Match events", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(
+    sql,
+    /alter function public\.binder_pulse_base_eligible_events_for_viewer_v1\(uuid\)[\s\S]*rename to legacy_binder_pulse_base_eligible_events_v1/i,
+  );
+  assert.match(sql, /eligible\.event_type <> 'want_match_available'/i);
+  assert.match(sql, /wm\.status = 'active'/i);
+  assert.match(sql, /wm\.want_user_id = p_viewer_user_id/i);
+  assert.match(sql, /wm\.card_print_id = eligible\.card_print_id/i);
+  assert.match(
+    sql,
+    /public\.viewer_has_current_card_want_v1\(\s*p_viewer_user_id,\s*wm\.card_print_id\s*\)/i,
+  );
+});
+
+test("existing drift is status-repaired and owner-side cleanup is scheduled", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(
+    sql,
+    /update public\.want_matches wm[\s\S]*where wm\.status = 'active'[\s\S]*not public\.viewer_has_current_card_want_v1/i,
+  );
+  assert.match(sql, /canonical_want_not_current_at_truth_repair/i);
+  assert.match(sql, /grookai-want-match-stale-cleanup-v1/i);
+  assert.match(sql, /mark_stale_want_matches_v1\(null, 1000\)/i);
+  assert.match(sql, /'\*\/15 \* \* \* \*'/i);
+  assert.doesNotMatch(sql, /\btruncate\b/i);
+  assert.doesNotMatch(sql, /\bdrop table\b/i);
+});
+
+test("rollback-only E3 smoke covers opt-out hiding and deterministic reactivation", () => {
+  const script = readSource(
+    "scripts/audits/e3_want_match_local_fixture_smoke_v1.mjs",
+  );
+
+  assert.match(script, /insert into public\.user_card_intents/i);
+  assert.match(script, /pulseBeforeWantOff/);
+  assert.match(script, /statusAfterWantOff/);
+  assert.match(script, /candidatesAfterWantOff/);
+  assert.match(script, /pulseAfterWantOff/);
+  assert.match(script, /reactivationRun/);
+  assert.match(script, /pulseAfterReactivation/);
+  assert.match(script, /rollback_only: true/);
+});
+
+test("Pulse fixture carries a real active match and exact current-want evidence", () => {
+  const script = readSource(
+    "scripts/audits/e4_pulse_local_fixture_smoke_v1.mjs",
+  );
+
+  assert.match(script, /wantMatchId/);
+  assert.match(script, /insert into public\.user_card_intents/i);
+  assert.match(script, /insert into public\.want_matches/i);
+  assert.match(script, /'want_match_id', \$13::text/i);
+  assert.match(script, /'active'/i);
+});

--- a/tests/contracts/want_match_current_want_truth_boundary_v1.test.mjs
+++ b/tests/contracts/want_match_current_want_truth_boundary_v1.test.mjs
@@ -53,6 +53,51 @@ test("turning off or deleting a want stales matches without deleting history", (
   assert.doesNotMatch(sql, /delete from public\.card_events/i);
 });
 
+test("every active match activation serializes against the exact current intent", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(sql, /create or replace function public\.enforce_current_want_match_activation_v1/i);
+  assert.match(sql, /from public\.user_card_intents uci[\s\S]*for update/i);
+  assert.match(sql, /after insert or update of status on public\.want_matches/i);
+  assert.match(sql, /activation_without_current_want/i);
+  assert.match(sql, /set status = 'stale'/i);
+});
+
+test("opt-out terminally cancels queued Want Match delivery", () => {
+  const sql = readSource(migrationPath);
+
+  assert.match(
+    sql,
+    /update public\.notification_outbox outbox[\s\S]*cancelled_current_want_removed/i,
+  );
+  assert.match(sql, /outbox\.send_started_at is null/i);
+  assert.match(sql, /outbox\.event_type = 'want_match_available'/i);
+  assert.match(sql, /'want_match_digest'::text, 'pulse_daily'::text/i);
+  assert.match(sql, /failed_at = now\(\)/i);
+});
+
+test("dispatcher claim and send-start both recheck current evidence", () => {
+  const sql = readSource(migrationPath);
+  const worker = readSource("supabase/functions/notification-dispatcher/index.ts");
+
+  assert.match(sql, /create or replace function public\.notification_outbox_has_current_want_truth_v1/i);
+  assert.match(
+    sql,
+    /create or replace function public\.notification_dispatcher_claim_batch_v1[\s\S]*notification_outbox_has_current_want_truth_v1/i,
+  );
+  assert.match(
+    sql,
+    /create or replace function public\.notification_dispatcher_mark_send_started_if_current_v1[\s\S]*same intent -> outbox lock order[\s\S]*from public\.user_card_intents[\s\S]*for update[\s\S]*from public\.notification_outbox[\s\S]*for update[\s\S]*notification_outbox_has_current_want_truth_v1/i,
+  );
+  assert.match(sql, /v_outbox\.send_started_at is not null then[\s\S]*return false/i);
+  assert.match(
+    worker,
+    /notification_dispatcher_mark_send_started_if_current_v1/,
+  );
+  assert.match(worker, /sendStarted !== true/);
+  assert.match(worker, /current_evidence_invalidated/);
+});
+
 test("Pulse eligibility rejects inactive or unsupported Want Match events", () => {
   const sql = readSource(migrationPath);
 
@@ -95,8 +140,11 @@ test("rollback-only E3 smoke covers opt-out hiding and deterministic reactivatio
   assert.match(script, /statusAfterWantOff/);
   assert.match(script, /candidatesAfterWantOff/);
   assert.match(script, /pulseAfterWantOff/);
+  assert.match(script, /invalidatedSendStart/);
   assert.match(script, /reactivationRun/);
   assert.match(script, /pulseAfterReactivation/);
+  assert.match(script, /validSendStart/);
+  assert.match(script, /duplicateSendStart/);
   assert.match(script, /rollback_only: true/);
 });
 


### PR DESCRIPTION
## Summary
- make `user_card_intents.want=true` the exact current Want Match authority
- stale durable matches synchronously on opt-out while preserving match/event history
- require active match plus current exact want at Pulse eligibility
- schedule bounded owner-side stale cleanup
- update rollback-only E3/E4 fixtures and permanent release evidence

## Production preflight
- 2 durable match rows
- 2 active rows without a current exact want
- 2 historical availability events retained
- 0 production writes during preflight

## Verification
- complete repository shipcheck passed three times
- 1,544 Node contracts passed
- strict web typecheck, lint, and production build passed
- Flutter analyze and 571 tests passed
- E3 and E4 rollback-only local database smokes passed
- local schema/security/trigger/cron readback passed
- artifact hash reconciliation passed

## Boundaries
- no match or event deletion
- no canonical identity, Vault, ownership, or pricing mutation
- no client privilege expansion
- production apply remains a separate controlled gate