### PR TITLE
Fix shared Memory links and publication route

### DIFF
--- a/.github/workflows/collector-memory-share-route-migration.yml
+++ b/.github/workflows/collector-memory-share-route-migration.yml
@@ -1,0 +1,91 @@
+name: Collector Memory Share Route Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Inspect or apply the frozen Memory share-route migration
+        required: true
+        type: choice
+        options:
+          - dry_run
+          - apply
+      expected_sha:
+        description: Exact pushed commit SHA that must be checked out
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: collector-memory-share-route-migration-v1
+  cancel-in-progress: false
+
+jobs:
+  migration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      TARGET_MIGRATION: '20260811213000'
+      TARGET_FILE: supabase/migrations/20260811213000_collector_memory_share_route_v1.sql
+      DISPATCH_MODE: ${{ inputs.mode }}
+      EXPECTED_SHA: ${{ inputs.expected_sha }}
+
+    steps:
+      - name: Check out frozen ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.expected_sha }}
+          fetch-depth: 0
+
+      - name: Verify frozen boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_DB_URL"
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          test -z "$(git status --porcelain --untracked-files=no)"
+          test -f "$TARGET_FILE"
+          grep -q "collector_memory_accessible_by_id_v1" "$TARGET_FILE"
+
+      - name: Inspect pending migrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes supabase@2.90.0 db push \
+            --db-url "$SUPABASE_DB_URL" \
+            --dry-run 2>&1 | tee migration_dry_run.txt
+          grep -q "$TARGET_MIGRATION" migration_dry_run.txt
+          pending_count="$(grep -Ec '^[[:space:]]*•[[:space:]]+[0-9]{14}' migration_dry_run.txt || true)"
+          test "$pending_count" = "1"
+
+      - name: Apply frozen migration
+        if: ${{ inputs.mode == 'apply' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes supabase@2.90.0 db push --db-url "$SUPABASE_DB_URL" --yes
+
+      - name: Read back function and grants
+        if: ${{ inputs.mode == 'apply' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          psql "$SUPABASE_DB_URL" --no-psqlrc --tuples-only --no-align \
+            --field-separator=, \
+            --command="select p.proname, p.prosecdef, has_function_privilege('authenticated', p.oid, 'execute') as authenticated_execute, has_function_privilege('anon', p.oid, 'execute') as anon_execute from pg_proc p join pg_namespace n on n.oid = p.pronamespace where n.nspname = 'public' and p.proname = 'collector_memory_accessible_by_id_v1';" \
+            | tee function_readback.csv
+          grep -q 'collector_memory_accessible_by_id_v1,true,true,false' function_readback.csv
+
+      - name: Upload bounded evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: collector-memory-share-route-${{ inputs.mode }}-${{ github.run_id }}
+          path: |
+            migration_dry_run.txt
+            function_readback.csv
+          if-no-files-found: warn
+          retention-days: 90

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
                 <data android:scheme="grookai" />
                 <data android:scheme="grookaivault" />
                 <data android:host="card" />
+                <data android:host="memory" />
                 <data android:host="u" />
                 <data android:host="collector" />
                 <data android:host="set" />
@@ -76,6 +77,7 @@
                 <data android:scheme="https" />
                 <data android:host="grookaivault.com" />
                 <data android:pathPrefix="/card/" />
+                <data android:pathPrefix="/memory/" />
                 <data android:pathPrefix="/u/" />
                 <data android:pathPrefix="/collector/" />
                 <data android:pathPrefix="/set/" />

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -6,6 +6,7 @@
         "appID": "DUADT25J5V.com.cesar.grookaivault",
         "paths": [
           "/card/*",
+          "/memory/*",
           "/u/*",
           "/collector/*",
           "/set/*",

--- a/apps/web/src/app/memory/[memory_id]/page.tsx
+++ b/apps/web/src/app/memory/[memory_id]/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import PageSection from "@/components/layout/PageSection";
+import PublicCardImage from "@/components/PublicCardImage";
+import SectionHeader from "@/components/layout/SectionHeader";
+import { requireServerUser } from "@/lib/auth/requireServerUser";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: "Collector Memory | Grookai Vault",
+  description: "Open a shared collector Memory on Grookai Vault.",
+  robots: { index: false, follow: false },
+};
+
+type MemoryRouteRow = {
+  id: string;
+  gv_vi_id: string | null;
+  card_name: string | null;
+  set_name: string | null;
+  card_image_url: string | null;
+  gv_id: string | null;
+  owner_slug: string | null;
+  owner_display_name: string | null;
+  viewer_is_owner: boolean;
+  memory_type: string;
+  note: string | null;
+  photo_path: string | null;
+  place_label: string | null;
+  occasion_label: string | null;
+  memory_date: string | null;
+  is_public: boolean;
+  published_at: string | null;
+};
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function firstRow(value: unknown): MemoryRouteRow | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const row = value[0];
+  return row && typeof row === "object" ? (row as MemoryRouteRow) : null;
+}
+
+function formatMemoryType(value: string) {
+  switch (value.trim().toLowerCase()) {
+    case "added_place":
+      return "Added here";
+    case "occasion":
+      return "Occasion";
+    case "first":
+      return "First memory";
+    default:
+      return "Collector note";
+  }
+}
+
+function formatDate(value: string | null) {
+  if (!value) return null;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default async function CollectorMemoryRoutePage(props: {
+  params: Promise<{ memory_id: string }>;
+}) {
+  const params = await props.params;
+  const memoryId = params.memory_id.trim();
+  if (!isUuid(memoryId)) notFound();
+
+  const currentPath = `/memory/${encodeURIComponent(memoryId)}`;
+  const { supabase } = await requireServerUser(currentPath);
+  const { data, error } = await supabase.rpc(
+    "collector_memory_accessible_by_id_v1",
+    { p_memory_id: memoryId },
+  );
+  if (error) {
+    console.error("collector_memory_route_read_failed", {
+      code: error.code,
+      memoryId,
+    });
+    notFound();
+  }
+
+  const memory = firstRow(data);
+  if (!memory) notFound();
+
+  let signedPhotoUrl: string | null = null;
+  if (memory.photo_path) {
+    const { data: signedPhoto } = await supabase.storage
+      .from("collector-memory-images")
+      .createSignedUrl(memory.photo_path, 300);
+    signedPhotoUrl = signedPhoto?.signedUrl ?? null;
+  }
+
+  const cardName = memory.card_name?.trim() || "Card memory";
+  const ownerName = memory.owner_display_name?.trim() || "Collector";
+  const memoryDate = formatDate(memory.memory_date);
+  const imageUrl =
+    signedPhotoUrl ||
+    (memory.gv_id
+      ? `/api/canon/cards/${encodeURIComponent(memory.gv_id)}/image`
+      : memory.card_image_url);
+  const details = [
+    memoryDate ? { label: "Date", value: memoryDate } : null,
+    memory.place_label?.trim()
+      ? { label: "Place", value: memory.place_label.trim() }
+      : null,
+    memory.occasion_label?.trim()
+      ? { label: "Occasion", value: memory.occasion_label.trim() }
+      : null,
+  ].filter((item): item is { label: string; value: string } => Boolean(item));
+
+  return (
+    <div className="space-y-7 py-6 md:space-y-9 md:py-8">
+      <header className="max-w-3xl space-y-2">
+        <p className="text-xs font-semibold uppercase text-emerald-700">
+          {formatMemoryType(memory.memory_type)}
+        </p>
+        <h1 className="text-3xl font-bold text-slate-950 dark:text-white">
+          {cardName}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          {memory.viewer_is_owner ? "Your collector Memory" : `Shared by ${ownerName}`}
+          {memory.set_name?.trim() ? ` · ${memory.set_name.trim()}` : ""}
+        </p>
+      </header>
+
+      <div className="grid gap-7 lg:grid-cols-[minmax(280px,0.8fr)_minmax(0,1.2fr)]">
+        <div className="mx-auto w-full max-w-xl lg:mx-0">
+          <PublicCardImage
+            src={imageUrl ?? undefined}
+            alt={`Memory for ${cardName}`}
+            imageClassName="max-h-[70vh] w-full rounded-lg border border-slate-200 bg-white object-contain shadow-sm dark:border-slate-700 dark:bg-slate-950"
+            fallbackClassName="flex aspect-[5/7] w-full items-center justify-center rounded-lg border border-slate-200 bg-slate-100 px-5 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400"
+            fallbackLabel={`Image unavailable for ${cardName}`}
+          />
+        </div>
+
+        <div className="space-y-6">
+          <PageSection surface="card" spacing="loose">
+            <SectionHeader
+              title="Memory"
+              description={memory.viewer_is_owner && !memory.is_public ? "Private" : "Shared with collectors"}
+            />
+            {memory.note?.trim() ? (
+              <p className="whitespace-pre-wrap text-base leading-7 text-slate-800 dark:text-slate-100">
+                {memory.note.trim()}
+              </p>
+            ) : (
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                This Memory does not include a written note.
+              </p>
+            )}
+
+            {details.length > 0 ? (
+              <dl className="grid gap-4 border-t border-slate-200 pt-5 sm:grid-cols-2 dark:border-slate-700">
+                {details.map((detail) => (
+                  <div key={detail.label}>
+                    <dt className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
+                      {detail.label}
+                    </dt>
+                    <dd className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                      {detail.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </PageSection>
+
+          <div className="flex flex-wrap gap-3">
+            {memory.gv_id ? (
+              <Link href={`/card/${encodeURIComponent(memory.gv_id)}`} className="gv-primary-button">
+                View card
+              </Link>
+            ) : null}
+            {!memory.viewer_is_owner && memory.owner_slug ? (
+              <Link href={`/u/${encodeURIComponent(memory.owner_slug)}`} className="gv-secondary-button">
+                View collector
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,22 +1,28 @@
 PODS:
   - Flutter (1.0.0)
+  - printing (1.0.0):
+    - Flutter
   - sensors_plus (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - printing (from `.symlinks/plugins/printing/ios`)
   - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  printing:
+    :path: ".symlinks/plugins/printing/ios"
   sensors_plus:
     :path: ".symlinks/plugins/sensors_plus/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  printing: 54ff03f28fe9ba3aa93358afb80a8595a071dd07
   sensors_plus: 3c3bac724a2128c895623e03efd82cf0e94fd8e8
 
-PODFILE CHECKSUM: 288656d4464589360115d6f81dd5d8f559352730
+PODFILE CHECKSUM: 5442629a0e43310dea8d09b4a44dc727bc895bae
 
 COCOAPODS: 1.17.0

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'screens/public_collector/public_collector_relationship_screen.dart';
 import 'screens/public_collector/public_collector_screen.dart';
 import 'screens/gvvi/public_gvvi_screen.dart';
 import 'screens/grookai_objects/collector_memories_screen.dart';
+import 'screens/grookai_objects/collector_memory_route_screen.dart';
 import 'screens/grookai_objects/grookai_objects_hub_screen.dart';
 import 'screens/grookai_objects/lot_pricing_screen.dart';
 import 'screens/sets/public_set_detail_screen.dart';
@@ -3204,6 +3205,7 @@ class _MyAppState extends State<MyApp> {
                     gvId: pendingRoute.value,
                   );
                   break;
+                case GrookaiCanonicalRouteKind.memory:
                 case GrookaiCanonicalRouteKind.collector:
                 case GrookaiCanonicalRouteKind.collectorSection:
                 case GrookaiCanonicalRouteKind.set:

--- a/lib/main_shell.dart
+++ b/lib/main_shell.dart
@@ -668,6 +668,16 @@ class _AppShellState extends State<AppShell> {
       case GrookaiCanonicalRouteKind.card:
         await _openCardDetailFromCanonicalGvId(route.value);
         break;
+      case GrookaiCanonicalRouteKind.memory:
+        unawaited(
+          _pushPage<void>(
+            CollectorMemoryRouteScreen(
+              memoryId: route.value,
+              onViewCard: _openCardDetailFromCanonicalGvId,
+            ),
+          ),
+        );
+        break;
       case GrookaiCanonicalRouteKind.collector:
         unawaited(_pushPage<void>(PublicCollectorScreen(slug: route.value)));
         break;

--- a/lib/models/grookai_memory_card.dart
+++ b/lib/models/grookai_memory_card.dart
@@ -35,6 +35,7 @@ class GrookaiMemoryCardAdapter {
       listingNo: listingNoFor(memory.id),
       date: date,
       location: memory.placeLabel,
+      occasion: memory.occasionLabel,
       photoUrl: signedPhotoUrl,
       storyText: memory.note,
       metadata: <String, dynamic>{
@@ -53,6 +54,7 @@ class GrookaiMemoryCardAdapter {
     DateTime? memoryDate,
     String? note,
     String? placeLabel,
+    String? occasionLabel,
     String? photoUrl,
   }) {
     return _object(
@@ -61,6 +63,7 @@ class GrookaiMemoryCardAdapter {
       listingNo: 'DRAFT',
       date: memoryDate ?? DateTime.now(),
       location: placeLabel,
+      occasion: occasionLabel,
       photoUrl: photoUrl,
       storyText: note,
       metadata: <String, dynamic>{'memory_type': memoryType.rpcValue},
@@ -84,6 +87,7 @@ class GrookaiMemoryCardAdapter {
     required DateTime date,
     required Map<String, dynamic> metadata,
     String? location,
+    String? occasion,
     String? photoUrl,
     String? storyText,
   }) {
@@ -98,6 +102,7 @@ class GrookaiMemoryCardAdapter {
       listingNo: listingNo,
       date: date,
       location: _fallback(location, 'Vault memory'),
+      occasion: _blankToNull(occasion),
       photoUrl: _blankToNull(photoUrl),
       storyText: _fallback(storyText, 'A memory from the vault.'),
       authorName: _fallback(source.authorName, 'You'),

--- a/lib/screens/grookai_objects/collector_memories_screen.dart
+++ b/lib/screens/grookai_objects/collector_memories_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../services/vault/collector_memory_service.dart';
 import '../../widgets/card_surface_artwork.dart';
-import '../vault/vault_manage_card_screen.dart';
+import 'collector_memory_detail_screen.dart';
 
 class CollectorMemoriesScreen extends StatefulWidget {
   CollectorMemoriesScreen({super.key, CollectorMemoryService? service})
@@ -44,14 +44,13 @@ class _CollectorMemoriesScreenState extends State<CollectorMemoriesScreen> {
     });
   }
 
-  Future<void> _openCard(OwnerCollectorMemory item) async {
-    final gvviId = item.memory.gvviId.trim();
-    if (gvviId.isEmpty) {
-      return;
-    }
+  Future<void> _openMemory(_OwnerMemoryViewModel model) async {
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
-        builder: (_) => VaultManageCardScreen(gvviId: gvviId),
+        builder: (_) => CollectorMemoryDetailScreen(
+          item: model.memory,
+          signedPhotoUrl: model.signedPhotoUrl,
+        ),
       ),
     );
     if (mounted) {
@@ -117,7 +116,7 @@ class _CollectorMemoriesScreenState extends State<CollectorMemoriesScreen> {
                   final model = memories[index];
                   return _OwnerMemoryTile(
                     model: model,
-                    onTap: () => _openCard(model.memory),
+                    onTap: () => _openMemory(model),
                   );
                 },
               );

--- a/lib/screens/grookai_objects/collector_memories_screen.dart
+++ b/lib/screens/grookai_objects/collector_memories_screen.dart
@@ -50,6 +50,7 @@ class _CollectorMemoriesScreenState extends State<CollectorMemoriesScreen> {
         builder: (_) => CollectorMemoryDetailScreen(
           item: model.memory,
           signedPhotoUrl: model.signedPhotoUrl,
+          memoryService: widget.service,
         ),
       ),
     );
@@ -180,12 +181,34 @@ class _OwnerMemoryTile extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      _memoryTypeLabel(memory.memoryType),
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: colorScheme.primary,
-                        fontWeight: FontWeight.w800,
-                      ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            _memoryTypeLabel(memory.memoryType),
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: colorScheme.primary,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ),
+                        if (memory.isPublic) ...[
+                          Icon(
+                            Icons.public_rounded,
+                            size: 14,
+                            color: colorScheme.primary,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Public',
+                            key: const Key('public-memory-indicator'),
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: colorScheme.primary,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
                     const SizedBox(height: 3),
                     Text(

--- a/lib/screens/grookai_objects/collector_memory_detail_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_detail_screen.dart
@@ -7,6 +7,7 @@ import '../../models/grookai_memory_card.dart';
 import '../../services/diagnostics/grookai_crash_reporting_service.dart';
 import '../../services/grookai_objects/grookai_object_export_service.dart';
 import '../../services/grookai_objects/memory_card_print_service.dart';
+import '../../services/navigation/grookai_web_route_service.dart';
 import '../../services/vault/collector_memory_service.dart';
 import '../../widgets/grookai_objects/grookai_object.dart';
 import '../../widgets/grookai_objects/grookai_object_destination_export_renderer.dart';
@@ -14,6 +15,14 @@ import '../../widgets/grookai_objects/grookai_object_share_destination_sheet.dar
 import '../../widgets/grookai_objects/grookai_object_skin.dart';
 import '../../widgets/grookai_objects/grookai_object_skin_picker.dart';
 import '../vault/vault_manage_card_screen.dart';
+
+String buildCollectorMemoryShareText(OwnerCollectorMemory item) {
+  final gvId = (item.gvId ?? '').trim();
+  final path = gvId.isEmpty ? '/' : '/card/${Uri.encodeComponent(gvId)}';
+  final appLink = GrookaiWebRouteService.buildUri(path);
+  return 'A collector Memory for ${item.cardName}.\n'
+      'Open in Grookai Vault: $appLink';
+}
 
 class CollectorMemoryDetailScreen extends StatefulWidget {
   CollectorMemoryDetailScreen({
@@ -188,7 +197,7 @@ class _CollectorMemoryDetailScreenState
           title: widget.item.cardName,
         ),
         subject: 'Grookai memory card',
-        text: 'Shared from Grookai Vault',
+        text: buildCollectorMemoryShareText(widget.item),
         sharePositionOrigin: sharePositionOrigin,
       );
     } catch (error, stackTrace) {

--- a/lib/screens/grookai_objects/collector_memory_detail_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_detail_screen.dart
@@ -17,11 +17,10 @@ import '../../widgets/grookai_objects/grookai_object_skin_picker.dart';
 import '../vault/vault_manage_card_screen.dart';
 
 String buildCollectorMemoryShareText(OwnerCollectorMemory item) {
-  final gvId = (item.gvId ?? '').trim();
-  final path = gvId.isEmpty ? '/' : '/card/${Uri.encodeComponent(gvId)}';
+  final path = '/memory/${Uri.encodeComponent(item.memory.id)}';
   final appLink = GrookaiWebRouteService.buildUri(path);
   return 'A collector Memory for ${item.cardName}.\n'
-      'Open in Grookai Vault: $appLink';
+      'Open this Memory in Grookai Vault: $appLink';
 }
 
 class CollectorMemoryDetailScreen extends StatefulWidget {

--- a/lib/screens/grookai_objects/collector_memory_detail_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_detail_screen.dart
@@ -8,7 +8,9 @@ import '../../services/diagnostics/grookai_crash_reporting_service.dart';
 import '../../services/grookai_objects/grookai_object_export_service.dart';
 import '../../services/grookai_objects/memory_card_print_service.dart';
 import '../../services/vault/collector_memory_service.dart';
-import '../../widgets/grookai_objects/grookai_object_flattened_renderer.dart';
+import '../../widgets/grookai_objects/grookai_object.dart';
+import '../../widgets/grookai_objects/grookai_object_destination_export_renderer.dart';
+import '../../widgets/grookai_objects/grookai_object_share_destination_sheet.dart';
 import '../../widgets/grookai_objects/grookai_object_skin.dart';
 import '../../widgets/grookai_objects/grookai_object_skin_picker.dart';
 import '../vault/vault_manage_card_screen.dart';
@@ -41,8 +43,11 @@ class _CollectorMemoryDetailScreenState
   // available on the front without replacing the Memory experience.
   bool _showFront = false;
   bool _printing = false;
+  bool _sharing = false;
   GrookaiObjectSkin _skin = GrookaiObjectSkin.onyx;
-  final GlobalKey _printBoundaryKey = GlobalKey();
+  GrookaiObjectExportDestination _exportDestination =
+      GrookaiObjectExportDestination.saveImage;
+  final GlobalKey _exportBoundaryKey = GlobalKey();
 
   void _openCard() {
     final injectedAction = widget.onViewCard;
@@ -63,7 +68,7 @@ class _CollectorMemoryDetailScreenState
   }
 
   Future<void> _openPrintMenu() async {
-    if (_printing) {
+    if (_printing || _sharing) {
       return;
     }
     final action = await showModalBottomSheet<_MemoryPrintAction>(
@@ -135,11 +140,83 @@ class _CollectorMemoryDetailScreenState
   }
 
   Future<Uint8List> _captureSide({required bool showFront}) async {
-    if (_showFront != showFront) {
-      setState(() => _showFront = showFront);
+    if (_showFront != showFront ||
+        _exportDestination != GrookaiObjectExportDestination.saveImage) {
+      setState(() {
+        _showFront = showFront;
+        _exportDestination = GrookaiObjectExportDestination.saveImage;
+      });
     }
     await WidgetsBinding.instance.endOfFrame;
-    return widget.exportService.capturePng(_printBoundaryKey, pixelRatio: 3);
+    return widget.exportService.capturePng(_exportBoundaryKey, pixelRatio: 3);
+  }
+
+  Future<void> _shareCurrentSide() async {
+    if (_sharing || _printing) {
+      return;
+    }
+
+    final object = _memoryObject;
+    final destination = await showGrookaiObjectShareDestinationSheet(
+      context: context,
+      object: object,
+    );
+    if (destination == null || !mounted) {
+      return;
+    }
+
+    final previousDestination = _exportDestination;
+    setState(() {
+      _sharing = true;
+      _exportDestination = destination;
+    });
+    final sharePositionOrigin =
+        GrookaiObjectExportService.sharePositionOriginFor(context);
+
+    try {
+      await _precachePrintImages();
+      await WidgetsBinding.instance.endOfFrame;
+      final bytes = await widget.exportService.exportObjectPng(
+        object: object,
+        destination: destination,
+        repaintBoundaryKey: _exportBoundaryKey,
+      );
+      await widget.exportService.sharePng(
+        bytes: bytes,
+        fileName: GrookaiObjectExportService.fileNameFor(
+          type: 'memory-${destination.slug}',
+          title: widget.item.cardName,
+        ),
+        subject: 'Grookai memory card',
+        text: 'Shared from Grookai Vault',
+        sharePositionOrigin: sharePositionOrigin,
+      );
+    } catch (error, stackTrace) {
+      GrookaiCrashReportingService.recordNonFatalError(
+        error,
+        stackTrace,
+        reason: 'grookai_object_share_failed',
+        context: <String, Object?>{
+          'memory_id': widget.item.memory.id,
+          'card_print_id': widget.item.cardPrintId,
+          'surface': 'collector_memory_detail',
+          'operation': 'share_png',
+          'destination': destination.slug,
+        },
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unable to share this Memory.')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _sharing = false;
+          _exportDestination = previousDestination;
+        });
+      }
+    }
   }
 
   Future<void> _precachePrintImages() async {
@@ -166,13 +243,11 @@ class _CollectorMemoryDetailScreenState
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
+  GrookaiObject get _memoryObject {
     final item = widget.item;
-    final memory = item.memory;
     final artwork = item.catalogArtwork;
-    final object = GrookaiMemoryCardAdapter.fromMemory(
-      memory: memory,
+    return GrookaiMemoryCardAdapter.fromMemory(
+      memory: item.memory,
       source: GrookaiMemoryCardSource(
         cardName: item.cardName,
         setLine: item.setName,
@@ -182,6 +257,13 @@ class _CollectorMemoryDetailScreenState
       skin: _skin,
       signedPhotoUrl: widget.signedPhotoUrl,
     );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final memory = item.memory;
+    final object = _memoryObject;
     final note = (memory.note ?? '').trim();
     final details = _memoryDetails(memory);
     final canOpenCard =
@@ -193,8 +275,19 @@ class _CollectorMemoryDetailScreenState
         title: const Text('Memory'),
         actions: [
           IconButton(
+            key: const Key('share-memory-button'),
+            onPressed: _printing || _sharing ? null : _shareCurrentSide,
+            tooltip: 'Share Memory',
+            icon: _sharing
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.ios_share_outlined),
+          ),
+          IconButton(
             key: const Key('print-memory-button'),
-            onPressed: _printing ? null : _openPrintMenu,
+            onPressed: _printing || _sharing ? null : _openPrintMenu,
             tooltip: 'Print Memory',
             icon: _printing
                 ? const SizedBox.square(
@@ -212,9 +305,10 @@ class _CollectorMemoryDetailScreenState
             Center(
               child: FittedBox(
                 fit: BoxFit.scaleDown,
-                child: GrookaiObjectFlattenedRenderer(
-                  repaintBoundaryKey: _printBoundaryKey,
+                child: GrookaiObjectDestinationExportRenderer(
+                  repaintBoundaryKey: _exportBoundaryKey,
                   object: object,
+                  destination: _exportDestination,
                   showFront: _showFront,
                 ),
               ),

--- a/lib/screens/grookai_objects/collector_memory_detail_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_detail_screen.dart
@@ -1,0 +1,451 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+import '../../models/grookai_memory_card.dart';
+import '../../services/diagnostics/grookai_crash_reporting_service.dart';
+import '../../services/grookai_objects/grookai_object_export_service.dart';
+import '../../services/grookai_objects/memory_card_print_service.dart';
+import '../../services/vault/collector_memory_service.dart';
+import '../../widgets/grookai_objects/grookai_object_flattened_renderer.dart';
+import '../../widgets/grookai_objects/grookai_object_skin.dart';
+import '../../widgets/grookai_objects/grookai_object_skin_picker.dart';
+import '../vault/vault_manage_card_screen.dart';
+
+class CollectorMemoryDetailScreen extends StatefulWidget {
+  CollectorMemoryDetailScreen({
+    super.key,
+    required this.item,
+    this.signedPhotoUrl,
+    this.onViewCard,
+    MemoryCardPrintService? printService,
+    GrookaiObjectExportService? exportService,
+  }) : printService = printService ?? MemoryCardPrintService(),
+       exportService = exportService ?? const GrookaiObjectExportService();
+
+  final OwnerCollectorMemory item;
+  final String? signedPhotoUrl;
+  final VoidCallback? onViewCard;
+  final MemoryCardPrintService printService;
+  final GrookaiObjectExportService exportService;
+
+  @override
+  State<CollectorMemoryDetailScreen> createState() =>
+      _CollectorMemoryDetailScreenState();
+}
+
+class _CollectorMemoryDetailScreenState
+    extends State<CollectorMemoryDetailScreen> {
+  // A saved Memory opens on its story side. The card artwork remains
+  // available on the front without replacing the Memory experience.
+  bool _showFront = false;
+  bool _printing = false;
+  GrookaiObjectSkin _skin = GrookaiObjectSkin.onyx;
+  final GlobalKey _printBoundaryKey = GlobalKey();
+
+  void _openCard() {
+    final injectedAction = widget.onViewCard;
+    if (injectedAction != null) {
+      injectedAction();
+      return;
+    }
+
+    final gvviId = widget.item.memory.gvviId.trim();
+    if (gvviId.isEmpty) {
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => VaultManageCardScreen(gvviId: gvviId),
+      ),
+    );
+  }
+
+  Future<void> _openPrintMenu() async {
+    if (_printing) {
+      return;
+    }
+    final action = await showModalBottomSheet<_MemoryPrintAction>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => const _MemoryPrintSheet(),
+    );
+    if (action == null || !mounted) {
+      return;
+    }
+    await _print(action);
+  }
+
+  Future<void> _print(_MemoryPrintAction action) async {
+    final previousSide = _showFront;
+    setState(() => _printing = true);
+    try {
+      await _precachePrintImages();
+      final memorySide = await _captureSide(showFront: false);
+      Uint8List? cardSide;
+      final mode = action == _MemoryPrintAction.frontAndBack
+          ? MemoryCardPrintMode.frontAndBack
+          : MemoryCardPrintMode.memoryInsert;
+      if (mode == MemoryCardPrintMode.frontAndBack) {
+        cardSide = await _captureSide(showFront: true);
+      }
+      if (mounted && _showFront != previousSide) {
+        setState(() => _showFront = previousSide);
+        await WidgetsBinding.instance.endOfFrame;
+      }
+
+      final fileName = _printFileName(widget.item.cardName);
+      if (action == _MemoryPrintAction.sharePdf) {
+        await widget.printService.shareMemoryPdf(
+          memorySidePng: memorySide,
+          mode: mode,
+          fileName: fileName,
+        );
+      } else {
+        await widget.printService.printMemory(
+          memorySidePng: memorySide,
+          cardSidePng: cardSide,
+          mode: mode,
+          documentName: fileName,
+        );
+      }
+    } catch (error, stackTrace) {
+      GrookaiCrashReportingService.recordNonFatalError(
+        error,
+        stackTrace,
+        reason: 'collector_memory_print_failed',
+        context: <String, Object?>{
+          'memory_id': widget.item.memory.id,
+          'card_print_id': widget.item.cardPrintId,
+          'surface': 'collector_memory_detail',
+          'operation': action.name,
+        },
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unable to prepare this Memory.')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _printing = false);
+      }
+    }
+  }
+
+  Future<Uint8List> _captureSide({required bool showFront}) async {
+    if (_showFront != showFront) {
+      setState(() => _showFront = showFront);
+    }
+    await WidgetsBinding.instance.endOfFrame;
+    return widget.exportService.capturePng(_printBoundaryKey, pixelRatio: 3);
+  }
+
+  Future<void> _precachePrintImages() async {
+    final artwork = widget.item.catalogArtwork;
+    await _precacheFirstAvailable([widget.signedPhotoUrl]);
+    await _precacheFirstAvailable([
+      artwork.primaryImageUrl,
+      artwork.fallbackImageUrl,
+    ]);
+  }
+
+  Future<void> _precacheFirstAvailable(List<String?> candidates) async {
+    for (final candidate in candidates) {
+      final url = (candidate ?? '').trim();
+      if (url.isEmpty) {
+        continue;
+      }
+      try {
+        await precacheImage(CachedNetworkImageProvider(url), context);
+        return;
+      } catch (_) {
+        // The renderer applies its own fallback or placeholder contract.
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final memory = item.memory;
+    final artwork = item.catalogArtwork;
+    final object = GrookaiMemoryCardAdapter.fromMemory(
+      memory: memory,
+      source: GrookaiMemoryCardSource(
+        cardName: item.cardName,
+        setLine: item.setName,
+        cardImageUrl: artwork.primaryImageUrl,
+        cardImageFallbackUrl: artwork.fallbackImageUrl,
+      ),
+      skin: _skin,
+      signedPhotoUrl: widget.signedPhotoUrl,
+    );
+    final note = (memory.note ?? '').trim();
+    final details = _memoryDetails(memory);
+    final canOpenCard =
+        widget.onViewCard != null || memory.gvviId.trim().isNotEmpty;
+
+    return Scaffold(
+      key: const Key('collector-memory-detail'),
+      appBar: AppBar(
+        title: const Text('Memory'),
+        actions: [
+          IconButton(
+            key: const Key('print-memory-button'),
+            onPressed: _printing ? null : _openPrintMenu,
+            tooltip: 'Print Memory',
+            icon: _printing
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.print_outlined),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 28),
+          children: [
+            Center(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: GrookaiObjectFlattenedRenderer(
+                  repaintBoundaryKey: _printBoundaryKey,
+                  object: object,
+                  showFront: _showFront,
+                ),
+              ),
+            ),
+            const SizedBox(height: 14),
+            SegmentedButton<bool>(
+              showSelectedIcon: false,
+              segments: const [
+                ButtonSegment<bool>(
+                  value: false,
+                  icon: Icon(Icons.menu_book_outlined),
+                  label: Text('Memory'),
+                ),
+                ButtonSegment<bool>(
+                  value: true,
+                  icon: Icon(Icons.style_outlined),
+                  label: Text('Card'),
+                ),
+              ],
+              selected: {_showFront},
+              onSelectionChanged: (selection) {
+                setState(() => _showFront = selection.single);
+              },
+            ),
+            const SizedBox(height: 18),
+            Text(
+              'Style',
+              style: Theme.of(
+                context,
+              ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            GrookaiObjectSkinPicker(
+              selected: _skin,
+              onChanged: (skin) => setState(() => _skin = skin),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              _memoryTypeLabel(memory.memoryType),
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              item.cardName,
+              style: Theme.of(
+                context,
+              ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
+            ),
+            if (item.setName.trim().isNotEmpty) ...[
+              const SizedBox(height: 3),
+              Text(
+                item.setName.trim(),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            if (note.isNotEmpty) ...[
+              const SizedBox(height: 20),
+              Text(
+                note,
+                key: const Key('collector-memory-full-note'),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyLarge?.copyWith(height: 1.45),
+              ),
+            ],
+            if (details.isNotEmpty) ...[
+              const SizedBox(height: 18),
+              Wrap(
+                spacing: 16,
+                runSpacing: 10,
+                children: [
+                  for (final detail in details)
+                    _MemoryDetail(icon: detail.icon, label: detail.label),
+                ],
+              ),
+            ],
+            if (canOpenCard) ...[
+              const SizedBox(height: 24),
+              OutlinedButton.icon(
+                key: const Key('view-memory-card-button'),
+                onPressed: _openCard,
+                icon: const Icon(Icons.open_in_new_rounded),
+                label: const Text('View card'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum _MemoryPrintAction { memoryInsert, frontAndBack, sharePdf }
+
+class _MemoryPrintSheet extends StatelessWidget {
+  const _MemoryPrintSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Print Memory',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              key: const Key('print-memory-insert-option'),
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.note_outlined),
+              title: const Text('Memory insert'),
+              subtitle: const Text('One card-size Memory side'),
+              onTap: () =>
+                  Navigator.of(context).pop(_MemoryPrintAction.memoryInsert),
+            ),
+            ListTile(
+              key: const Key('print-memory-front-back-option'),
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.copy_all_outlined),
+              title: const Text('Front and back'),
+              subtitle: const Text('Two aligned card-size pages'),
+              onTap: () =>
+                  Navigator.of(context).pop(_MemoryPrintAction.frontAndBack),
+            ),
+            ListTile(
+              key: const Key('share-memory-pdf-option'),
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.ios_share_outlined),
+              title: const Text('Share PDF'),
+              subtitle: const Text('Save or send the Memory insert'),
+              onTap: () =>
+                  Navigator.of(context).pop(_MemoryPrintAction.sharePdf),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MemoryDetail extends StatelessWidget {
+  const _MemoryDetail({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          icon,
+          size: 17,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 6),
+        Text(label, style: Theme.of(context).textTheme.bodyMedium),
+      ],
+    );
+  }
+}
+
+class _MemoryDetailValue {
+  const _MemoryDetailValue(this.icon, this.label);
+
+  final IconData icon;
+  final String label;
+}
+
+List<_MemoryDetailValue> _memoryDetails(CollectorMemory memory) {
+  return [
+    if (memory.memoryDate != null)
+      _MemoryDetailValue(
+        Icons.calendar_month_outlined,
+        _formatDate(memory.memoryDate!),
+      ),
+    if ((memory.placeLabel ?? '').trim().isNotEmpty)
+      _MemoryDetailValue(Icons.location_on_outlined, memory.placeLabel!.trim()),
+    if ((memory.occasionLabel ?? '').trim().isNotEmpty)
+      _MemoryDetailValue(
+        Icons.celebration_outlined,
+        memory.occasionLabel!.trim(),
+      ),
+  ];
+}
+
+String _formatDate(DateTime date) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[date.month - 1]} ${date.day}, ${date.year}';
+}
+
+String _printFileName(String cardName) {
+  final normalized = cardName
+      .trim()
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+      .replaceAll(RegExp(r'^-+|-+$'), '');
+  return 'grookai-memory-${normalized.isEmpty ? 'card' : normalized}.pdf';
+}
+
+String _memoryTypeLabel(CollectorMemoryType type) {
+  return switch (type) {
+    CollectorMemoryType.addedPlace => 'Added here',
+    CollectorMemoryType.occasion => 'Occasion',
+    CollectorMemoryType.first => 'First memory',
+    CollectorMemoryType.note => 'Collector note',
+  };
+}

--- a/lib/screens/grookai_objects/collector_memory_detail_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_detail_screen.dart
@@ -16,10 +16,17 @@ import '../../widgets/grookai_objects/grookai_object_skin.dart';
 import '../../widgets/grookai_objects/grookai_object_skin_picker.dart';
 import '../vault/vault_manage_card_screen.dart';
 
-String buildCollectorMemoryShareText(OwnerCollectorMemory item) {
+String buildCollectorMemoryShareText(
+  OwnerCollectorMemory item, {
+  bool includeAppLink = false,
+}) {
+  final summary = 'A collector Memory for ${item.cardName}.';
+  if (!includeAppLink) {
+    return summary;
+  }
   final path = '/memory/${Uri.encodeComponent(item.memory.id)}';
   final appLink = GrookaiWebRouteService.buildUri(path);
-  return 'A collector Memory for ${item.cardName}.\n'
+  return '$summary\n'
       'Open this Memory in Grookai Vault: $appLink';
 }
 
@@ -206,7 +213,10 @@ class _CollectorMemoryDetailScreenState
           title: widget.item.cardName,
         ),
         subject: 'Grookai memory card',
-        text: buildCollectorMemoryShareText(widget.item),
+        text: buildCollectorMemoryShareText(
+          widget.item,
+          includeAppLink: _isPublic,
+        ),
         sharePositionOrigin: sharePositionOrigin,
       );
     } catch (error, stackTrace) {

--- a/lib/screens/grookai_objects/collector_memory_detail_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_detail_screen.dart
@@ -32,6 +32,7 @@ class CollectorMemoryDetailScreen extends StatefulWidget {
     this.onViewCard,
     MemoryCardPrintService? printService,
     GrookaiObjectExportService? exportService,
+    this.memoryService,
   }) : printService = printService ?? MemoryCardPrintService(),
        exportService = exportService ?? const GrookaiObjectExportService();
 
@@ -40,6 +41,7 @@ class CollectorMemoryDetailScreen extends StatefulWidget {
   final VoidCallback? onViewCard;
   final MemoryCardPrintService printService;
   final GrookaiObjectExportService exportService;
+  final CollectorMemoryService? memoryService;
 
   @override
   State<CollectorMemoryDetailScreen> createState() =>
@@ -53,10 +55,18 @@ class _CollectorMemoryDetailScreenState
   bool _showFront = false;
   bool _printing = false;
   bool _sharing = false;
+  bool _publicationBusy = false;
+  late bool _isPublic;
   GrookaiObjectSkin _skin = GrookaiObjectSkin.onyx;
   GrookaiObjectExportDestination _exportDestination =
       GrookaiObjectExportDestination.saveImage;
   final GlobalKey _exportBoundaryKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    _isPublic = widget.item.memory.isPublic;
+  }
 
   void _openCard() {
     final injectedAction = widget.onViewCard;
@@ -77,7 +87,7 @@ class _CollectorMemoryDetailScreenState
   }
 
   Future<void> _openPrintMenu() async {
-    if (_printing || _sharing) {
+    if (_printing || _sharing || _publicationBusy) {
       return;
     }
     final action = await showModalBottomSheet<_MemoryPrintAction>(
@@ -161,7 +171,7 @@ class _CollectorMemoryDetailScreenState
   }
 
   Future<void> _shareCurrentSide() async {
-    if (_sharing || _printing) {
+    if (_sharing || _printing || _publicationBusy) {
       return;
     }
 
@@ -228,6 +238,90 @@ class _CollectorMemoryDetailScreenState
     }
   }
 
+  Future<void> _changePublication(bool nextValue) async {
+    if (_publicationBusy || nextValue == _isPublic) {
+      return;
+    }
+
+    if (nextValue) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Share this Memory in Pulse?'),
+          content: const Text(
+            'Eligible collectors may see this Memory, including its note, '
+            'photo, place, occasion, and date. You can make it private again '
+            'at any time.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              key: const Key('confirm-publish-memory-button'),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Publish'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true || !mounted) {
+        return;
+      }
+    }
+
+    setState(() => _publicationBusy = true);
+    try {
+      final service = widget.memoryService ?? CollectorMemoryService();
+      final updated = await service.setPublic(
+        memoryId: widget.item.memory.id,
+        isPublic: nextValue,
+      );
+      if (!mounted) return;
+      setState(() => _isPublic = updated.isPublic);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            updated.isPublic
+                ? 'Memory published to Pulse.'
+                : 'Memory is private again.',
+          ),
+        ),
+      );
+    } catch (error, stackTrace) {
+      GrookaiCrashReportingService.recordNonFatalError(
+        error,
+        stackTrace,
+        reason: 'collector_memory_publication_failed',
+        context: <String, Object?>{
+          'memory_id': widget.item.memory.id,
+          'card_print_id': widget.item.cardPrintId,
+          'surface': 'collector_memory_detail',
+          'requested_public': nextValue,
+        },
+      );
+      if (mounted) {
+        final needsPublicProfile = error.toString().contains(
+          'enable your public profile and vault sharing',
+        );
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              needsPublicProfile
+                  ? 'Enable your public profile and vault sharing first.'
+                  : 'Unable to change Memory visibility.',
+            ),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _publicationBusy = false);
+      }
+    }
+  }
+
   Future<void> _precachePrintImages() async {
     final artwork = widget.item.catalogArtwork;
     await _precacheFirstAvailable([widget.signedPhotoUrl]);
@@ -285,7 +379,9 @@ class _CollectorMemoryDetailScreenState
         actions: [
           IconButton(
             key: const Key('share-memory-button'),
-            onPressed: _printing || _sharing ? null : _shareCurrentSide,
+            onPressed: _printing || _sharing || _publicationBusy
+                ? null
+                : _shareCurrentSide,
             tooltip: 'Share Memory',
             icon: _sharing
                 ? const SizedBox.square(
@@ -296,7 +392,9 @@ class _CollectorMemoryDetailScreenState
           ),
           IconButton(
             key: const Key('print-memory-button'),
-            onPressed: _printing || _sharing ? null : _openPrintMenu,
+            onPressed: _printing || _sharing || _publicationBusy
+                ? null
+                : _openPrintMenu,
             tooltip: 'Print Memory',
             icon: _printing
                 ? const SizedBox.square(
@@ -399,6 +497,32 @@ class _CollectorMemoryDetailScreenState
                 ],
               ),
             ],
+            const SizedBox(height: 22),
+            const Divider(),
+            SwitchListTile(
+              key: const Key('memory-public-switch'),
+              contentPadding: EdgeInsets.zero,
+              value: _isPublic,
+              onChanged: _printing || _sharing || _publicationBusy
+                  ? null
+                  : _changePublication,
+              secondary: _publicationBusy
+                  ? const SizedBox.square(
+                      dimension: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      _isPublic
+                          ? Icons.public_rounded
+                          : Icons.lock_outline_rounded,
+                    ),
+              title: const Text('Public in Pulse'),
+              subtitle: Text(
+                _isPublic
+                    ? 'Eligible collectors can see this Memory in Pulse.'
+                    : 'Private. Publish it when you want to share it.',
+              ),
+            ),
             if (canOpenCard) ...[
               const SizedBox(height: 24),
               OutlinedButton.icon(

--- a/lib/screens/grookai_objects/collector_memory_route_screen.dart
+++ b/lib/screens/grookai_objects/collector_memory_route_screen.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../services/vault/collector_memory_service.dart';
+import '../../widgets/card_surface_artwork.dart';
+import 'collector_memory_detail_screen.dart';
+
+class CollectorMemoryRouteScreen extends StatefulWidget {
+  CollectorMemoryRouteScreen({
+    super.key,
+    required this.memoryId,
+    this.onViewCard,
+    CollectorMemoryService? service,
+  }) : service = service ?? CollectorMemoryService();
+
+  final String memoryId;
+  final Future<void> Function(String gvId)? onViewCard;
+  final CollectorMemoryService service;
+
+  @override
+  State<CollectorMemoryRouteScreen> createState() =>
+      _CollectorMemoryRouteScreenState();
+}
+
+class _CollectorMemoryRouteScreenState
+    extends State<CollectorMemoryRouteScreen> {
+  OwnerCollectorMemory? _item;
+  String? _signedPhotoUrl;
+  Object? _error;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    try {
+      final item = await widget.service.loadAccessibleMemory(
+        memoryId: widget.memoryId,
+      );
+      final signedPhotoUrl = item == null
+          ? null
+          : await widget.service.createSignedPhotoUrl(
+              item.memory.photoPath,
+              expiresIn: 300,
+            );
+      if (!mounted) return;
+      setState(() {
+        _item = item;
+        _signedPhotoUrl = signedPhotoUrl;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        key: Key('collector-memory-route-loading'),
+        appBar: _MemoryRouteAppBar(),
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final item = _item;
+    if (_error != null || item == null) {
+      return Scaffold(
+        key: const Key('collector-memory-route-unavailable'),
+        appBar: const _MemoryRouteAppBar(),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(28),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.lock_outline_rounded, size: 34),
+                const SizedBox(height: 14),
+                Text(
+                  'Memory unavailable',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'This Memory may be private, removed, or no longer shared.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 18),
+                OutlinedButton.icon(
+                  onPressed: () {
+                    setState(() {
+                      _loading = true;
+                      _error = null;
+                    });
+                    unawaited(_load());
+                  },
+                  icon: const Icon(Icons.refresh_rounded),
+                  label: const Text('Try again'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (item.viewerIsOwner) {
+      return CollectorMemoryDetailScreen(
+        item: item,
+        signedPhotoUrl: _signedPhotoUrl,
+        memoryService: widget.service,
+        onViewCard: _canViewCard(item)
+            ? () => widget.onViewCard!(item.gvId!.trim())
+            : null,
+      );
+    }
+
+    return _SharedCollectorMemoryScreen(
+      item: item,
+      signedPhotoUrl: _signedPhotoUrl,
+      onViewCard: _canViewCard(item)
+          ? () => widget.onViewCard!(item.gvId!.trim())
+          : null,
+    );
+  }
+
+  bool _canViewCard(OwnerCollectorMemory item) =>
+      widget.onViewCard != null && (item.gvId ?? '').trim().isNotEmpty;
+}
+
+class _MemoryRouteAppBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const _MemoryRouteAppBar();
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) => AppBar(title: const Text('Memory'));
+}
+
+class _SharedCollectorMemoryScreen extends StatelessWidget {
+  const _SharedCollectorMemoryScreen({
+    required this.item,
+    required this.signedPhotoUrl,
+    required this.onViewCard,
+  });
+
+  final OwnerCollectorMemory item;
+  final String? signedPhotoUrl;
+  final Future<void> Function()? onViewCard;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final memory = item.memory;
+    final note = (memory.note ?? '').trim();
+    final details = <(IconData, String)>[
+      if ((memory.placeLabel ?? '').trim().isNotEmpty)
+        (Icons.place_outlined, memory.placeLabel!.trim()),
+      if ((memory.occasionLabel ?? '').trim().isNotEmpty)
+        (Icons.celebration_outlined, memory.occasionLabel!.trim()),
+      if (memory.memoryDate != null)
+        (Icons.calendar_today_outlined, _formatMemoryDate(memory.memoryDate!)),
+    ];
+    final artwork = item.catalogArtwork;
+
+    return Scaffold(
+      key: const Key('shared-collector-memory-detail'),
+      appBar: const _MemoryRouteAppBar(),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 28),
+          children: [
+            Text(
+              'Shared by ${(item.ownerDisplayName ?? 'Collector').trim()}',
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 5),
+            Text(
+              item.cardName,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (item.setName.trim().isNotEmpty) ...[
+              const SizedBox(height: 3),
+              Text(
+                item.setName,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            const SizedBox(height: 20),
+            AspectRatio(
+              aspectRatio: signedPhotoUrl == null ? 0.69 : 4 / 3,
+              child: CardSurfaceArtwork(
+                key: const Key('shared-collector-memory-image'),
+                label: 'Memory for ${item.cardName}',
+                imageUrl: signedPhotoUrl ?? artwork.primaryImageUrl,
+                fallbackImageUrl: artwork.fallbackImageUrl,
+                borderRadius: 8,
+                frame: CardArtworkFrame.soft,
+                padding: EdgeInsets.zero,
+                showShadow: false,
+              ),
+            ),
+            if (note.isNotEmpty) ...[
+              const SizedBox(height: 22),
+              Text(
+                note,
+                key: const Key('shared-collector-memory-note'),
+                style: theme.textTheme.bodyLarge?.copyWith(height: 1.45),
+              ),
+            ],
+            if (details.isNotEmpty) ...[
+              const SizedBox(height: 18),
+              Wrap(
+                spacing: 16,
+                runSpacing: 10,
+                children: [
+                  for (final detail in details)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          detail.$1,
+                          size: 17,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: 6),
+                        Text(detail.$2),
+                      ],
+                    ),
+                ],
+              ),
+            ],
+            if (onViewCard != null) ...[
+              const SizedBox(height: 26),
+              OutlinedButton.icon(
+                key: const Key('shared-memory-view-card-button'),
+                onPressed: () async => onViewCard!(),
+                icon: const Icon(Icons.style_outlined),
+                label: const Text('View card'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _formatMemoryDate(DateTime date) {
+  const months = <String>[
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[date.month - 1]} ${date.day}, ${date.year}';
+}

--- a/lib/screens/grookai_objects/memory_card_capture_screen.dart
+++ b/lib/screens/grookai_objects/memory_card_capture_screen.dart
@@ -277,6 +277,7 @@ class _MemoryCardCaptureScreenState extends State<MemoryCardCaptureScreen> {
       memoryDate: _parseDate(_dateController.text),
       note: _noteController.text,
       placeLabel: _placeController.text,
+      occasionLabel: _occasionController.text,
     );
   }
 

--- a/lib/screens/network/network_screen.dart
+++ b/lib/screens/network/network_screen.dart
@@ -29,6 +29,7 @@ import '../../widgets/vault/vault_quick_action_sheet.dart';
 import '../dex/grookai_dex_screen.dart';
 import '../dex/grookai_dex_species_screen.dart';
 import '../gvvi/public_gvvi_screen.dart';
+import 'pulse_memory_detail_screen.dart';
 import '../public_collector/public_collector_screen.dart';
 import '../sets/public_set_detail_screen.dart';
 import '../vault/vault_manage_card_screen.dart';
@@ -1148,10 +1149,14 @@ class _PulseItemRow extends StatelessWidget {
                       runSpacing: 4,
                       children: [
                         _PulseActionPill(
-                          label: item.isCompletion
+                          label: item.isMemory
+                              ? 'View memory'
+                              : item.isCompletion
                               ? 'View progress'
                               : 'View card',
-                          icon: item.isCompletion
+                          icon: item.isMemory
+                              ? Icons.auto_stories_outlined
+                              : item.isCompletion
                               ? Icons.trending_up_rounded
                               : Icons.style_outlined,
                           primary: true,
@@ -1190,10 +1195,16 @@ class _PulseItemRow extends StatelessWidget {
       subtitle: _secondaryLine,
       actions: [
         VaultQuickAction(
-          icon: item.isCompletion
+          icon: item.isMemory
+              ? Icons.auto_stories_outlined
+              : item.isCompletion
               ? Icons.trending_up_rounded
               : Icons.style_outlined,
-          label: item.isCompletion ? 'View progress' : 'View card',
+          label: item.isMemory
+              ? 'View memory'
+              : item.isCompletion
+              ? 'View progress'
+              : 'View card',
           onPressed: () => unawaited(_openPrimary(context)),
         ),
         VaultQuickAction(
@@ -1232,6 +1243,9 @@ class _PulseItemRow extends StatelessWidget {
   }
 
   String get _primaryLine {
+    if (item.isMemory) {
+      return '${item.displayActorName} shared a Memory about ${item.displayCardName}';
+    }
     if (item.isWantMatch) {
       return '${item.displayCardName} is available from ${item.displayActorName}';
     }
@@ -1261,6 +1275,9 @@ class _PulseItemRow extends StatelessWidget {
   }
 
   String get _secondaryLine {
+    if (item.isMemory && item.memoryNote.isNotEmpty) {
+      return item.memoryNote;
+    }
     final setLabel = item.setName.isNotEmpty ? item.setName : item.setCode;
     final setAndNumber = [
       if (setLabel.isNotEmpty) setLabel,
@@ -1277,6 +1294,10 @@ class _PulseItemRow extends StatelessWidget {
   }
 
   Future<void> _openPrimary(BuildContext context) async {
+    if (item.isMemory) {
+      await _openMemoryDetail(context);
+      return;
+    }
     if (await _openPrimaryActionRoute(context)) {
       return;
     }
@@ -1297,6 +1318,19 @@ class _PulseItemRow extends StatelessWidget {
         ),
       );
     }
+  }
+
+  Future<void> _openMemoryDetail(BuildContext context) {
+    return Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute<void>(
+        builder: (detailContext) => PulseMemoryDetailScreen(
+          item: item,
+          onViewCard: () async {
+            await _openCardDetail(detailContext);
+          },
+        ),
+      ),
+    );
   }
 
   Future<bool> _openPrimaryActionRoute(BuildContext context) async {
@@ -1532,6 +1566,13 @@ class _PulseTone {
   final Color foreground;
 
   static _PulseTone forItem(ColorScheme colorScheme, PulseItem item) {
+    if (item.isMemory) {
+      return _PulseTone(
+        label: 'Memory',
+        icon: Icons.auto_stories_outlined,
+        foreground: colorScheme.tertiary,
+      );
+    }
     if (item.isWantMatch) {
       return const _PulseTone(
         label: 'Want match',
@@ -1619,8 +1660,10 @@ class _PulseArtworkTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
           child: CardSurfaceArtwork(
             label: item.displayCardName,
-            imageUrl: item.displayImageUrl,
-            fallbackImageUrl: item.fallbackImageUrl,
+            imageUrl: item.memoryPhotoUrl ?? item.displayImageUrl,
+            fallbackImageUrl: item.memoryPhotoUrl == null
+                ? item.fallbackImageUrl
+                : item.displayImageUrl ?? item.fallbackImageUrl,
             borderRadius: 8,
             padding: EdgeInsets.zero,
             frame: CardArtworkFrame.none,

--- a/lib/screens/network/network_screen.dart
+++ b/lib/screens/network/network_screen.dart
@@ -29,6 +29,7 @@ import '../../widgets/vault/vault_quick_action_sheet.dart';
 import '../dex/grookai_dex_screen.dart';
 import '../dex/grookai_dex_species_screen.dart';
 import '../gvvi/public_gvvi_screen.dart';
+import '../grookai_objects/collector_memory_route_screen.dart';
 import 'pulse_memory_detail_screen.dart';
 import '../public_collector/public_collector_screen.dart';
 import '../sets/public_set_detail_screen.dart';
@@ -1345,6 +1346,18 @@ class _PulseItemRow extends StatelessWidget {
     switch (route.kind) {
       case GrookaiCanonicalRouteKind.card:
         return _openCardDetail(context, preferredGvId: route.value);
+      case GrookaiCanonicalRouteKind.memory:
+        await navigator.push(
+          MaterialPageRoute<void>(
+            builder: (_) => CollectorMemoryRouteScreen(
+              memoryId: route.value,
+              onViewCard: (gvId) async {
+                await _openCardDetail(context, preferredGvId: gvId);
+              },
+            ),
+          ),
+        );
+        return true;
       case GrookaiCanonicalRouteKind.collector:
         await navigator.push(
           MaterialPageRoute<void>(

--- a/lib/screens/network/pulse_memory_detail_screen.dart
+++ b/lib/screens/network/pulse_memory_detail_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+import '../../services/network/pulse_service.dart';
+import '../../widgets/card_surface_artwork.dart';
+
+class PulseMemoryDetailScreen extends StatelessWidget {
+  const PulseMemoryDetailScreen({
+    super.key,
+    required this.item,
+    required this.onViewCard,
+  });
+
+  final PulseItem item;
+  final Future<void> Function() onViewCard;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final note = item.memoryNote.trim();
+    final details = <_MemoryDetail>[
+      if (item.memoryPlaceLabel.isNotEmpty)
+        _MemoryDetail(Icons.place_outlined, item.memoryPlaceLabel),
+      if (item.memoryOccasionLabel.isNotEmpty)
+        _MemoryDetail(Icons.celebration_outlined, item.memoryOccasionLabel),
+      if (item.memoryDate.isNotEmpty)
+        _MemoryDetail(Icons.calendar_today_outlined, item.memoryDate),
+    ];
+
+    return Scaffold(
+      key: const Key('pulse-memory-detail'),
+      appBar: AppBar(title: const Text('Memory')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 28),
+          children: [
+            Text(
+              'Shared by ${item.displayActorName}',
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: colorScheme.primary,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 5),
+            Text(
+              item.displayCardName,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (item.setName.isNotEmpty || item.setCode.isNotEmpty) ...[
+              const SizedBox(height: 3),
+              Text(
+                item.setName.isNotEmpty ? item.setName : item.setCode,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            const SizedBox(height: 20),
+            AspectRatio(
+              aspectRatio: item.memoryPhotoUrl == null ? 0.69 : 4 / 3,
+              child: CardSurfaceArtwork(
+                key: const Key('pulse-memory-image'),
+                label: 'Memory for ${item.displayCardName}',
+                imageUrl: item.memoryPhotoUrl ?? item.displayImageUrl,
+                fallbackImageUrl: item.fallbackImageUrl,
+                borderRadius: 8,
+                frame: CardArtworkFrame.soft,
+                padding: EdgeInsets.zero,
+                showShadow: false,
+              ),
+            ),
+            if (note.isNotEmpty) ...[
+              const SizedBox(height: 22),
+              Text(
+                note,
+                key: const Key('pulse-memory-note'),
+                style: theme.textTheme.bodyLarge?.copyWith(height: 1.45),
+              ),
+            ],
+            if (details.isNotEmpty) ...[
+              const SizedBox(height: 18),
+              Wrap(
+                spacing: 16,
+                runSpacing: 10,
+                children: [
+                  for (final detail in details)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          detail.icon,
+                          size: 17,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: 6),
+                        Text(detail.label),
+                      ],
+                    ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 26),
+            OutlinedButton.icon(
+              key: const Key('pulse-memory-view-card-button'),
+              onPressed: () async => onViewCard(),
+              icon: const Icon(Icons.style_outlined),
+              label: const Text('View card'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MemoryDetail {
+  const _MemoryDetail(this.icon, this.label);
+
+  final IconData icon;
+  final String label;
+}

--- a/lib/services/grookai_objects/memory_card_print_service.dart
+++ b/lib/services/grookai_objects/memory_card_print_service.dart
@@ -1,0 +1,201 @@
+import 'dart:typed_data';
+
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:printing/printing.dart';
+
+enum MemoryCardPrintMode { memoryInsert, frontAndBack }
+
+typedef MemoryCardPdfLayout =
+    Future<bool> Function({
+      required String name,
+      required Future<Uint8List> Function(PdfPageFormat format) onLayout,
+    });
+
+typedef MemoryCardPdfShare =
+    Future<bool> Function({required Uint8List bytes, required String filename});
+
+class MemoryCardPrintPlacement {
+  const MemoryCardPrintPlacement({
+    required this.left,
+    required this.top,
+    required this.width,
+    required this.height,
+  });
+
+  final double left;
+  final double top;
+  final double width;
+  final double height;
+}
+
+class MemoryCardPrintService {
+  MemoryCardPrintService({
+    MemoryCardPdfLayout? layoutPdf,
+    MemoryCardPdfShare? sharePdf,
+  }) : _layoutPdf = layoutPdf ?? _systemLayoutPdf,
+       _sharePdf = sharePdf ?? _systemSharePdf;
+
+  static const double cardWidthInches = 2.5;
+  static const double cardHeightInches = 3.5;
+  static const double cardWidthPoints = cardWidthInches * PdfPageFormat.inch;
+  static const double cardHeightPoints = cardHeightInches * PdfPageFormat.inch;
+
+  static const double _cropMarkGap = 2;
+  static const double _cropMarkLength = 6;
+  static const double _cropMarkThickness = 0.5;
+  static const double _cropMarkExtent = _cropMarkGap + _cropMarkLength;
+
+  final MemoryCardPdfLayout _layoutPdf;
+  final MemoryCardPdfShare _sharePdf;
+
+  static MemoryCardPrintPlacement placementFor(PdfPageFormat pageFormat) {
+    return MemoryCardPrintPlacement(
+      left: (pageFormat.width - cardWidthPoints) / 2,
+      top: (pageFormat.height - cardHeightPoints) / 2,
+      width: cardWidthPoints,
+      height: cardHeightPoints,
+    );
+  }
+
+  Future<bool> printMemory({
+    required Uint8List memorySidePng,
+    Uint8List? cardSidePng,
+    required MemoryCardPrintMode mode,
+    required String documentName,
+  }) {
+    if (mode == MemoryCardPrintMode.frontAndBack && cardSidePng == null) {
+      throw ArgumentError.notNull('cardSidePng');
+    }
+    return _layoutPdf(
+      name: documentName,
+      onLayout: (format) => buildPdf(
+        pageFormat: format,
+        memorySidePng: memorySidePng,
+        cardSidePng: cardSidePng,
+        mode: mode,
+        title: documentName,
+      ),
+    );
+  }
+
+  Future<bool> shareMemoryPdf({
+    required Uint8List memorySidePng,
+    Uint8List? cardSidePng,
+    required MemoryCardPrintMode mode,
+    required String fileName,
+    PdfPageFormat pageFormat = PdfPageFormat.letter,
+  }) async {
+    if (mode == MemoryCardPrintMode.frontAndBack && cardSidePng == null) {
+      throw ArgumentError.notNull('cardSidePng');
+    }
+    final bytes = await buildPdf(
+      pageFormat: pageFormat,
+      memorySidePng: memorySidePng,
+      cardSidePng: cardSidePng,
+      mode: mode,
+      title: fileName,
+    );
+    return _sharePdf(bytes: bytes, filename: fileName);
+  }
+
+  Future<Uint8List> buildPdf({
+    required PdfPageFormat pageFormat,
+    required Uint8List memorySidePng,
+    Uint8List? cardSidePng,
+    required MemoryCardPrintMode mode,
+    String title = 'Grookai Memory',
+  }) async {
+    final document = pw.Document(
+      title: title,
+      author: 'Grookai Vault',
+      creator: 'Grookai Vault Memory Print V1',
+    );
+
+    if (mode == MemoryCardPrintMode.frontAndBack) {
+      document.addPage(_page(pageFormat: pageFormat, imageBytes: cardSidePng!));
+    }
+    document.addPage(_page(pageFormat: pageFormat, imageBytes: memorySidePng));
+    return document.save();
+  }
+
+  pw.Page _page({
+    required PdfPageFormat pageFormat,
+    required Uint8List imageBytes,
+  }) {
+    final image = pw.MemoryImage(imageBytes);
+    return pw.Page(
+      pageFormat: pageFormat,
+      margin: pw.EdgeInsets.zero,
+      build: (_) => pw.Center(child: _cardWithCropMarks(image)),
+    );
+  }
+
+  pw.Widget _cardWithCropMarks(pw.ImageProvider image) {
+    final canvasWidth = cardWidthPoints + (_cropMarkExtent * 2);
+    final canvasHeight = cardHeightPoints + (_cropMarkExtent * 2);
+    final cardLeft = _cropMarkExtent;
+    final cardTop = _cropMarkExtent;
+    final cardRight = cardLeft + cardWidthPoints;
+    final cardBottom = cardTop + cardHeightPoints;
+
+    pw.Widget horizontal(double left, double top) => pw.Positioned(
+      left: left,
+      top: top,
+      child: pw.Container(
+        width: _cropMarkLength,
+        height: _cropMarkThickness,
+        color: PdfColors.grey700,
+      ),
+    );
+    pw.Widget vertical(double left, double top) => pw.Positioned(
+      left: left,
+      top: top,
+      child: pw.Container(
+        width: _cropMarkThickness,
+        height: _cropMarkLength,
+        color: PdfColors.grey700,
+      ),
+    );
+
+    return pw.SizedBox(
+      width: canvasWidth,
+      height: canvasHeight,
+      child: pw.Stack(
+        children: [
+          pw.Positioned(
+            left: cardLeft,
+            top: cardTop,
+            child: pw.SizedBox(
+              width: cardWidthPoints,
+              height: cardHeightPoints,
+              child: pw.Image(image, fit: pw.BoxFit.fill),
+            ),
+          ),
+          horizontal(0, cardTop),
+          horizontal(cardRight + _cropMarkGap, cardTop),
+          horizontal(0, cardBottom),
+          horizontal(cardRight + _cropMarkGap, cardBottom),
+          vertical(cardLeft, 0),
+          vertical(cardRight, 0),
+          vertical(cardLeft, cardBottom + _cropMarkGap),
+          vertical(cardRight, cardBottom + _cropMarkGap),
+        ],
+      ),
+    );
+  }
+
+  static Future<bool> _systemLayoutPdf({
+    required String name,
+    required Future<Uint8List> Function(PdfPageFormat format) onLayout,
+  }) {
+    return Printing.layoutPdf(name: name, onLayout: onLayout);
+  }
+
+  static Future<bool> _systemSharePdf({
+    required Uint8List bytes,
+    required String filename,
+  }) {
+    return Printing.sharePdf(bytes: bytes, filename: filename);
+  }
+}

--- a/lib/services/navigation/grookai_web_route_service.dart
+++ b/lib/services/navigation/grookai_web_route_service.dart
@@ -4,6 +4,7 @@ import '../../secrets.dart';
 
 enum GrookaiCanonicalRouteKind {
   card,
+  memory,
   collector,
   collectorSection,
   set,
@@ -31,6 +32,15 @@ class GrookaiCanonicalRoute {
     return GrookaiCanonicalRoute._(
       kind: GrookaiCanonicalRouteKind.card,
       path: '/card/$normalized',
+      value: normalized,
+    );
+  }
+
+  factory GrookaiCanonicalRoute.memory(String memoryId) {
+    final normalized = memoryId.trim();
+    return GrookaiCanonicalRoute._(
+      kind: GrookaiCanonicalRouteKind.memory,
+      path: '/memory/${Uri.encodeComponent(normalized)}',
       value: normalized,
     );
   }
@@ -275,6 +285,8 @@ class GrookaiWebRouteService {
     switch (head) {
       case 'card':
         return GrookaiCanonicalRoute.card(value);
+      case 'memory':
+        return GrookaiCanonicalRoute.memory(value);
       case 'u':
       case 'collector':
         if (segments.length >= 4 && segments[2].toLowerCase() == 'section') {
@@ -313,6 +325,9 @@ class GrookaiWebRouteService {
 
     if (host == 'card' && segments.isNotEmpty) {
       return GrookaiCanonicalRoute.card(segments.first);
+    }
+    if (host == 'memory' && segments.isNotEmpty) {
+      return GrookaiCanonicalRoute.memory(segments.first);
     }
     if ((host == 'set' || host == 'sets') && segments.isNotEmpty) {
       return GrookaiCanonicalRoute.set(segments.first);

--- a/lib/services/network/pulse_service.dart
+++ b/lib/services/network/pulse_service.dart
@@ -8,6 +8,9 @@ const bool kPulseSurfaceEnabled = bool.fromEnvironment(
   defaultValue: true,
 );
 
+typedef PulseMemoryPhotoSigner =
+    Future<String> Function({required String path, required int expiresIn});
+
 class PulseUnreadSnapshot {
   const PulseUnreadSnapshot({
     required this.unreadCount,
@@ -70,6 +73,7 @@ class PulseItem {
     this.setIdentityModel,
     required this.displayImageUrl,
     required this.fallbackImageUrl,
+    this.memoryPhotoUrl,
     required this.ownershipContext,
     required this.distanceBucket,
     required this.localityLabel,
@@ -102,6 +106,7 @@ class PulseItem {
   final String? setIdentityModel;
   final String? displayImageUrl;
   final String? fallbackImageUrl;
+  final String? memoryPhotoUrl;
   final String ownershipContext;
   final String distanceBucket;
   final String localityLabel;
@@ -117,6 +122,7 @@ class PulseItem {
   bool get isWantMatch => rankBucket == 'want_match';
   bool get isCompletion => rankBucket == 'completion';
   bool get isCollectorActivity => rankBucket == 'collector_activity';
+  bool get isMemory => eventType == 'collector_memory_published';
   bool get isDexCompletion =>
       eventType == 'dex_completion_crossed' ||
       (isCompletion && completionSubjectType == 'character');
@@ -164,6 +170,14 @@ class PulseItem {
 
   String get contactVaultItemId => _text(payload['vault_item_id']);
 
+  String get memoryId => _text(payload['memory_id']);
+  String get memoryNote => _text(payload['memory_note']);
+  String get memoryPhotoPath => _text(payload['memory_photo_path']);
+  String get memoryPlaceLabel => _text(payload['memory_place_label']);
+  String get memoryOccasionLabel => _text(payload['memory_occasion_label']);
+  String get memoryDate => _text(payload['memory_date']);
+  String get memoryType => _text(payload['memory_type']);
+
   String get intent {
     final payloadIntent = _text(payload['intent']);
     if (payloadIntent.isNotEmpty) return payloadIntent;
@@ -195,6 +209,7 @@ class PulseItem {
       setIdentityModel: setIdentityModel,
       displayImageUrl: displayImageUrl,
       fallbackImageUrl: fallbackImageUrl,
+      memoryPhotoUrl: memoryPhotoUrl,
       ownershipContext: ownershipContext,
       distanceBucket: distanceBucket,
       localityLabel: localityLabel,
@@ -241,6 +256,43 @@ class PulseItem {
       setIdentityModel: setIdentityModel,
       displayImageUrl: displayImageUrl,
       fallbackImageUrl: fallbackImageUrl,
+      memoryPhotoUrl: memoryPhotoUrl,
+      ownershipContext: ownershipContext,
+      distanceBucket: distanceBucket,
+      localityLabel: localityLabel,
+      completionSubjectType: completionSubjectType,
+      completionSubjectLabel: completionSubjectLabel,
+      completionThreshold: completionThreshold,
+      primaryActionLabel: primaryActionLabel,
+      primaryActionRoute: primaryActionRoute,
+      payload: payload,
+      nextCursorCreatedAt: nextCursorCreatedAt,
+      nextCursorEventId: nextCursorEventId,
+    );
+  }
+
+  PulseItem copyWithMemoryPhotoUrl(String signedUrl) {
+    return PulseItem(
+      pulseItemId: pulseItemId,
+      cardEventId: cardEventId,
+      eventType: eventType,
+      rankBucket: rankBucket,
+      createdAt: createdAt,
+      actorUserId: actorUserId,
+      actorSlug: actorSlug,
+      actorDisplayName: actorDisplayName,
+      cardPrintId: cardPrintId,
+      gvId: gvId,
+      cardName: cardName,
+      setCode: setCode,
+      setName: setName,
+      cardNumber: cardNumber,
+      variantKey: variantKey,
+      printedIdentityModifier: printedIdentityModifier,
+      setIdentityModel: setIdentityModel,
+      displayImageUrl: displayImageUrl,
+      fallbackImageUrl: fallbackImageUrl,
+      memoryPhotoUrl: signedUrl,
       ownershipContext: ownershipContext,
       distanceBucket: distanceBucket,
       localityLabel: localityLabel,
@@ -298,6 +350,7 @@ class PulseItem {
       setIdentityModel: _nullableText(json['set_identity_model']),
       displayImageUrl: hostedImageUrl ?? fallbackImageUrl,
       fallbackImageUrl: hostedImageUrl == null ? null : fallbackImageUrl,
+      memoryPhotoUrl: null,
       ownershipContext: _text(json['ownership_context']),
       distanceBucket: _text(json['distance_bucket']),
       localityLabel: _text(json['locality_label']),
@@ -316,9 +369,17 @@ class PulseItem {
 }
 
 class PulseService {
-  const PulseService({required SupabaseClient client}) : _client = client;
+  const PulseService({
+    required SupabaseClient client,
+    PulseMemoryPhotoSigner? memoryPhotoSigner,
+  }) : _client = client,
+       _memoryPhotoSigner = memoryPhotoSigner;
 
   final SupabaseClient _client;
+  final PulseMemoryPhotoSigner? _memoryPhotoSigner;
+
+  static const String _memoryPhotoBucket = 'collector-memory-images';
+  static const int _memoryPhotoExpirySeconds = 300;
 
   Future<PulseUnreadSnapshot> fetchUnread() async {
     if (_client.auth.currentUser == null) {
@@ -359,13 +420,50 @@ class PulseService {
         .whereType<PulseItem>()
         .toList(growable: false);
     final identityItems = await _resolveCardDisplayIdentities(items);
-    final resolvedItems = await _resolveDexCompletionRoutes(identityItems);
+    final completionItems = await _resolveDexCompletionRoutes(identityItems);
+    final resolvedItems = await _resolveMemoryPhotos(completionItems);
     final tail = resolvedItems.isEmpty ? null : resolvedItems.last;
     return PulsePage(
       items: resolvedItems,
       nextCursorCreatedAt: tail?.nextCursorCreatedAt,
       nextCursorEventId: tail?.nextCursorEventId,
     );
+  }
+
+  Future<List<PulseItem>> _resolveMemoryPhotos(List<PulseItem> items) {
+    return Future.wait(
+      items.map((item) async {
+        final path = item.memoryPhotoPath;
+        if (!item.isMemory || !_validMemoryPhotoPath(item, path)) {
+          return item;
+        }
+
+        try {
+          final injected = _memoryPhotoSigner;
+          final signedUrl = injected != null
+              ? await injected(path: path, expiresIn: _memoryPhotoExpirySeconds)
+              : await _client.storage
+                    .from(_memoryPhotoBucket)
+                    .createSignedUrl(path, _memoryPhotoExpirySeconds);
+          return signedUrl.trim().isEmpty
+              ? item
+              : item.copyWithMemoryPhotoUrl(signedUrl);
+        } catch (_) {
+          // The card artwork remains a safe fallback when the private photo
+          // cannot be signed or the current publication is no longer visible.
+          return item;
+        }
+      }),
+    );
+  }
+
+  bool _validMemoryPhotoPath(PulseItem item, String path) {
+    final segments = path.split('/');
+    return segments.length == 4 &&
+        segments[0] == item.actorUserId &&
+        segments[1] == 'memories' &&
+        segments[2] == item.memoryId &&
+        segments[3] == 'photo';
   }
 
   Future<List<PulseItem>> _resolveCardDisplayIdentities(

--- a/lib/services/vault/collector_memory_service.dart
+++ b/lib/services/vault/collector_memory_service.dart
@@ -136,6 +136,10 @@ class OwnerCollectorMemory {
     required this.setName,
     this.gvId,
     this.cardImageUrl,
+    this.ownerUserId,
+    this.ownerSlug,
+    this.ownerDisplayName,
+    this.viewerIsOwner = true,
   });
 
   final CollectorMemory memory;
@@ -144,6 +148,10 @@ class OwnerCollectorMemory {
   final String setName;
   final String? gvId;
   final String? cardImageUrl;
+  final String? ownerUserId;
+  final String? ownerSlug;
+  final String? ownerDisplayName;
+  final bool viewerIsOwner;
 
   CatalogArtworkResolution get catalogArtwork =>
       resolveCatalogArtwork(gvId: gvId, providerImageUrl: cardImageUrl);
@@ -160,6 +168,10 @@ class OwnerCollectorMemory {
       setName: setName,
       gvId: _optionalText(gvId) ?? this.gvId,
       cardImageUrl: _optionalText(providerImageUrl) ?? cardImageUrl,
+      ownerUserId: ownerUserId,
+      ownerSlug: ownerSlug,
+      ownerDisplayName: ownerDisplayName,
+      viewerIsOwner: viewerIsOwner,
     );
   }
 
@@ -175,6 +187,12 @@ class OwnerCollectorMemory {
       setName: _text(json['set_name']),
       gvId: _optionalText(json['gv_id']),
       cardImageUrl: _optionalText(json['card_image_url']),
+      ownerUserId: _optionalText(json['owner_user_id']),
+      ownerSlug: _optionalText(json['owner_slug']),
+      ownerDisplayName: _optionalText(json['owner_display_name']),
+      viewerIsOwner: json.containsKey('viewer_is_owner')
+          ? _bool(json['viewer_is_owner'])
+          : true,
     );
   }
 }
@@ -332,6 +350,22 @@ class CollectorMemoryService {
       // hide the owner's private memories or their signed photos.
       return memories;
     }
+  }
+
+  Future<OwnerCollectorMemory?> loadAccessibleMemory({
+    required String memoryId,
+  }) async {
+    final normalizedId = _text(memoryId);
+    if (normalizedId.isEmpty) {
+      return null;
+    }
+
+    final response = await _callRpc(
+      'collector_memory_accessible_by_id_v1',
+      params: <String, dynamic>{'p_memory_id': normalizedId},
+    );
+    final row = _firstMap(response);
+    return row == null ? null : OwnerCollectorMemory.fromJson(row);
   }
 
   Future<List<Map<String, dynamic>>> _loadCatalogRows(

--- a/lib/services/vault/collector_memory_service.dart
+++ b/lib/services/vault/collector_memory_service.dart
@@ -82,6 +82,9 @@ class CollectorMemory {
     this.occasionLabel,
     this.memoryDate,
     this.promptKey,
+    this.isPublic = false,
+    this.publishedAt,
+    this.publicationVersion = 0,
     this.createdAt,
     this.updatedAt,
   });
@@ -96,6 +99,9 @@ class CollectorMemory {
   final String? occasionLabel;
   final DateTime? memoryDate;
   final String? promptKey;
+  final bool isPublic;
+  final DateTime? publishedAt;
+  final int publicationVersion;
   final DateTime? createdAt;
   final DateTime? updatedAt;
 
@@ -113,6 +119,9 @@ class CollectorMemory {
       occasionLabel: _optionalText(json['occasion_label']),
       memoryDate: _date(json['memory_date']),
       promptKey: _optionalText(json['prompt_key']),
+      isPublic: _bool(json['is_public']),
+      publishedAt: _date(json['published_at']),
+      publicationVersion: _integer(json['publication_version']),
       createdAt: _date(json['created_at']),
       updatedAt: _date(json['updated_at']),
     );
@@ -418,6 +427,20 @@ class CollectorMemoryService {
     );
   }
 
+  Future<CollectorMemory> setPublic({
+    required String memoryId,
+    required bool isPublic,
+  }) async {
+    final response = await _callRpc(
+      'collector_memory_set_public_v1',
+      params: <String, dynamic>{
+        'p_memory_id': _text(memoryId),
+        'p_is_public': isPublic,
+      },
+    );
+    return _requiredMemory(response, 'collector_memory_set_public_v1');
+  }
+
   Future<void> dismissPrompt({required String promptKey}) async {
     await _callRpc(
       'collector_memory_prompt_dismiss_v1',
@@ -599,6 +622,17 @@ String? _optionalText(dynamic value) {
 DateTime? _date(dynamic value) {
   final normalized = _text(value);
   return normalized.isEmpty ? null : DateTime.tryParse(normalized);
+}
+
+bool _bool(dynamic value) {
+  if (value is bool) return value;
+  return _text(value).toLowerCase() == 'true';
+}
+
+int _integer(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(_text(value)) ?? 0;
 }
 
 String? _dateParam(DateTime? value) =>

--- a/lib/widgets/grookai_objects/grookai_object_models.dart
+++ b/lib/widgets/grookai_objects/grookai_object_models.dart
@@ -30,6 +30,7 @@ class MemoryCardData {
   final String listingNo; // display only, e.g. "001"
   final DateTime date;
   final String location;
+  final String? occasion;
   final String? photoUrl; // null -> polaroid placeholder
   final String storyText;
   final String authorName;
@@ -40,6 +41,7 @@ class MemoryCardData {
     required this.listingNo,
     required this.date,
     required this.location,
+    this.occasion,
     this.photoUrl,
     required this.storyText,
     required this.authorName,
@@ -60,6 +62,7 @@ class MemoryCardData {
       listingNo: f['listingNo'] as String,
       date: DateTime.parse(f['date'] as String),
       location: f['location'] as String,
+      occasion: f['occasion'] as String?,
       photoUrl: f['photoUrl'] as String?,
       storyText: f['storyText'] as String,
       authorName: f['authorName'] as String,
@@ -74,6 +77,7 @@ class MemoryCardData {
     'listingNo': listingNo,
     'date': date.toIso8601String(),
     'location': location,
+    'occasion': occasion,
     'photoUrl': photoUrl,
     'storyText': storyText,
     'authorName': authorName,

--- a/lib/widgets/grookai_objects/grookai_object_share_destination_sheet.dart
+++ b/lib/widgets/grookai_objects/grookai_object_share_destination_sheet.dart
@@ -24,35 +24,37 @@ class GrookaiObjectShareDestinationSheet extends StatelessWidget {
     final theme = Theme.of(context);
     final destinations = GrookaiObjectExportService.destinationsFor(object);
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 6, 20, 20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Share destination',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w800,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 6, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Share destination',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
               ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Choose the output shape before generating the image.',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+              const SizedBox(height: 4),
+              Text(
+                'Choose the output shape before generating the image.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
-            ),
-            const SizedBox(height: 12),
-            for (final destination in destinations)
-              ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: Icon(_iconFor(destination)),
-                title: Text(destination.label),
-                subtitle: Text(_descriptionFor(destination)),
-                onTap: () => Navigator.of(context).pop(destination),
-              ),
-          ],
+              const SizedBox(height: 12),
+              for (final destination in destinations)
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(_iconFor(destination)),
+                  title: Text(destination.label),
+                  subtitle: Text(_descriptionFor(destination)),
+                  onTap: () => Navigator.of(context).pop(destination),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/grookai_objects/memory_card_widgets.dart
+++ b/lib/widgets/grookai_objects/memory_card_widgets.dart
@@ -71,6 +71,7 @@ class MemoryCardBack extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final t = grookaiObjectTokens[data.skin]!;
+    final density = _MemoryBackDensity.forStory(data.storyText);
     return GrookaiObjectFrame(
       skin: data.skin,
       child: Column(
@@ -126,36 +127,42 @@ class MemoryCardBack extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 20),
-          Center(
-            child: _Polaroid(skin: data.skin, imageUrl: data.photoUrl),
-          ),
-          const SizedBox(height: 20),
-          Expanded(
-            child: Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    '"${data.storyText}"',
-                    textAlign: TextAlign.center,
-                    style: serifTitle(
-                      t,
-                      size: 17,
-                    ).copyWith(fontStyle: FontStyle.italic),
-                  ),
-                  const SizedBox(height: 10),
-                  Text(
-                    '— ${data.authorName.toUpperCase()}',
-                    style: monoLabel(
-                      t,
-                      size: 10.5,
-                      color: t.accent,
-                      letterSpacing: 0.08,
+          if ((data.occasion ?? '').trim().isNotEmpty) ...[
+            const SizedBox(height: 9),
+            Row(
+              children: [
+                Icon(Icons.celebration_outlined, size: 15, color: t.accent),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    data.occasion!.trim(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: t.primaryText.withValues(alpha: 0.72),
                     ),
                   ),
-                ],
+                ),
+              ],
+            ),
+          ],
+          if (density.showPhoto) ...[
+            SizedBox(height: density.photoSpacing),
+            Center(
+              child: _Polaroid(
+                skin: data.skin,
+                imageUrl: data.photoUrl,
+                width: density.photoWidth,
+                height: density.photoHeight,
               ),
+            ),
+            SizedBox(height: density.photoSpacing),
+          ] else
+            const SizedBox(height: 14),
+          Expanded(
+            child: Center(
+              child: _MemoryStoryBlock(data: data, tokens: t, density: density),
             ),
           ),
           CardDivider(tokens: t),
@@ -185,12 +192,74 @@ class MemoryCardBack extends StatelessWidget {
   }
 }
 
+class _MemoryStoryBlock extends StatelessWidget {
+  const _MemoryStoryBlock({
+    required this.data,
+    required this.tokens,
+    required this.density,
+  });
+
+  final MemoryCardData data;
+  final GrookaiObjectTokens tokens;
+  final _MemoryBackDensity density;
+
+  @override
+  Widget build(BuildContext context) {
+    final author = Text(
+      '— ${data.authorName.toUpperCase()}',
+      style: monoLabel(
+        tokens,
+        size: 10.5,
+        color: tokens.accent,
+        letterSpacing: 0.08,
+      ),
+    );
+    if (!density.compactStory) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '"${data.storyText}"',
+            textAlign: TextAlign.center,
+            style: serifTitle(
+              tokens,
+              size: 17,
+            ).copyWith(fontStyle: FontStyle.italic),
+          ),
+          const SizedBox(height: 10),
+          author,
+        ],
+      );
+    }
+    return Column(
+      children: [
+        Expanded(
+          child: _MemoryStoryText(
+            text: data.storyText,
+            tokens: tokens,
+            preferredFontSize: density.storyFontSize,
+          ),
+        ),
+        const SizedBox(height: 10),
+        author,
+      ],
+    );
+  }
+}
+
 /// Polaroid photo block, rotation differs per skin (-3deg Onyx, 0deg Ivory,
 /// +2deg Kraft) to match the mockup exactly.
 class _Polaroid extends StatelessWidget {
   final GrookaiObjectSkin skin;
   final String? imageUrl;
-  const _Polaroid({required this.skin, this.imageUrl});
+  final double width;
+  final double height;
+  const _Polaroid({
+    required this.skin,
+    this.imageUrl,
+    this.width = 176,
+    this.height = 220,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -203,8 +272,8 @@ class _Polaroid extends StatelessWidget {
     return Transform.rotate(
       angle: rotation * 3.14159 / 180,
       child: Container(
-        width: 176,
-        height: 220,
+        width: width,
+        height: height,
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
           color: t.primaryText.withValues(alpha: 0.05),
@@ -223,8 +292,8 @@ class _Polaroid extends StatelessWidget {
         child: imageUrl != null
             ? GrookaiObjectNetworkImage(
                 imageUrl: imageUrl!,
-                width: 160,
-                height: 204,
+                width: width - 16,
+                height: height - 16,
                 fit: BoxFit.cover,
                 borderRadius: BorderRadius.zero,
               )
@@ -240,6 +309,106 @@ class _Polaroid extends StatelessWidget {
                 ),
               ),
       ),
+    );
+  }
+}
+
+class _MemoryStoryText extends StatelessWidget {
+  const _MemoryStoryText({
+    required this.text,
+    required this.tokens,
+    required this.preferredFontSize,
+  });
+
+  final String text;
+  final GrookaiObjectTokens tokens;
+  final double preferredFontSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final quotedText = '"$text"';
+        var fontSize = preferredFontSize;
+        while (fontSize > 8.5) {
+          final painter = TextPainter(
+            text: TextSpan(
+              text: quotedText,
+              style: serifTitle(
+                tokens,
+                size: fontSize,
+              ).copyWith(fontStyle: FontStyle.italic),
+            ),
+            textAlign: TextAlign.center,
+            textDirection: TextDirection.ltr,
+          )..layout(maxWidth: constraints.maxWidth);
+          if (painter.height <= constraints.maxHeight) {
+            break;
+          }
+          fontSize -= 0.5;
+        }
+        return Align(
+          alignment: Alignment.center,
+          child: Text(
+            quotedText,
+            textAlign: TextAlign.center,
+            style: serifTitle(
+              tokens,
+              size: fontSize,
+            ).copyWith(fontStyle: FontStyle.italic),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MemoryBackDensity {
+  const _MemoryBackDensity({
+    required this.showPhoto,
+    required this.photoWidth,
+    required this.photoHeight,
+    required this.photoSpacing,
+    required this.storyFontSize,
+    required this.compactStory,
+  });
+
+  final bool showPhoto;
+  final double photoWidth;
+  final double photoHeight;
+  final double photoSpacing;
+  final double storyFontSize;
+  final bool compactStory;
+
+  factory _MemoryBackDensity.forStory(String story) {
+    final length = story.trim().length;
+    if (length > 700) {
+      return const _MemoryBackDensity(
+        showPhoto: false,
+        photoWidth: 0,
+        photoHeight: 0,
+        photoSpacing: 0,
+        storyFontSize: 11,
+        compactStory: true,
+      );
+    }
+    if (length > 320) {
+      return const _MemoryBackDensity(
+        showPhoto: true,
+        photoWidth: 104,
+        photoHeight: 130,
+        photoSpacing: 12,
+        storyFontSize: 13,
+        compactStory: true,
+      );
+    }
+    return const _MemoryBackDensity(
+      showPhoto: true,
+      photoWidth: 176,
+      photoHeight: 220,
+      photoSpacing: 20,
+      storyFontSize: 17,
+      compactStory: false,
     );
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <gtk/gtk_plugin.h>
+#include <printing/printing_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) printing_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
+  printing_plugin_register_with_registrar(printing_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   gtk
+  printing
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import firebase_core
 import firebase_crashlytics
 import firebase_messaging
 import path_provider_foundation
+import printing
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
@@ -25,6 +26,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:
@@ -608,6 +624,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
@@ -656,6 +680,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: e47a275b267873d5944ad5f5ff0dcc7ac2e36c02b3046a0ffac9b72fd362c44b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.12.0"
+  pdf_widget_wrapper:
+    dependency: transitive
+    description:
+      name: pdf_widget_wrapper
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -704,6 +744,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.3"
+  printing:
+    dependency: "direct main"
+    description:
+      name: printing
+      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.3"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   realtime_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   camera: ^0.10.5+9
   sensors_plus: ^5.0.1
   share_plus: ^12.0.2
+  pdf: 3.12.0
+  printing: 5.14.3
   url_launcher: ^6.3.2
   app_links: ^6.4.1
   visibility_detector: ^0.4.0+2

--- a/supabase/migrations/20260811170000_collector_memory_public_pulse_v1.sql
+++ b/supabase/migrations/20260811170000_collector_memory_public_pulse_v1.sql
@@ -1,0 +1,619 @@
+begin;
+
+alter table public.collector_memories
+  add column if not exists is_public boolean not null default false,
+  add column if not exists published_at timestamptz null,
+  add column if not exists publication_version integer not null default 0,
+  add column if not exists publication_event_id uuid null
+    references public.card_events(id);
+
+alter table public.collector_memories
+  drop constraint if exists collector_memories_publication_state_check;
+
+alter table public.collector_memories
+  add constraint collector_memories_publication_state_check
+  check (
+    publication_version >= 0
+    and (
+      (
+      is_public is false
+      and published_at is null
+      and publication_event_id is null
+      )
+      or (
+        is_public is true
+        and published_at is not null
+        and publication_event_id is not null
+        and publication_version > 0
+      )
+    )
+  );
+
+create index if not exists collector_memories_public_event_idx
+  on public.collector_memories (publication_event_id)
+  where is_public is true and archived_at is null;
+
+comment on type public.collector_memory_type is
+'Collector memory kinds. Memories remain owner-private by default and may be explicitly published by their owner.';
+
+comment on table public.collector_memories is
+'Exact-copy collector memories. Rows remain owner-only; explicit publication is exposed only through governed Pulse and signed-photo contracts.';
+
+comment on column public.collector_memories.is_public is
+'Owner-controlled publication state. False by default for all existing and new memories.';
+
+comment on column public.collector_memories.publication_event_id is
+'Current append-only collector_memory_published event. Pulse requires this exact event to remain current.';
+
+drop function if exists public.collector_memories_for_gvvi_v1(
+  text,
+  integer,
+  timestamptz,
+  uuid
+);
+
+create function public.collector_memories_for_gvvi_v1(
+  p_gv_vi_id text,
+  p_limit integer default 20,
+  p_before_created_at timestamptz default null,
+  p_before_id uuid default null
+)
+returns table (
+  id uuid,
+  vault_item_instance_id uuid,
+  gv_vi_id text,
+  memory_type public.collector_memory_type,
+  note text,
+  photo_path text,
+  place_label text,
+  occasion_label text,
+  memory_date date,
+  prompt_key text,
+  is_public boolean,
+  published_at timestamptz,
+  publication_version integer,
+  created_at timestamptz,
+  updated_at timestamptz,
+  cursor_created_at timestamptz,
+  cursor_id uuid
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with viewer as (
+    select auth.uid() as user_id
+  ), target as (
+    select vii.id, vii.gv_vi_id
+    from public.vault_item_instances vii, viewer
+    where viewer.user_id is not null
+      and vii.user_id = viewer.user_id
+      and vii.archived_at is null
+      and vii.gv_vi_id = upper(btrim(coalesce(p_gv_vi_id, '')))
+    limit 1
+  )
+  select
+    cm.id,
+    cm.vault_item_instance_id,
+    target.gv_vi_id,
+    cm.memory_type,
+    cm.note,
+    cm.photo_path,
+    cm.place_label,
+    cm.occasion_label,
+    cm.memory_date,
+    cm.prompt_key,
+    cm.is_public,
+    cm.published_at,
+    cm.publication_version,
+    cm.created_at,
+    cm.updated_at,
+    cm.created_at as cursor_created_at,
+    cm.id as cursor_id
+  from public.collector_memories cm
+  join target on target.id = cm.vault_item_instance_id
+  where cm.user_id = auth.uid()
+    and cm.archived_at is null
+    and (
+      p_before_created_at is null
+      or (cm.created_at, cm.id) < (
+        p_before_created_at,
+        coalesce(p_before_id, 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid)
+      )
+    )
+  order by cm.created_at desc, cm.id desc
+  limit least(greatest(coalesce(p_limit, 20), 1), 50);
+$$;
+
+revoke all on function public.collector_memories_for_gvvi_v1(
+  text,
+  integer,
+  timestamptz,
+  uuid
+) from public, anon;
+grant execute on function public.collector_memories_for_gvvi_v1(
+  text,
+  integer,
+  timestamptz,
+  uuid
+) to authenticated;
+
+comment on function public.collector_memories_for_gvvi_v1(
+  text,
+  integer,
+  timestamptz,
+  uuid
+) is
+'Owner-only collector Memory read for one active exact copy, including the owner-controlled publication state.';
+
+drop function if exists public.collector_memories_for_owner_v1(
+  integer,
+  timestamptz,
+  uuid
+);
+
+create function public.collector_memories_for_owner_v1(
+  p_limit integer default 50,
+  p_before_created_at timestamptz default null,
+  p_before_id uuid default null
+)
+returns table (
+  id uuid,
+  vault_item_instance_id uuid,
+  gv_vi_id text,
+  card_print_id uuid,
+  card_name text,
+  set_name text,
+  card_image_url text,
+  memory_type public.collector_memory_type,
+  note text,
+  photo_path text,
+  place_label text,
+  occasion_label text,
+  memory_date date,
+  prompt_key text,
+  is_public boolean,
+  published_at timestamptz,
+  publication_version integer,
+  created_at timestamptz,
+  updated_at timestamptz,
+  cursor_created_at timestamptz,
+  cursor_id uuid
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    cm.id,
+    cm.vault_item_instance_id,
+    vii.gv_vi_id,
+    vii.card_print_id,
+    coalesce(cp.name, 'Card memory') as card_name,
+    coalesce(s.name, cp.set_code, '') as set_name,
+    coalesce(cp.image_url, cp.image_alt_url) as card_image_url,
+    cm.memory_type,
+    cm.note,
+    cm.photo_path,
+    cm.place_label,
+    cm.occasion_label,
+    cm.memory_date,
+    cm.prompt_key,
+    cm.is_public,
+    cm.published_at,
+    cm.publication_version,
+    cm.created_at,
+    cm.updated_at,
+    cm.created_at as cursor_created_at,
+    cm.id as cursor_id
+  from public.collector_memories cm
+  join public.vault_item_instances vii
+    on vii.id = cm.vault_item_instance_id
+   and vii.user_id = auth.uid()
+   and vii.archived_at is null
+  left join public.card_prints cp
+    on cp.id = vii.card_print_id
+  left join public.sets s
+    on s.id = cp.set_id
+  where auth.uid() is not null
+    and cm.user_id = auth.uid()
+    and cm.archived_at is null
+    and (
+      p_before_created_at is null
+      or (cm.created_at, cm.id) < (
+        p_before_created_at,
+        coalesce(p_before_id, 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid)
+      )
+    )
+  order by cm.created_at desc, cm.id desc
+  limit least(greatest(coalesce(p_limit, 50), 1), 100);
+$$;
+
+revoke all on function public.collector_memories_for_owner_v1(
+  integer,
+  timestamptz,
+  uuid
+) from public, anon;
+grant execute on function public.collector_memories_for_owner_v1(
+  integer,
+  timestamptz,
+  uuid
+) to authenticated;
+
+comment on function public.collector_memories_for_owner_v1(
+  integer,
+  timestamptz,
+  uuid
+) is
+'Owner-only collector Memory feed across active exact copies, including the owner-controlled publication state. Memory rows are never directly public.';
+
+create or replace function public.collector_memory_set_public_v1(
+  p_memory_id uuid,
+  p_is_public boolean
+)
+returns public.collector_memories
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_memory public.collector_memories%rowtype;
+  v_instance public.vault_item_instances%rowtype;
+  v_event_id uuid;
+  v_next_version integer;
+begin
+  if v_user_id is null then
+    raise exception 'sign in required';
+  end if;
+
+  select *
+  into v_memory
+  from public.collector_memories
+  where id = p_memory_id
+    and user_id = v_user_id
+    and archived_at is null
+  for update;
+
+  if v_memory.id is null then
+    raise exception 'collector memory not found';
+  end if;
+
+  if p_is_public is not true then
+    if v_memory.is_public is false then
+      return v_memory;
+    end if;
+
+    update public.collector_memories
+    set
+      is_public = false,
+      published_at = null,
+      publication_event_id = null
+    where id = v_memory.id
+      and user_id = v_user_id
+    returning * into v_memory;
+
+    return v_memory;
+  end if;
+
+  if v_memory.is_public is true then
+    return v_memory;
+  end if;
+
+  if public.interest_graph_collector_public_v1(v_user_id) is false then
+    raise exception 'enable your public profile and vault sharing before publishing a Memory';
+  end if;
+
+  select *
+  into v_instance
+  from public.vault_item_instances
+  where id = v_memory.vault_item_instance_id
+    and user_id = v_user_id
+    and archived_at is null
+    and card_print_id is not null
+  limit 1;
+
+  if v_instance.id is null then
+    raise exception 'collector memory active exact copy not found';
+  end if;
+
+  v_event_id := gen_random_uuid();
+  v_next_version := v_memory.publication_version + 1;
+
+  insert into public.card_events (
+    id,
+    event_type,
+    card_print_id,
+    actor_user_id,
+    subject_user_id,
+    payload,
+    visibility,
+    dedupe_key
+  ) values (
+    v_event_id,
+    'collector_memory_published',
+    v_instance.card_print_id,
+    v_user_id,
+    null,
+    jsonb_build_object(
+      'memory_id', v_memory.id,
+      'publication_version', v_next_version,
+      'gvvi_id', v_instance.gv_vi_id
+    ),
+    'public',
+    concat_ws(
+      ':',
+      'collector-memory-published',
+      v_memory.id::text,
+      v_next_version::text
+    )
+  );
+
+  update public.collector_memories
+  set
+    is_public = true,
+    published_at = now(),
+    publication_version = v_next_version,
+    publication_event_id = v_event_id
+  where id = v_memory.id
+    and user_id = v_user_id
+  returning * into v_memory;
+
+  return v_memory;
+end;
+$$;
+
+revoke all on function public.collector_memory_set_public_v1(uuid, boolean)
+from public, anon;
+grant execute on function public.collector_memory_set_public_v1(uuid, boolean)
+to authenticated;
+
+comment on function public.collector_memory_set_public_v1(uuid, boolean) is
+'Owner-only publication switch. Publishing requires current public collector visibility and creates one current append-only Pulse event; unpublishing invalidates that event without deleting history.';
+
+create or replace function public.collector_memory_archive_v1(p_memory_id uuid)
+returns public.collector_memories
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_row public.collector_memories%rowtype;
+begin
+  if v_user_id is null then
+    raise exception 'sign in required';
+  end if;
+
+  update public.collector_memories
+  set
+    archived_at = coalesce(archived_at, now()),
+    is_public = false,
+    published_at = null,
+    publication_event_id = null
+  where id = p_memory_id
+    and user_id = v_user_id
+  returning * into v_row;
+
+  if v_row.id is null then
+    raise exception 'collector memory not found';
+  end if;
+
+  return v_row;
+end;
+$$;
+
+revoke all on function public.collector_memory_archive_v1(uuid)
+from public, anon;
+grant execute on function public.collector_memory_archive_v1(uuid)
+to authenticated;
+
+drop policy if exists collector_memory_images_published_select_v1
+on storage.objects;
+
+create policy collector_memory_images_published_select_v1
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'collector-memory-images'
+  and exists (
+    select 1
+    from public.collector_memories cm
+    join public.vault_item_instances vii
+      on vii.id = cm.vault_item_instance_id
+     and vii.user_id = cm.user_id
+     and vii.archived_at is null
+     and vii.card_print_id is not null
+    join public.card_events e
+      on e.id = cm.publication_event_id
+     and e.event_type = 'collector_memory_published'
+     and e.actor_user_id = cm.user_id
+     and e.visibility = 'public'
+     and (e.payload ->> 'publication_version') = cm.publication_version::text
+    where cm.photo_path = name
+      and cm.is_public is true
+      and cm.archived_at is null
+      and public.interest_graph_collectors_visible_to_viewer_v1(
+        auth.uid(),
+        cm.user_id,
+        null
+      )
+  )
+);
+
+alter function public.pulse_eligible_events_for_viewer_v1(uuid)
+rename to collector_memory_pulse_base_eligible_events_v1;
+
+create or replace function public.pulse_eligible_events_for_viewer_v1(
+  p_viewer_user_id uuid
+)
+returns table (
+  card_event_id uuid,
+  event_type text,
+  rank_bucket text,
+  bucket_rank integer,
+  created_at timestamptz,
+  actor_user_id uuid,
+  actor_slug text,
+  actor_display_name text,
+  actor_avatar_path text,
+  subject_user_id uuid,
+  subject_slug text,
+  subject_display_name text,
+  card_print_id uuid,
+  gv_id text,
+  card_name text,
+  set_code text,
+  set_name text,
+  card_number text,
+  display_image_url text,
+  display_image_kind text,
+  ownership_context text,
+  distance_bucket text,
+  locality_label text,
+  value_delta_amount numeric,
+  value_delta_percent numeric,
+  completion_subject_type text,
+  completion_subject_label text,
+  completion_threshold numeric,
+  primary_action text,
+  primary_action_label text,
+  primary_action_route text,
+  payload jsonb,
+  visibility text,
+  watch_subject_type text,
+  watch_subject_id uuid,
+  watch_strength double precision
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select *
+  from public.collector_memory_pulse_base_eligible_events_v1(
+    p_viewer_user_id
+  )
+
+  union all
+
+  select
+    e.id as card_event_id,
+    e.event_type,
+    'collector_activity'::text as rank_bucket,
+    2::integer as bucket_rank,
+    e.created_at,
+    e.actor_user_id,
+    actor_profile.slug as actor_slug,
+    actor_profile.display_name as actor_display_name,
+    actor_profile.avatar_path as actor_avatar_path,
+    null::uuid as subject_user_id,
+    null::text as subject_slug,
+    null::text as subject_display_name,
+    cp.id as card_print_id,
+    cp.gv_id,
+    cp.name as card_name,
+    cp.set_code,
+    s.name as set_name,
+    cp.number as card_number,
+    coalesce(cp.image_url, cp.image_alt_url) as display_image_url,
+    case
+      when nullif(btrim(coalesce(cp.image_url, cp.image_alt_url)), '') is not null
+        then 'exact'
+      else 'missing'
+    end::text as display_image_kind,
+    'memory'::text as ownership_context,
+    null::text as distance_bucket,
+    null::text as locality_label,
+    null::numeric as value_delta_amount,
+    null::numeric as value_delta_percent,
+    null::text as completion_subject_type,
+    null::text as completion_subject_label,
+    null::numeric as completion_threshold,
+    'open_memory'::text as primary_action,
+    'View memory'::text as primary_action_label,
+    null::text as primary_action_route,
+    e.payload || jsonb_strip_nulls(
+      jsonb_build_object(
+        'memory_type', cm.memory_type::text,
+        'memory_note', cm.note,
+        'memory_photo_path', cm.photo_path,
+        'memory_place_label', cm.place_label,
+        'memory_occasion_label', cm.occasion_label,
+        'memory_date', cm.memory_date,
+        'published_at', cm.published_at,
+        'gvvi_id', vii.gv_vi_id
+      )
+    ) as payload,
+    e.visibility,
+    selected_watch.subject_type as watch_subject_type,
+    selected_watch.subject_id as watch_subject_id,
+    selected_watch.strength as watch_strength
+  from public.card_events e
+  join public.collector_memories cm
+    on cm.id = public.pulse_jsonb_uuid_v1(e.payload ->> 'memory_id')
+   and cm.user_id = e.actor_user_id
+   and cm.is_public is true
+   and cm.archived_at is null
+   and cm.publication_event_id = e.id
+   and (e.payload ->> 'publication_version') = cm.publication_version::text
+  join public.vault_item_instances vii
+    on vii.id = cm.vault_item_instance_id
+   and vii.user_id = cm.user_id
+   and vii.archived_at is null
+   and vii.card_print_id = e.card_print_id
+  join public.card_prints cp
+    on cp.id = vii.card_print_id
+  left join public.sets s
+    on s.id = cp.set_id
+  left join public.public_profiles actor_profile
+    on actor_profile.user_id = e.actor_user_id
+  join lateral (
+    select
+      w.subject_type,
+      w.subject_id,
+      w.strength
+    from public.watches w
+    where w.user_id = p_viewer_user_id
+      and w.muted_at is null
+      and (
+        (w.subject_type = 'collector' and w.subject_id = e.actor_user_id)
+        or (w.subject_type = 'card' and w.subject_id = e.card_print_id)
+        or (w.subject_type = 'set' and w.subject_id = cp.set_id)
+      )
+    order by w.strength desc, w.created_at desc
+    limit 1
+  ) selected_watch on true
+  where e.event_type = 'collector_memory_published'
+    and e.visibility = 'public'
+    and public.interest_graph_collector_public_v1(e.actor_user_id)
+    and public.interest_graph_card_event_visible_to_viewer_v1(
+      p_viewer_user_id,
+      e.actor_user_id,
+      e.subject_user_id,
+      e.visibility
+    )
+    and not exists (
+      select 1
+      from public.watches muted_card_watch
+      where muted_card_watch.user_id = p_viewer_user_id
+        and muted_card_watch.subject_type = 'card'
+        and muted_card_watch.subject_id = e.card_print_id
+        and muted_card_watch.muted_at is not null
+    );
+$$;
+
+comment on function public.pulse_eligible_events_for_viewer_v1(uuid) is
+'Pulse eligibility including current owner-published collector Memories. Historical events are ineligible unless they remain the active publication event for an active public Memory.';
+
+revoke all on function public.collector_memory_pulse_base_eligible_events_v1(uuid)
+from public, anon, authenticated;
+revoke all on function public.pulse_eligible_events_for_viewer_v1(uuid)
+from public, anon, authenticated;
+grant execute on function public.collector_memory_pulse_base_eligible_events_v1(uuid)
+to service_role;
+grant execute on function public.pulse_eligible_events_for_viewer_v1(uuid)
+to service_role;
+
+commit;

--- a/supabase/migrations/20260811213000_collector_memory_share_route_v1.sql
+++ b/supabase/migrations/20260811213000_collector_memory_share_route_v1.sql
@@ -1,0 +1,110 @@
+begin;
+
+create or replace function public.collector_memory_accessible_by_id_v1(
+  p_memory_id uuid
+)
+returns table (
+  id uuid,
+  vault_item_instance_id uuid,
+  gv_vi_id text,
+  card_print_id uuid,
+  card_name text,
+  set_name text,
+  card_image_url text,
+  gv_id text,
+  owner_user_id uuid,
+  owner_slug text,
+  owner_display_name text,
+  viewer_is_owner boolean,
+  memory_type public.collector_memory_type,
+  note text,
+  photo_path text,
+  place_label text,
+  occasion_label text,
+  memory_date date,
+  prompt_key text,
+  is_public boolean,
+  published_at timestamptz,
+  publication_version integer,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    cm.id,
+    cm.vault_item_instance_id,
+    vii.gv_vi_id,
+    vii.card_print_id,
+    coalesce(cp.name, 'Card memory') as card_name,
+    coalesce(s.name, cp.set_code, '') as set_name,
+    coalesce(cp.image_url, cp.image_alt_url) as card_image_url,
+    cp.gv_id,
+    cm.user_id as owner_user_id,
+    owner_profile.slug as owner_slug,
+    owner_profile.display_name as owner_display_name,
+    (cm.user_id = auth.uid()) as viewer_is_owner,
+    cm.memory_type,
+    cm.note,
+    cm.photo_path,
+    cm.place_label,
+    cm.occasion_label,
+    cm.memory_date,
+    cm.prompt_key,
+    cm.is_public,
+    cm.published_at,
+    cm.publication_version,
+    cm.created_at,
+    cm.updated_at
+  from public.collector_memories cm
+  join public.vault_item_instances vii
+    on vii.id = cm.vault_item_instance_id
+   and vii.user_id = cm.user_id
+   and vii.archived_at is null
+   and vii.card_print_id is not null
+  join public.card_prints cp
+    on cp.id = vii.card_print_id
+  left join public.sets s
+    on s.id = cp.set_id
+  left join public.public_profiles owner_profile
+    on owner_profile.user_id = cm.user_id
+  left join public.card_events publication_event
+    on publication_event.id = cm.publication_event_id
+   and publication_event.event_type = 'collector_memory_published'
+   and publication_event.actor_user_id = cm.user_id
+   and publication_event.card_print_id = vii.card_print_id
+   and publication_event.visibility = 'public'
+   and (publication_event.payload ->> 'memory_id') = cm.id::text
+   and (publication_event.payload ->> 'publication_version') =
+     cm.publication_version::text
+  where auth.uid() is not null
+    and cm.id = p_memory_id
+    and cm.archived_at is null
+    and (
+      cm.user_id = auth.uid()
+      or (
+        cm.is_public is true
+        and cm.published_at is not null
+        and cm.publication_event_id = publication_event.id
+        and public.interest_graph_collectors_visible_to_viewer_v1(
+          auth.uid(),
+          cm.user_id,
+          null
+        )
+      )
+    )
+  limit 1;
+$$;
+
+revoke all on function public.collector_memory_accessible_by_id_v1(uuid)
+from public, anon;
+grant execute on function public.collector_memory_accessible_by_id_v1(uuid)
+to authenticated;
+
+comment on function public.collector_memory_accessible_by_id_v1(uuid) is
+'Governed signed-in Memory route read. Owners may read their active private Memory; other collectors may read only its exact current public publication when collector visibility permits.';
+
+commit;

--- a/test/collector_memory_service_test.dart
+++ b/test/collector_memory_service_test.dart
@@ -78,8 +78,26 @@ void main() {
         memories.single.cardImageUrl,
         '/api/canon/cards/GV-PK-JPN-M5-118/image',
       );
+      expect(memories.single.memory.isPublic, isFalse);
     },
   );
+
+  test('publication state parses from owner RPC rows', () {
+    final memory = CollectorMemory.fromJson(<String, dynamic>{
+      'id': memoryId,
+      'vault_item_instance_id': '33333333-3333-3333-3333-333333333333',
+      'gv_vi_id': gvviId,
+      'memory_type': 'note',
+      'is_public': true,
+      'published_at': '2026-08-11T12:00:00Z',
+      'publication_version': 3,
+    });
+
+    expect(memory, isNotNull);
+    expect(memory!.isPublic, isTrue);
+    expect(memory.publicationVersion, 3);
+    expect(memory.publishedAt, DateTime.parse('2026-08-11T12:00:00Z'));
+  });
 
   test(
     'owner memory feed batch-enriches GV-ID and raw provider fallback',
@@ -246,6 +264,36 @@ void main() {
     expect(removed, <String>['$userId/memories/$memoryId/photo']);
     expect(calls, <String>['collector_memory_archive_v1']);
   });
+
+  test(
+    'publication uses the governed owner RPC and returns current state',
+    () async {
+      final service = CollectorMemoryService(
+        rpc: (functionName, {params}) async {
+          expect(functionName, 'collector_memory_set_public_v1');
+          expect(params?['p_memory_id'], memoryId);
+          expect(params?['p_is_public'], isTrue);
+          return <String, dynamic>{
+            'id': memoryId,
+            'vault_item_instance_id': '33333333-3333-3333-3333-333333333333',
+            'gv_vi_id': gvviId,
+            'memory_type': 'note',
+            'is_public': true,
+            'published_at': '2026-08-11T12:00:00Z',
+            'publication_version': 1,
+          };
+        },
+      );
+
+      final memory = await service.setPublic(
+        memoryId: memoryId,
+        isPublic: true,
+      );
+
+      expect(memory.isPublic, isTrue);
+      expect(memory.publicationVersion, 1);
+    },
+  );
 
   test(
     'photo upload uses the private memory bucket and deterministic path',

--- a/test/collector_memory_service_test.dart
+++ b/test/collector_memory_service_test.dart
@@ -100,6 +100,46 @@ void main() {
   });
 
   test(
+    'accessible Memory uses governed route RPC and parses viewer authority',
+    () async {
+      final service = CollectorMemoryService(
+        rpc: (functionName, {params}) async {
+          expect(functionName, 'collector_memory_accessible_by_id_v1');
+          expect(params, <String, dynamic>{'p_memory_id': memoryId});
+          return <Map<String, dynamic>>[
+            <String, dynamic>{
+              'id': memoryId,
+              'vault_item_instance_id': '33333333-3333-3333-3333-333333333333',
+              'gv_vi_id': gvviId,
+              'card_print_id': '44444444-4444-4444-4444-444444444444',
+              'card_name': 'Pikachu',
+              'set_name': 'Promo',
+              'gv_id': 'GV-PK-TEST-001',
+              'owner_user_id': userId,
+              'owner_slug': 'collector-one',
+              'owner_display_name': 'Collector One',
+              'viewer_is_owner': false,
+              'memory_type': 'note',
+              'note': 'Trade night pull.',
+              'is_public': true,
+              'publication_version': 1,
+            },
+          ];
+        },
+      );
+
+      final item = await service.loadAccessibleMemory(memoryId: memoryId);
+
+      expect(item, isNotNull);
+      expect(item!.memory.id, memoryId);
+      expect(item.viewerIsOwner, isFalse);
+      expect(item.ownerSlug, 'collector-one');
+      expect(item.ownerDisplayName, 'Collector One');
+      expect(item.gvId, 'GV-PK-TEST-001');
+    },
+  );
+
+  test(
     'owner memory feed batch-enriches GV-ID and raw provider fallback',
     () async {
       const cardPrintId = '44444444-4444-4444-4444-444444444444';

--- a/test/collector_memory_service_test.dart
+++ b/test/collector_memory_service_test.dart
@@ -312,6 +312,9 @@ void main() {
     final privateHome = File(
       'lib/screens/grookai_objects/collector_memories_screen.dart',
     ).readAsStringSync();
+    final privateDetail = File(
+      'lib/screens/grookai_objects/collector_memory_detail_screen.dart',
+    ).readAsStringSync();
     final publicCard = File('lib/card_detail_screen.dart').readAsStringSync();
     final publicGvvi = File(
       'lib/screens/gvvi/public_gvvi_screen.dart',
@@ -327,7 +330,9 @@ void main() {
     expect(privateScreen, contains('ImagePicker().pickImage'));
     expect(privateScreen, contains('createSignedPhotoUrl'));
     expect(privateHome, contains('loadOwnerMemories'));
-    expect(privateHome, contains('VaultManageCardScreen'));
+    expect(privateHome, contains('CollectorMemoryDetailScreen'));
+    expect(privateDetail, contains('VaultManageCardScreen'));
+    expect(privateDetail, contains('MemoryCardPrintService'));
     expect(publicCard, contains('MemoryCardCaptureScreen'));
     expect(publicCard, contains('kCollectorMemoriesEnabled'));
     expect(publicGvvi, isNot(contains('CollectorMemory')));

--- a/test/grookai_objects/collector_memories_screen_test.dart
+++ b/test/grookai_objects/collector_memories_screen_test.dart
@@ -1,8 +1,14 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grookai_vault/screens/grookai_objects/collector_memories_screen.dart';
+import 'package:grookai_vault/screens/grookai_objects/collector_memory_detail_screen.dart';
+import 'package:grookai_vault/services/grookai_objects/grookai_object_export_service.dart';
+import 'package:grookai_vault/services/grookai_objects/memory_card_print_service.dart';
 import 'package:grookai_vault/services/vault/collector_memory_service.dart';
 import 'package:grookai_vault/widgets/card_surface_artwork.dart';
+import 'package:grookai_vault/widgets/grookai_objects/grookai_object_renderer.dart';
 
 void main() {
   testWidgets('Memories home renders empty state', (tester) async {
@@ -143,6 +149,162 @@ void main() {
       '/api/canon/cards/GV-PK-TEST-001/image',
     );
   });
+
+  testWidgets('tapping a Memory opens its Memory detail, not card detail', (
+    tester,
+  ) async {
+    const fullNote =
+        'Found at trade night after looking for this exact printing all year.';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoriesScreen(
+          service: _FakeMemoryService(
+            memories: [
+              OwnerCollectorMemory(
+                memory: CollectorMemory(
+                  id: 'memory-1',
+                  vaultItemInstanceId: 'instance-1',
+                  gvviId: 'GVVI-1',
+                  memoryType: CollectorMemoryType.occasion,
+                  note: fullNote,
+                  placeLabel: 'Denver',
+                  occasionLabel: 'Trade night',
+                  memoryDate: DateTime.utc(2026, 7, 10),
+                ),
+                cardPrintId: 'card-1',
+                cardName: 'Pikachu',
+                setName: 'Scarlet & Violet Promos',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Pikachu').first);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('collector-memory-detail')), findsOneWidget);
+    expect(find.byType(GrookaiObjectRenderer), findsOneWidget);
+    expect(find.text('Memory'), findsWidgets);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('collector-memory-full-note')),
+      300,
+    );
+    expect(find.byKey(const Key('collector-memory-full-note')), findsOneWidget);
+    expect(find.text(fullNote), findsWidgets);
+    expect(find.text('Trade night'), findsWidgets);
+    expect(find.text('Jul 10, 2026'), findsWidgets);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('view-memory-card-button')),
+      300,
+    );
+    expect(find.byKey(const Key('view-memory-card-button')), findsOneWidget);
+  });
+
+  testWidgets('Memory detail opens card only from the explicit action', (
+    tester,
+  ) async {
+    var viewCardCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryDetailScreen(
+          item: const OwnerCollectorMemory(
+            memory: CollectorMemory(
+              id: 'memory-1',
+              vaultItemInstanceId: 'instance-1',
+              gvviId: 'GVVI-1',
+              memoryType: CollectorMemoryType.note,
+              note: 'A complete memory.',
+            ),
+            cardPrintId: 'card-1',
+            cardName: 'Pikachu',
+            setName: 'Promo',
+          ),
+          onViewCard: () => viewCardCalls += 1,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(viewCardCalls, 0);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('view-memory-card-button')),
+      300,
+    );
+    await tester.tap(find.byKey(const Key('view-memory-card-button')));
+    await tester.pump();
+    expect(viewCardCalls, 1);
+  });
+
+  testWidgets('Memory detail prepares an exact-size Memory insert for print', (
+    tester,
+  ) async {
+    final printService = _FakeMemoryPrintService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryDetailScreen(
+          item: const OwnerCollectorMemory(
+            memory: CollectorMemory(
+              id: 'memory-1',
+              vaultItemInstanceId: 'instance-1',
+              gvviId: 'GVVI-1',
+              memoryType: CollectorMemoryType.note,
+              note: 'A complete memory.',
+            ),
+            cardPrintId: 'card-1',
+            cardName: 'Pikachu',
+            setName: 'Promo',
+          ),
+          printService: printService,
+          exportService: _FakeObjectExportService(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('print-memory-button')));
+    await tester.pumpAndSettle();
+    expect(find.text('Memory insert'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('print-memory-insert-option')));
+    await tester.pumpAndSettle();
+
+    expect(printService.printCalls, 1);
+    expect(printService.lastMode, MemoryCardPrintMode.memoryInsert);
+    expect(printService.lastMemorySide, isNotNull);
+    expect(printService.lastMemorySide, isNotEmpty);
+  });
+
+  testWidgets('maximum-length Memory note renders without overflow', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryDetailScreen(
+          item: OwnerCollectorMemory(
+            memory: CollectorMemory(
+              id: 'memory-long',
+              vaultItemInstanceId: 'instance-1',
+              gvviId: 'GVVI-1',
+              memoryType: CollectorMemoryType.note,
+              note: List.filled(
+                120,
+                'remembered detail',
+              ).join(' ').substring(0, 1200),
+            ),
+            cardPrintId: 'card-1',
+            cardName: 'Pikachu',
+            setName: 'Promo',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _FakeMemoryService extends CollectorMemoryService {
@@ -175,5 +337,34 @@ class _FakeMemoryService extends CollectorMemoryService {
     int expiresIn = 3600,
   }) async {
     return photoPath == null ? null : signedPhotoUrl;
+  }
+}
+
+class _FakeMemoryPrintService extends MemoryCardPrintService {
+  int printCalls = 0;
+  MemoryCardPrintMode? lastMode;
+  Uint8List? lastMemorySide;
+
+  @override
+  Future<bool> printMemory({
+    required Uint8List memorySidePng,
+    Uint8List? cardSidePng,
+    required MemoryCardPrintMode mode,
+    required String documentName,
+  }) async {
+    printCalls += 1;
+    lastMode = mode;
+    lastMemorySide = memorySidePng;
+    return true;
+  }
+}
+
+class _FakeObjectExportService extends GrookaiObjectExportService {
+  @override
+  Future<Uint8List> capturePng(
+    GlobalKey repaintBoundaryKey, {
+    double pixelRatio = 3,
+  }) async {
+    return Uint8List.fromList(const [137, 80, 78, 71]);
   }
 }

--- a/test/grookai_objects/collector_memories_screen_test.dart
+++ b/test/grookai_objects/collector_memories_screen_test.dart
@@ -94,6 +94,36 @@ void main() {
     expect(find.textContaining('Denver'), findsOneWidget);
   });
 
+  testWidgets('Memories home identifies published Memories', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoriesScreen(
+          service: _FakeMemoryService(
+            memories: const [
+              OwnerCollectorMemory(
+                memory: CollectorMemory(
+                  id: 'memory-1',
+                  vaultItemInstanceId: 'instance-1',
+                  gvviId: 'GVVI-1',
+                  memoryType: CollectorMemoryType.note,
+                  isPublic: true,
+                  publicationVersion: 1,
+                ),
+                cardPrintId: 'card-1',
+                cardName: 'Pikachu',
+                setName: 'Promo',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('public-memory-indicator')), findsOneWidget);
+    expect(find.text('Public'), findsOneWidget);
+  });
+
   testWidgets('catalog thumbnail uses hosted primary and provider fallback', (
     tester,
   ) async {
@@ -261,6 +291,90 @@ void main() {
     expect(viewCardCalls, 1);
   });
 
+  testWidgets('Memory detail publishes only after explicit confirmation', (
+    tester,
+  ) async {
+    final service = _FakeMemoryService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryDetailScreen(
+          item: const OwnerCollectorMemory(
+            memory: CollectorMemory(
+              id: 'memory-1',
+              vaultItemInstanceId: 'instance-1',
+              gvviId: 'GVVI-1',
+              memoryType: CollectorMemoryType.note,
+              note: 'A complete memory.',
+            ),
+            cardPrintId: 'card-1',
+            cardName: 'Pikachu',
+            setName: 'Promo',
+          ),
+          memoryService: service,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('memory-public-switch')),
+      300,
+    );
+    await tester.tap(find.byKey(const Key('memory-public-switch')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Share this Memory in Pulse?'), findsOneWidget);
+    expect(service.requestedPublic, isNull);
+
+    await tester.tap(find.byKey(const Key('confirm-publish-memory-button')));
+    await tester.pumpAndSettle();
+
+    expect(service.requestedPublic, isTrue);
+    expect(find.text('Memory published to Pulse.'), findsOneWidget);
+    final toggle = tester.widget<SwitchListTile>(
+      find.byKey(const Key('memory-public-switch')),
+    );
+    expect(toggle.value, isTrue);
+  });
+
+  testWidgets('published Memory can be made private without deleting it', (
+    tester,
+  ) async {
+    final service = _FakeMemoryService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryDetailScreen(
+          item: const OwnerCollectorMemory(
+            memory: CollectorMemory(
+              id: 'memory-1',
+              vaultItemInstanceId: 'instance-1',
+              gvviId: 'GVVI-1',
+              memoryType: CollectorMemoryType.note,
+              isPublic: true,
+              publicationVersion: 2,
+            ),
+            cardPrintId: 'card-1',
+            cardName: 'Pikachu',
+            setName: 'Promo',
+          ),
+          memoryService: service,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('memory-public-switch')),
+      300,
+    );
+    await tester.tap(find.byKey(const Key('memory-public-switch')));
+    await tester.pumpAndSettle();
+
+    expect(service.requestedPublic, isFalse);
+    expect(find.text('Memory is private again.'), findsOneWidget);
+    expect(find.text('Share this Memory in Pulse?'), findsNothing);
+  });
+
   testWidgets('Memory detail prepares an exact-size Memory insert for print', (
     tester,
   ) async {
@@ -388,6 +502,7 @@ class _FakeMemoryService extends CollectorMemoryService {
   final List<OwnerCollectorMemory> memories;
   final Object? error;
   final String? signedPhotoUrl;
+  bool? requestedPublic;
 
   @override
   Future<List<OwnerCollectorMemory>> loadOwnerMemories({
@@ -408,6 +523,23 @@ class _FakeMemoryService extends CollectorMemoryService {
     int expiresIn = 3600,
   }) async {
     return photoPath == null ? null : signedPhotoUrl;
+  }
+
+  @override
+  Future<CollectorMemory> setPublic({
+    required String memoryId,
+    required bool isPublic,
+  }) async {
+    requestedPublic = isPublic;
+    return CollectorMemory(
+      id: memoryId,
+      vaultItemInstanceId: 'instance-1',
+      gvviId: 'GVVI-1',
+      memoryType: CollectorMemoryType.note,
+      isPublic: isPublic,
+      publishedAt: isPublic ? DateTime.utc(2026, 8, 11) : null,
+      publicationVersion: isPublic ? 1 : 2,
+    );
   }
 }
 

--- a/test/grookai_objects/collector_memories_screen_test.dart
+++ b/test/grookai_objects/collector_memories_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:grookai_vault/services/grookai_objects/memory_card_print_service
 import 'package:grookai_vault/services/vault/collector_memory_service.dart';
 import 'package:grookai_vault/widgets/card_surface_artwork.dart';
 import 'package:grookai_vault/widgets/grookai_objects/grookai_object_renderer.dart';
+import 'package:share_plus/share_plus.dart';
 
 void main() {
   testWidgets('Memories home renders empty state', (tester) async {
@@ -277,6 +278,49 @@ void main() {
     expect(printService.lastMemorySide, isNotEmpty);
   });
 
+  testWidgets(
+    'Memory detail shares through the existing destination workflow',
+    (tester) async {
+      final exportService = _FakeObjectExportService();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CollectorMemoryDetailScreen(
+            item: const OwnerCollectorMemory(
+              memory: CollectorMemory(
+                id: 'memory-1',
+                vaultItemInstanceId: 'instance-1',
+                gvviId: 'GVVI-1',
+                memoryType: CollectorMemoryType.note,
+                note: 'A complete memory.',
+              ),
+              cardPrintId: 'card-1',
+              cardName: 'Pikachu',
+              setName: 'Promo',
+            ),
+            exportService: exportService,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('share-memory-button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Instagram Feed'), findsOneWidget);
+      expect(find.text('Story'), findsOneWidget);
+      expect(find.text('Save Image'), findsOneWidget);
+      expect(find.text('eBay Listing'), findsNothing);
+
+      await tester.tap(find.text('Story'));
+      await tester.pumpAndSettle();
+
+      expect(exportService.shareCalls, 1);
+      expect(exportService.lastFileName, 'grookai-memory-story-pikachu.png');
+      expect(exportService.lastSubject, 'Grookai memory card');
+      expect(exportService.lastBytes, isNotEmpty);
+    },
+  );
+
   testWidgets('maximum-length Memory note renders without overflow', (
     tester,
   ) async {
@@ -360,11 +404,31 @@ class _FakeMemoryPrintService extends MemoryCardPrintService {
 }
 
 class _FakeObjectExportService extends GrookaiObjectExportService {
+  int shareCalls = 0;
+  Uint8List? lastBytes;
+  String? lastFileName;
+  String? lastSubject;
+
   @override
   Future<Uint8List> capturePng(
     GlobalKey repaintBoundaryKey, {
     double pixelRatio = 3,
   }) async {
     return Uint8List.fromList(const [137, 80, 78, 71]);
+  }
+
+  @override
+  Future<ShareResult> sharePng({
+    required Uint8List bytes,
+    required String fileName,
+    String? text,
+    String? subject,
+    Rect? sharePositionOrigin,
+  }) async {
+    shareCalls += 1;
+    lastBytes = bytes;
+    lastFileName = fileName;
+    lastSubject = subject;
+    return ShareResult.unavailable;
   }
 }

--- a/test/grookai_objects/collector_memories_screen_test.dart
+++ b/test/grookai_objects/collector_memories_screen_test.dart
@@ -12,6 +12,28 @@ import 'package:grookai_vault/widgets/grookai_objects/grookai_object_renderer.da
 import 'package:share_plus/share_plus.dart';
 
 void main() {
+  test('Memory share text links to the canonical card app route', () {
+    const item = OwnerCollectorMemory(
+      memory: CollectorMemory(
+        id: 'memory-1',
+        vaultItemInstanceId: 'instance-1',
+        gvviId: 'GVVI-1',
+        memoryType: CollectorMemoryType.note,
+      ),
+      cardPrintId: 'card-1',
+      cardName: 'Pikachu',
+      setName: 'Promo',
+      gvId: 'GV-PK-TEST-001',
+    );
+
+    expect(
+      buildCollectorMemoryShareText(item),
+      'A collector Memory for Pikachu.\n'
+      'Open in Grookai Vault: '
+      'https://grookaivault.com/card/GV-PK-TEST-001',
+    );
+  });
+
   testWidgets('Memories home renders empty state', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -317,6 +339,11 @@ void main() {
       expect(exportService.shareCalls, 1);
       expect(exportService.lastFileName, 'grookai-memory-story-pikachu.png');
       expect(exportService.lastSubject, 'Grookai memory card');
+      expect(
+        exportService.lastText,
+        'A collector Memory for Pikachu.\n'
+        'Open in Grookai Vault: https://grookaivault.com/',
+      );
       expect(exportService.lastBytes, isNotEmpty);
     },
   );
@@ -408,6 +435,7 @@ class _FakeObjectExportService extends GrookaiObjectExportService {
   Uint8List? lastBytes;
   String? lastFileName;
   String? lastSubject;
+  String? lastText;
 
   @override
   Future<Uint8List> capturePng(
@@ -429,6 +457,7 @@ class _FakeObjectExportService extends GrookaiObjectExportService {
     lastBytes = bytes;
     lastFileName = fileName;
     lastSubject = subject;
+    lastText = text;
     return ShareResult.unavailable;
   }
 }

--- a/test/grookai_objects/collector_memories_screen_test.dart
+++ b/test/grookai_objects/collector_memories_screen_test.dart
@@ -12,7 +12,7 @@ import 'package:grookai_vault/widgets/grookai_objects/grookai_object_renderer.da
 import 'package:share_plus/share_plus.dart';
 
 void main() {
-  test('Memory share text links to the canonical card app route', () {
+  test('Memory share text links to the canonical Memory app route', () {
     const item = OwnerCollectorMemory(
       memory: CollectorMemory(
         id: 'memory-1',
@@ -29,8 +29,8 @@ void main() {
     expect(
       buildCollectorMemoryShareText(item),
       'A collector Memory for Pikachu.\n'
-      'Open in Grookai Vault: '
-      'https://grookaivault.com/card/GV-PK-TEST-001',
+      'Open this Memory in Grookai Vault: '
+      'https://grookaivault.com/memory/memory-1',
     );
   });
 
@@ -456,7 +456,8 @@ void main() {
       expect(
         exportService.lastText,
         'A collector Memory for Pikachu.\n'
-        'Open in Grookai Vault: https://grookaivault.com/',
+        'Open this Memory in Grookai Vault: '
+        'https://grookaivault.com/memory/memory-1',
       );
       expect(exportService.lastBytes, isNotEmpty);
     },

--- a/test/grookai_objects/collector_memories_screen_test.dart
+++ b/test/grookai_objects/collector_memories_screen_test.dart
@@ -28,6 +28,10 @@ void main() {
 
     expect(
       buildCollectorMemoryShareText(item),
+      'A collector Memory for Pikachu.',
+    );
+    expect(
+      buildCollectorMemoryShareText(item, includeAppLink: true),
       'A collector Memory for Pikachu.\n'
       'Open this Memory in Grookai Vault: '
       'https://grookaivault.com/memory/memory-1',
@@ -453,12 +457,7 @@ void main() {
       expect(exportService.shareCalls, 1);
       expect(exportService.lastFileName, 'grookai-memory-story-pikachu.png');
       expect(exportService.lastSubject, 'Grookai memory card');
-      expect(
-        exportService.lastText,
-        'A collector Memory for Pikachu.\n'
-        'Open this Memory in Grookai Vault: '
-        'https://grookaivault.com/memory/memory-1',
-      );
+      expect(exportService.lastText, 'A collector Memory for Pikachu.');
       expect(exportService.lastBytes, isNotEmpty);
     },
   );

--- a/test/grookai_objects/collector_memory_route_screen_test.dart
+++ b/test/grookai_objects/collector_memory_route_screen_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grookai_vault/screens/grookai_objects/collector_memory_route_screen.dart';
+import 'package:grookai_vault/services/vault/collector_memory_service.dart';
+
+void main() {
+  const memoryId = '22222222-2222-2222-2222-222222222222';
+
+  testWidgets('shared route renders the Memory rather than card detail', (
+    tester,
+  ) async {
+    final service = CollectorMemoryService(
+      rpc: (functionName, {params}) async => <Map<String, dynamic>>[
+        _memoryRow(viewerIsOwner: false, isPublic: true),
+      ],
+      sign: ({required bucket, required path, required expiresIn}) async {
+        expect(bucket, CollectorMemoryService.memoryBucket);
+        expect(path, 'owner/memories/$memoryId/photo');
+        expect(expiresIn, 300);
+        return 'https://storage.example.test/memory.jpg';
+      },
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryRouteScreen(memoryId: memoryId, service: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('shared-collector-memory-detail')), findsOne);
+    expect(find.text('Shared by Collector One'), findsOne);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('shared-collector-memory-note')),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('Trade night pull.'), findsOne);
+    expect(find.byKey(const Key('collector-memory-detail')), findsNothing);
+  });
+
+  testWidgets('owner route renders editable owner Memory detail', (
+    tester,
+  ) async {
+    final service = CollectorMemoryService(
+      rpc: (functionName, {params}) async => <Map<String, dynamic>>[
+        _memoryRow(viewerIsOwner: true, isPublic: false),
+      ],
+      sign: ({required bucket, required path, required expiresIn}) async =>
+          'https://storage.example.test/memory.jpg',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryRouteScreen(memoryId: memoryId, service: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('collector-memory-detail')), findsOne);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('memory-public-switch')),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.byKey(const Key('memory-public-switch')), findsOne);
+  });
+
+  testWidgets('private or removed Memory is unavailable to another viewer', (
+    tester,
+  ) async {
+    final service = CollectorMemoryService(
+      rpc: (functionName, {params}) async => const <Map<String, dynamic>>[],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectorMemoryRouteScreen(memoryId: memoryId, service: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('collector-memory-route-unavailable')),
+      findsOne,
+    );
+    expect(find.text('Memory unavailable'), findsOne);
+    expect(find.textContaining('private, removed'), findsOne);
+  });
+}
+
+Map<String, dynamic> _memoryRow({
+  required bool viewerIsOwner,
+  required bool isPublic,
+}) {
+  return <String, dynamic>{
+    'id': '22222222-2222-2222-2222-222222222222',
+    'vault_item_instance_id': '33333333-3333-3333-3333-333333333333',
+    'gv_vi_id': 'GVVI-1',
+    'card_print_id': '44444444-4444-4444-4444-444444444444',
+    'card_name': 'Pikachu',
+    'set_name': 'Promo',
+    'gv_id': 'GV-PK-TEST-001',
+    'owner_user_id': '11111111-1111-1111-1111-111111111111',
+    'owner_slug': 'collector-one',
+    'owner_display_name': 'Collector One',
+    'viewer_is_owner': viewerIsOwner,
+    'memory_type': 'note',
+    'note': 'Trade night pull.',
+    'photo_path': 'owner/memories/22222222-2222-2222-2222-222222222222/photo',
+    'is_public': isPublic,
+    'publication_version': isPublic ? 1 : 0,
+  };
+}

--- a/test/grookai_objects/grookai_memory_card_adapter_test.dart
+++ b/test/grookai_objects/grookai_memory_card_adapter_test.dart
@@ -13,6 +13,7 @@ void main() {
         memoryType: CollectorMemoryType.addedPlace,
         note: 'Found this at a local show.',
         placeLabel: 'Dallas card show',
+        occasionLabel: 'Trade night',
         memoryDate: DateTime.utc(2026, 7, 10),
       ),
       source: const GrookaiMemoryCardSource(
@@ -31,6 +32,7 @@ void main() {
     expect(object.fields['cardName'], 'Pikachu');
     expect(object.fields['setLine'], 'SVP #001');
     expect(object.fields['location'], 'Dallas card show');
+    expect(object.fields['occasion'], 'Trade night');
     expect(object.fields['storyText'], 'Found this at a local show.');
     expect(
       object.fields['photoUrl'],

--- a/test/grookai_objects/memory_card_print_service_test.dart
+++ b/test/grookai_objects/memory_card_print_service_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grookai_vault/services/grookai_objects/memory_card_print_service.dart';
+import 'package:pdf/pdf.dart';
+
+void main() {
+  test('card placement is exactly 2.5 by 3.5 inches and centered', () {
+    final placement = MemoryCardPrintService.placementFor(PdfPageFormat.letter);
+
+    expect(
+      placement.width,
+      MemoryCardPrintService.cardWidthInches * PdfPageFormat.inch,
+    );
+    expect(
+      placement.height,
+      MemoryCardPrintService.cardHeightInches * PdfPageFormat.inch,
+    );
+    expect(placement.left, (PdfPageFormat.letter.width - placement.width) / 2);
+    expect(placement.top, (PdfPageFormat.letter.height - placement.height) / 2);
+  });
+
+  test('Memory insert PDF has one page', () async {
+    final service = MemoryCardPrintService();
+    final bytes = await service.buildPdf(
+      pageFormat: PdfPageFormat.letter,
+      memorySidePng: _onePixelPng,
+      mode: MemoryCardPrintMode.memoryInsert,
+    );
+
+    expect(_pdfPageCount(bytes), 1);
+    expect(ascii.decode(bytes.take(4).toList()), '%PDF');
+  });
+
+  test('front-and-back PDF has two aligned pages', () async {
+    final service = MemoryCardPrintService();
+    final bytes = await service.buildPdf(
+      pageFormat: PdfPageFormat.a4,
+      memorySidePng: _onePixelPng,
+      cardSidePng: _onePixelPng,
+      mode: MemoryCardPrintMode.frontAndBack,
+    );
+
+    expect(_pdfPageCount(bytes), 2);
+    final placement = MemoryCardPrintService.placementFor(PdfPageFormat.a4);
+    expect(placement.width, 180);
+    expect(placement.height, 252);
+  });
+
+  test('print uses the printer-selected paper format', () async {
+    Uint8List? printedBytes;
+    String? printedName;
+    final service = MemoryCardPrintService(
+      layoutPdf: ({required name, required onLayout}) async {
+        printedName = name;
+        printedBytes = await onLayout(PdfPageFormat.a4);
+        return true;
+      },
+    );
+
+    final accepted = await service.printMemory(
+      memorySidePng: _onePixelPng,
+      mode: MemoryCardPrintMode.memoryInsert,
+      documentName: 'grookai-memory-pikachu.pdf',
+    );
+
+    expect(accepted, isTrue);
+    expect(printedName, 'grookai-memory-pikachu.pdf');
+    expect(printedBytes, isNotNull);
+    expect(_pdfPageCount(printedBytes!), 1);
+  });
+
+  test('front-and-back mode requires a card-side image', () {
+    final service = MemoryCardPrintService();
+
+    expect(
+      () => service.printMemory(
+        memorySidePng: _onePixelPng,
+        mode: MemoryCardPrintMode.frontAndBack,
+        documentName: 'memory.pdf',
+      ),
+      throwsArgumentError,
+    );
+  });
+}
+
+int _pdfPageCount(Uint8List bytes) {
+  final content = latin1.decode(bytes, allowInvalid: true);
+  return RegExp(r'/Type\s*/Page(?!s)').allMatches(content).length;
+}
+
+final Uint8List _onePixelPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+);

--- a/test/mobile_navigation_and_set_retention_contract_test.dart
+++ b/test/mobile_navigation_and_set_retention_contract_test.dart
@@ -133,6 +133,7 @@ void main() {
     expect(manifest, contains('android:scheme="grookaivault"'));
     for (final host in <String>[
       'card',
+      'memory',
       'u',
       'collector',
       'set',
@@ -151,6 +152,14 @@ void main() {
 
     expect(source, contains('case GrookaiCanonicalRouteKind.gvvi:'));
     expect(source, contains('PublicGvviScreen(gvviId: route.value)'));
+  });
+
+  test('root deep-link dispatch opens shared Memories in the app', () {
+    final source = File('lib/main_shell.dart').readAsStringSync();
+
+    expect(source, contains('case GrookaiCanonicalRouteKind.memory:'));
+    expect(source, contains('CollectorMemoryRouteScreen('));
+    expect(source, contains('memoryId: route.value'));
   });
 
   test(

--- a/test/notification_deep_link_routing_test.dart
+++ b/test/notification_deep_link_routing_test.dart
@@ -22,6 +22,23 @@ void main() {
     }
   });
 
+  test('shared Memory links parse to canonical Memory routes', () {
+    const memoryId = '22222222-2222-2222-2222-222222222222';
+    for (final link in <String>[
+      'grookai://memory/$memoryId',
+      'grookaivault://memory/$memoryId',
+      'grookai:///memory/$memoryId',
+      'https://grookaivault.com/memory/$memoryId',
+    ]) {
+      final route = GrookaiWebRouteService.parseCanonicalUri(Uri.parse(link));
+
+      expect(route, isNotNull, reason: link);
+      expect(route!.kind, GrookaiCanonicalRouteKind.memory);
+      expect(route.value, memoryId);
+      expect(route.path, '/memory/$memoryId');
+    }
+  });
+
   test(
     'notification collector and set app links parse to canonical routes',
     () {
@@ -167,6 +184,7 @@ void main() {
         paths,
         containsAll(<String>[
           '/card/*',
+          '/memory/*',
           '/u/*',
           '/collector/*',
           '/set/*',
@@ -207,6 +225,7 @@ void main() {
     expect(manifest, contains('android:host="grookaivault.com"'));
     for (final path in <String>[
       '/card/',
+      '/memory/',
       '/u/',
       '/collector/',
       '/set/',

--- a/test/pulse_memory_publication_test.dart
+++ b/test/pulse_memory_publication_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grookai_vault/screens/network/pulse_memory_detail_screen.dart';
+import 'package:grookai_vault/services/network/pulse_service.dart';
+
+PulseItem _memoryItem() {
+  return PulseItem.fromJson(<String, dynamic>{
+    'pulse_item_id': 'pulse-memory-1',
+    'card_event_id': 'event-memory-1',
+    'event_type': 'collector_memory_published',
+    'rank_bucket': 'collector_activity',
+    'created_at': '2026-08-11T12:00:00Z',
+    'actor_user_id': '11111111-1111-1111-1111-111111111111',
+    'actor_slug': 'collector-one',
+    'actor_display_name': 'Collector One',
+    'card_print_id': '22222222-2222-2222-2222-222222222222',
+    'gv_id': '',
+    'card_name': 'Pikachu',
+    'set_code': 'PROMO',
+    'set_name': 'Promo',
+    'card_number': '1',
+    'display_image_url': null,
+    'ownership_context': 'memory',
+    'payload': <String, dynamic>{
+      'memory_id': '33333333-3333-3333-3333-333333333333',
+      'memory_type': 'occasion',
+      'memory_note': 'Pulled together at trade night.',
+      'memory_photo_path':
+          '11111111-1111-1111-1111-111111111111/memories/'
+          '33333333-3333-3333-3333-333333333333/photo',
+      'memory_place_label': 'Denver',
+      'memory_occasion_label': 'Trade night',
+      'memory_date': '2026-08-10',
+    },
+  })!;
+}
+
+void main() {
+  test('published Memory payload remains a distinct Pulse content type', () {
+    final item = _memoryItem();
+
+    expect(item.isMemory, isTrue);
+    expect(item.memoryId, '33333333-3333-3333-3333-333333333333');
+    expect(item.memoryNote, 'Pulled together at trade night.');
+    expect(item.memoryPlaceLabel, 'Denver');
+    expect(item.memoryOccasionLabel, 'Trade night');
+    expect(item.memoryDate, '2026-08-10');
+
+    final signed = item.copyWithMemoryPhotoUrl(
+      'https://storage.example.test/signed-memory-photo',
+    );
+    expect(
+      signed.memoryPhotoUrl,
+      'https://storage.example.test/signed-memory-photo',
+    );
+    expect(signed.displayCardName, 'Pikachu');
+  });
+
+  testWidgets('Pulse Memory detail shows the Memory before the card action', (
+    tester,
+  ) async {
+    var viewCardCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PulseMemoryDetailScreen(
+          item: _memoryItem(),
+          onViewCard: () async => viewCardCalls += 1,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('pulse-memory-detail')), findsOneWidget);
+    expect(find.text('Shared by Collector One'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('pulse-memory-note')),
+      300,
+    );
+    expect(find.text('Pulled together at trade night.'), findsOneWidget);
+    expect(find.text('Denver'), findsOneWidget);
+    expect(find.text('Trade night'), findsOneWidget);
+    expect(viewCardCalls, 0);
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('pulse-memory-view-card-button')),
+      300,
+    );
+    await tester.tap(find.byKey(const Key('pulse-memory-view-card-button')));
+    await tester.pump();
+    expect(viewCardCalls, 1);
+  });
+
+  test('Pulse UI routes Memories to Memory detail before card routes', () {
+    final source = File(
+      'lib/screens/network/network_screen.dart',
+    ).readAsStringSync();
+    final memoryBranch = source.indexOf('if (item.isMemory)');
+    final actionRoute = source.indexOf('_openPrimaryActionRoute(context)');
+
+    expect(memoryBranch, greaterThanOrEqualTo(0));
+    expect(actionRoute, greaterThan(memoryBranch));
+    expect(source, contains("label: 'Memory'"));
+    expect(source, contains("? 'View memory'"));
+    expect(source, contains('item.memoryPhotoUrl ?? item.displayImageUrl'));
+  });
+}

--- a/tests/contracts/collector_memory_public_pulse_v1.test.mjs
+++ b/tests/contracts/collector_memory_public_pulse_v1.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const migrationPath =
+  "supabase/migrations/20260811170000_collector_memory_public_pulse_v1.sql";
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+test("collector Memories remain private until their owner explicitly publishes", () => {
+  const sql = read(migrationPath);
+
+  assert.match(sql, /add column if not exists is_public boolean not null default false/i);
+  assert.match(sql, /collector_memories_publication_state_check/i);
+  assert.match(sql, /is_public is false\s+and published_at is null\s+and publication_event_id is null/i);
+  assert.match(sql, /create or replace function public\.collector_memory_set_public_v1/i);
+  assert.match(sql, /v_user_id uuid := auth\.uid\(\)/i);
+  assert.match(sql, /and user_id = v_user_id\s+and archived_at is null\s+for update/i);
+  assert.match(sql, /interest_graph_collector_public_v1\(v_user_id\)/i);
+  assert.match(sql, /vault_item_instances[\s\S]*and card_print_id is not null/i);
+  assert.match(sql, /grant execute on function public\.collector_memory_set_public_v1\(uuid, boolean\)\s+to authenticated/i);
+  assert.doesNotMatch(sql, /grant execute on function public\.collector_memory_set_public_v1\(uuid, boolean\)\s+to anon/i);
+});
+
+test("Memory publication creates append-only current-version Pulse evidence", () => {
+  const sql = read(migrationPath);
+
+  assert.match(sql, /insert into public\.card_events/i);
+  assert.match(sql, /'collector_memory_published'/i);
+  assert.match(sql, /'publication_version', v_next_version/i);
+  assert.match(sql, /publication_event_id = v_event_id/i);
+  assert.match(sql, /cm\.publication_event_id = e\.id/i);
+  assert.match(sql, /e\.payload ->> 'publication_version'\) = cm\.publication_version::text/i);
+  assert.doesNotMatch(sql, /delete from public\.card_events/i);
+  assert.doesNotMatch(sql, /update public\.card_events/i);
+});
+
+test("unpublish and archive immediately invalidate current Pulse visibility", () => {
+  const sql = read(migrationPath);
+
+  assert.match(sql, /is_public = false,\s+published_at = null,\s+publication_event_id = null/i);
+  assert.match(sql, /collector_memory_archive_v1/i);
+  assert.match(sql, /archived_at = coalesce\(archived_at, now\(\)\)/i);
+  assert.match(sql, /cm\.is_public is true\s+and cm\.archived_at is null/i);
+  assert.match(sql, /vii\.archived_at is null/i);
+});
+
+test("published Memory photos stay private and require current governed evidence", () => {
+  const sql = read(migrationPath);
+
+  assert.match(sql, /create policy collector_memory_images_published_select_v1/i);
+  assert.match(sql, /bucket_id = 'collector-memory-images'/i);
+  assert.match(sql, /join public\.vault_item_instances vii/i);
+  assert.match(sql, /join public\.card_events e/i);
+  assert.match(sql, /cm\.photo_path = name/i);
+  assert.match(sql, /interest_graph_collectors_visible_to_viewer_v1\(\s*auth\.uid\(\),\s*cm\.user_id/i);
+  assert.doesNotMatch(sql, /on public\.collector_memories\s+for select\s+to anon/i);
+  assert.doesNotMatch(sql, /on public\.collector_memories\s+for select\s+to authenticated\s+using \(is_public/i);
+});
+
+test("Pulse publication remains watch-backed and rechecks privacy boundaries", () => {
+  const sql = read(migrationPath);
+
+  assert.match(sql, /rename to collector_memory_pulse_base_eligible_events_v1/i);
+  assert.match(sql, /from public\.collector_memory_pulse_base_eligible_events_v1/i);
+  assert.match(sql, /join lateral \([\s\S]*from public\.watches w/i);
+  assert.match(sql, /w\.muted_at is null/i);
+  assert.match(sql, /w\.subject_type = 'collector'/i);
+  assert.match(sql, /w\.subject_type = 'card'/i);
+  assert.match(sql, /w\.subject_type = 'set'/i);
+  assert.match(sql, /interest_graph_card_event_visible_to_viewer_v1/i);
+  assert.match(sql, /interest_graph_collector_public_v1\(e\.actor_user_id\)/i);
+  assert.match(sql, /muted_card_watch\.muted_at is not null/i);
+});
+
+test("Flutter exposes owner publication control without direct Memory table reads", () => {
+  const service = read("lib/services/vault/collector_memory_service.dart");
+  const detail = read(
+    "lib/screens/grookai_objects/collector_memory_detail_screen.dart",
+  );
+  const pulse = read("lib/services/network/pulse_service.dart");
+
+  assert.match(service, /collector_memory_set_public_v1/);
+  assert.doesNotMatch(service, /\.from\('collector_memories'\)/);
+  assert.match(detail, /memory-public-switch/);
+  assert.match(detail, /Share this Memory in Pulse\?/);
+  assert.match(pulse, /_memoryPhotoExpirySeconds = 300/);
+  assert.match(pulse, /_validMemoryPhotoPath/);
+  assert.match(pulse, /collector-memory-images/);
+});

--- a/tests/contracts/collector_memory_share_route_v1.test.mjs
+++ b/tests/contracts/collector_memory_share_route_v1.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const migration = fs.readFileSync(
+  "supabase/migrations/20260811213000_collector_memory_share_route_v1.sql",
+  "utf8",
+);
+const shareScreen = fs.readFileSync(
+  "lib/screens/grookai_objects/collector_memory_detail_screen.dart",
+  "utf8",
+);
+const webRoute = fs.readFileSync(
+  "apps/web/src/app/memory/[memory_id]/page.tsx",
+  "utf8",
+);
+
+test("Memory share route is authenticated and does not expose a direct table read", () => {
+  assert.match(migration, /collector_memory_accessible_by_id_v1\(\s*p_memory_id uuid/i);
+  assert.match(migration, /security definer/i);
+  assert.match(migration, /revoke all[\s\S]*from public, anon/i);
+  assert.match(migration, /grant execute[\s\S]*to authenticated/i);
+});
+
+test("owner access and public viewer access remain distinct", () => {
+  assert.match(migration, /cm\.user_id = auth\.uid\(\)/i);
+  assert.match(migration, /cm\.is_public is true/i);
+  assert.match(migration, /cm\.publication_event_id = publication_event\.id/i);
+  assert.match(migration, /interest_graph_collectors_visible_to_viewer_v1\(/i);
+  assert.match(migration, /viewer_is_owner/i);
+});
+
+test("public route requires exact current publication evidence", () => {
+  assert.match(migration, /publication_event\.event_type = 'collector_memory_published'/i);
+  assert.match(migration, /publication_event\.card_print_id = vii\.card_print_id/i);
+  assert.match(migration, /publication_event\.payload ->> 'memory_id'/i);
+  assert.match(migration, /publication_event\.payload ->> 'publication_version'/i);
+  assert.match(migration, /cm\.archived_at is null/i);
+});
+
+test("share identity is the Memory and web does not substitute the card", () => {
+  assert.match(shareScreen, /\/memory\/\$\{Uri\.encodeComponent\(item\.memory\.id\)\}/);
+  assert.doesNotMatch(shareScreen, /final path = gvId/);
+  assert.match(webRoute, /collector_memory_accessible_by_id_v1/);
+  assert.match(webRoute, /Memory unavailable|notFound\(\)/);
+  assert.match(webRoute, /requireServerUser\(currentPath\)/);
+});

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <app_links/app_links_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -19,6 +20,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  PrintingPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PrintingPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   file_selector_windows
   firebase_core
+  printing
   share_plus
   url_launcher_windows
 )


### PR DESCRIPTION
## Summary
- add printable and shareable Memory detail flows
- allow owners to publish or privatize Memories in Pulse
- route shared /memory/{id} links to Memory detail on web and mobile
- preserve owner/private and signed-in public-viewer access boundaries

## Verification
- flutter analyze
- 68 targeted Flutter tests
- 10 Memory database/web contract tests
- web typecheck and production build
- production migration 20260811213000 already applied and read back

## Deployment note
The local global pre-push hook could not run its database preflight because SUPABASE_DB_URL is not available in this clean worktree. The scoped verification above passed before publishing.