### PR TITLE
Finish MEE pricing publication surface proof

### DIFF
--- a/apps/web/src/app/card/[gv_id]/market/page.tsx
+++ b/apps/web/src/app/card/[gv_id]/market/page.tsx
@@ -242,6 +242,7 @@ export default async function MarketAnalysisPage(
                   <p
                     className="text-5xl font-semibold tracking-tight text-slate-950"
                     data-pricing-proof="tcgplayer-market"
+                    data-pricing-proof-role="primary"
                     data-pricing-status="available"
                     data-pricing-scope="card_printing"
                     data-card-print-id={model.selectedSlice?.cardPrintId}
@@ -320,6 +321,7 @@ export default async function MarketAnalysisPage(
                   <p
                     className="pt-2 text-lg font-medium text-slate-950"
                     data-pricing-proof="tcgplayer-market"
+                    data-pricing-proof-role="primary"
                     data-pricing-status="available"
                     data-pricing-scope="card_printing"
                     data-card-print-id={model.selectedSlice?.cardPrintId}

--- a/apps/web/src/components/compare/CompareWorkspace.tsx
+++ b/apps/web/src/components/compare/CompareWorkspace.tsx
@@ -105,6 +105,7 @@ function renderAttributeContent(
             sourceLabel={card.pricing_source_label}
             pricingScope={card.pricing_scope}
             isFromPrice={card.pricing_is_from_price}
+            proofRole="supplemental"
           />
         )
       : <LockedPrice href={pricingSignInHref} size="dense" />;

--- a/apps/web/src/components/pricing/CardPagePricingRail.tsx
+++ b/apps/web/src/components/pricing/CardPagePricingRail.tsx
@@ -61,6 +61,7 @@ function PricingEmptyState() {
     <div
       className="space-y-1.5"
       data-pricing-proof="tcgplayer-market"
+      data-pricing-proof-role="primary"
       data-pricing-status="unavailable"
     >
       <p className="text-base font-semibold text-slate-950 dark:text-slate-100">
@@ -94,6 +95,7 @@ function MarketPriceBlock({
     <div
       className="space-y-1"
       data-pricing-proof="tcgplayer-market"
+      data-pricing-proof-role="primary"
       data-pricing-status={pricing.status}
       data-pricing-scope={pricing.pricing_scope}
       data-card-print-id={pricing.card_print_id}

--- a/apps/web/src/components/pricing/VisiblePrice.tsx
+++ b/apps/web/src/components/pricing/VisiblePrice.tsx
@@ -15,6 +15,7 @@ type VisiblePriceProps = {
   provenanceId?: string;
   pricingScope?: "parent" | "card_printing";
   isFromPrice?: boolean;
+  proofRole?: "primary" | "supplemental";
 };
 
 function getClasses(size: VisiblePriceProps["size"]) {
@@ -65,6 +66,7 @@ export default function VisiblePrice({
   provenanceId,
   pricingScope = "parent",
   isFromPrice = false,
+  proofRole = "primary",
 }: VisiblePriceProps) {
   const classes = getClasses(size);
 
@@ -72,6 +74,7 @@ export default function VisiblePrice({
     <div
       className={`${classes.wrapper} ${className}`.trim()}
       data-pricing-proof="tcgplayer-market"
+      data-pricing-proof-role={proofRole}
       data-pricing-status={
         typeof value === "number" ? "available" : "unavailable"
       }

--- a/apps/web/src/components/vault/VaultInstancePricingCard.tsx
+++ b/apps/web/src/components/vault/VaultInstancePricingCard.tsx
@@ -170,6 +170,7 @@ export default function VaultInstancePricingCard({
               <p
                 className="text-xl font-semibold tracking-tight text-slate-950"
                 data-pricing-proof="tcgplayer-market"
+                data-pricing-proof-role="primary"
                 data-pricing-status="available"
                 data-pricing-scope="card_printing"
                 data-card-print-id={cardPrintId}

--- a/apps/web/src/components/vault/VaultInstanceVisiblePricingCard.tsx
+++ b/apps/web/src/components/vault/VaultInstanceVisiblePricingCard.tsx
@@ -76,6 +76,7 @@ export default function VaultInstanceVisiblePricingCard({
           <p
             className="text-xl font-semibold tracking-tight text-slate-950"
             data-pricing-proof="tcgplayer-market"
+            data-pricing-proof-role="primary"
             data-pricing-status="available"
             data-pricing-scope="card_printing"
             data-card-print-id={cardPrintId}

--- a/backend/pricing/tcgplayer_market_product_surface_registry_v1.mjs
+++ b/backend/pricing/tcgplayer_market_product_surface_registry_v1.mjs
@@ -15,7 +15,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
     auth_boundary_files: Object.freeze([
       "apps/web/src/app/card/[gv_id]/page.tsx",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_search",
@@ -36,7 +37,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
       "apps/web/src/app/explore/page.tsx",
       "apps/web/src/app/api/resolver/search/route.ts",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_explore",
@@ -54,7 +56,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
     auth_boundary_files: Object.freeze([
       "apps/web/src/app/explore/page.tsx",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_set_grid",
@@ -73,7 +76,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
       "apps/web/src/app/sets/[set_code]/page.tsx",
       "apps/web/src/app/api/public-set-cards/route.ts",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_compare",
@@ -92,7 +96,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
     auth_boundary_files: Object.freeze([
       "apps/web/src/app/compare/page.tsx",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_private_vault",
@@ -130,7 +135,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
     auth_boundary_files: Object.freeze([
       "apps/web/src/app/u/[slug]/page.tsx",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_vault_item",
@@ -148,7 +154,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
     auth_boundary_files: Object.freeze([
       "apps/web/src/app/vault/gvvi/[gvvi_id]/page.tsx",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "web_market_history",
@@ -167,7 +174,8 @@ export const TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1 = Object.freeze([
     auth_boundary_files: Object.freeze([
       "apps/web/src/app/card/[gv_id]/market/page.tsx",
     ]),
-    capture_selector: '[data-pricing-proof="tcgplayer-market"]',
+    capture_selector:
+      '[data-pricing-proof="tcgplayer-market"][data-pricing-proof-role="primary"]',
   }),
   Object.freeze({
     surface_id: "flutter_card_detail",

--- a/backend/pricing/tcgplayer_market_vault_production_readback_policy_v1.mjs
+++ b/backend/pricing/tcgplayer_market_vault_production_readback_policy_v1.mjs
@@ -15,6 +15,33 @@ function includesOption(options, expected) {
   return Array.isArray(options) && options.includes(expected);
 }
 
+function directViewAuthorityIsValid(schema) {
+  return (
+    includesOption(schema.relation_options, "security_invoker=false") &&
+    schema.definition_owner_scoped === true &&
+    schema.definition_excludes_archived === true &&
+    schema.definition_excludes_slabs === true
+  );
+}
+
+function functionAuthorityIsValid(schema, access) {
+  return (
+    includesOption(schema.relation_options, "security_invoker=true") &&
+    schema.definition_uses_backing_function === true &&
+    schema.backing_function_name ===
+      "vault_mobile_pricing_target_rows_for_current_user_v2" &&
+    schema.backing_function_security_definer === true &&
+    schema.backing_function_stable === true &&
+    schema.backing_function_fixed_search_path === true &&
+    schema.backing_function_owner_scoped === true &&
+    schema.backing_function_excludes_archived === true &&
+    schema.backing_function_excludes_slabs === true &&
+    access.backing_function_anonymous_execute_granted === false &&
+    access.backing_function_authenticated_execute_granted === true &&
+    access.backing_function_service_execute_granted === true
+  );
+}
+
 export function evaluateTcgplayerMarketVaultProductionReadbackV1(
   evidence = {},
 ) {
@@ -23,6 +50,13 @@ export function evaluateTcgplayerMarketVaultProductionReadbackV1(
   const access = evidence.access ?? {};
   const owner = evidence.owner_scope ?? {};
   const pricing = evidence.exact_pricing ?? {};
+  const directViewAuthority = directViewAuthorityIsValid(schema);
+  const functionAuthority = functionAuthorityIsValid(schema, access);
+  const authorityMode = functionAuthority
+    ? "security_invoker_function"
+    : directViewAuthority
+      ? "direct_security_definer_view"
+      : "invalid";
 
   if (schema.relation_name !== "v_vault_mobile_pricing_targets_v1") {
     findings.push("vault_pricing_target_view_missing");
@@ -33,20 +67,11 @@ export function evaluateTcgplayerMarketVaultProductionReadbackV1(
   if (!includesOption(schema.relation_options, "security_barrier=true")) {
     findings.push("vault_pricing_target_security_barrier_missing");
   }
-  if (!includesOption(schema.relation_options, "security_invoker=false")) {
-    findings.push("vault_pricing_target_security_invoker_not_false");
-  }
   if (schema.owner_table_rls_enabled !== true) {
     findings.push("vault_owner_table_rls_not_enabled");
   }
-  if (schema.definition_owner_scoped !== true) {
-    findings.push("vault_pricing_target_not_owner_scoped");
-  }
-  if (schema.definition_excludes_archived !== true) {
-    findings.push("vault_pricing_target_does_not_exclude_archived");
-  }
-  if (schema.definition_excludes_slabs !== true) {
-    findings.push("vault_pricing_target_does_not_exclude_slabs");
+  if (authorityMode === "invalid") {
+    findings.push("vault_pricing_target_authority_invalid");
   }
 
   if (access.anonymous_select_granted !== false) {
@@ -149,6 +174,7 @@ export function evaluateTcgplayerMarketVaultProductionReadbackV1(
     status: findings.length === 0 ? "passed" : "failed",
     findings: [...new Set(findings)].sort(),
     schema: {
+      authority_mode: authorityMode,
       relation_name: schema.relation_name ?? null,
       relation_kind: schema.relation_kind ?? null,
       relation_options: schema.relation_options ?? [],
@@ -157,6 +183,20 @@ export function evaluateTcgplayerMarketVaultProductionReadbackV1(
       definition_excludes_archived:
         schema.definition_excludes_archived === true,
       definition_excludes_slabs: schema.definition_excludes_slabs === true,
+      definition_uses_backing_function:
+        schema.definition_uses_backing_function === true,
+      backing_function_name: schema.backing_function_name ?? null,
+      backing_function_security_definer:
+        schema.backing_function_security_definer === true,
+      backing_function_stable: schema.backing_function_stable === true,
+      backing_function_fixed_search_path:
+        schema.backing_function_fixed_search_path === true,
+      backing_function_owner_scoped:
+        schema.backing_function_owner_scoped === true,
+      backing_function_excludes_archived:
+        schema.backing_function_excludes_archived === true,
+      backing_function_excludes_slabs:
+        schema.backing_function_excludes_slabs === true,
     },
     access: {
       anonymous_select_granted: access.anonymous_select_granted === true,
@@ -172,6 +212,12 @@ export function evaluateTcgplayerMarketVaultProductionReadbackV1(
       authenticated_without_uid_count: integer(
         access.authenticated_without_uid_count,
       ),
+      backing_function_anonymous_execute_granted:
+        access.backing_function_anonymous_execute_granted === true,
+      backing_function_authenticated_execute_granted:
+        access.backing_function_authenticated_execute_granted === true,
+      backing_function_service_execute_granted:
+        access.backing_function_service_execute_granted === true,
     },
     owner_scope: {
       sample_owner_available: owner.sample_owner_available === true,

--- a/scripts/audits/tcgplayer_market_vault_production_readback_v1.mjs
+++ b/scripts/audits/tcgplayer_market_vault_production_readback_v1.mjs
@@ -106,6 +106,14 @@ async function querySchemaEvidence(client) {
            when c.oid is null then null
            else pg_get_viewdef(c.oid, true)
          end as definition,
+         p.proname as backing_function_name,
+         p.prosecdef as backing_function_security_definer,
+         p.provolatile = 's' as backing_function_stable,
+         coalesce(p.proconfig, '{}'::text[]) as backing_function_config,
+         case
+           when p.oid is null then null
+           else pg_get_functiondef(p.oid)
+         end as backing_function_definition,
          owner_table.relrowsecurity as owner_table_rls_enabled,
          case
            when c.oid is null then null
@@ -140,14 +148,34 @@ async function querySchemaEvidence(client) {
              or has_table_privilege('service_role', c.oid, 'REFERENCES')
              or has_table_privilege('service_role', c.oid, 'TRIGGER')
            )
-         end as service_write_or_ddl_granted
+         end as service_write_or_ddl_granted,
+         case
+           when p.oid is null then null
+           else has_function_privilege('anon', p.oid, 'EXECUTE')
+         end as backing_function_anonymous_execute_granted,
+         case
+           when p.oid is null then null
+           else has_function_privilege('authenticated', p.oid, 'EXECUTE')
+         end as backing_function_authenticated_execute_granted,
+         case
+           when p.oid is null then null
+           else has_function_privilege('service_role', p.oid, 'EXECUTE')
+         end as backing_function_service_execute_granted
        from target
        left join pg_class c on c.oid = target.relation_oid
+       left join pg_proc p
+         on p.oid = to_regprocedure(
+           'public.vault_mobile_pricing_target_rows_for_current_user_v2()'
+         )
        left join pg_class owner_table
          on owner_table.oid = 'public.vault_item_instances'::regclass`,
     )
   ).rows[0] ?? {};
   const definition = String(row.definition ?? "").toLowerCase();
+  const backingFunctionDefinition = String(
+    row.backing_function_definition ?? "",
+  ).toLowerCase();
+  const backingFunctionConfig = row.backing_function_config ?? [];
   return {
     relation_name: row.relation_name ?? null,
     relation_kind: row.relation_kind ?? null,
@@ -160,6 +188,27 @@ async function querySchemaEvidence(client) {
       definition.includes("vii.archived_at is null"),
     definition_excludes_slabs:
       definition.includes("vii.slab_cert_id is null"),
+    definition_uses_backing_function: definition.includes(
+      "vault_mobile_pricing_target_rows_for_current_user_v2()",
+    ),
+    backing_function_name: row.backing_function_name ?? null,
+    backing_function_security_definer: bool(
+      row.backing_function_security_definer,
+    ),
+    backing_function_stable: bool(row.backing_function_stable),
+    backing_function_fixed_search_path: backingFunctionConfig.some(
+      (option) =>
+        String(option)
+          .toLowerCase()
+          .replaceAll(" ", "") === "search_path=pg_catalog,public",
+    ),
+    backing_function_owner_scoped:
+      backingFunctionDefinition.includes("auth.uid()") &&
+      backingFunctionDefinition.includes("vii.user_id = auth.uid()"),
+    backing_function_excludes_archived:
+      backingFunctionDefinition.includes("vii.archived_at is null"),
+    backing_function_excludes_slabs:
+      backingFunctionDefinition.includes("vii.slab_cert_id is null"),
     access: {
       anonymous_select_granted: bool(row.anonymous_select_granted),
       authenticated_select_granted: bool(
@@ -171,6 +220,15 @@ async function querySchemaEvidence(client) {
       service_select_granted: bool(row.service_select_granted),
       service_write_or_ddl_granted: bool(
         row.service_write_or_ddl_granted,
+      ),
+      backing_function_anonymous_execute_granted: bool(
+        row.backing_function_anonymous_execute_granted,
+      ),
+      backing_function_authenticated_execute_granted: bool(
+        row.backing_function_authenticated_execute_granted,
+      ),
+      backing_function_service_execute_granted: bool(
+        row.backing_function_service_execute_granted,
       ),
     },
   };
@@ -505,6 +563,7 @@ function markdown(report) {
     "## Schema And Access",
     "",
     `- View: \`${report.schema.relation_name}\``,
+    `- Authority mode: \`${report.schema.authority_mode}\``,
     `- Security options: \`${report.schema.relation_options.join(", ")}\``,
     `- Owner table RLS: \`${report.schema.owner_table_rls_enabled}\``,
     `- Authenticated SELECT: \`${report.access.authenticated_select_granted}\``,

--- a/tests/contracts/tcgplayer_market_product_surface_proof_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_product_surface_proof_v1.test.mjs
@@ -83,6 +83,12 @@ const COMPARE_WORKSPACE = readFileSync(
   ),
   "utf8",
 );
+const DIRECT_WEB_PRICE_EMITTERS = [
+  "apps/web/src/components/pricing/CardPagePricingRail.tsx",
+  "apps/web/src/components/vault/VaultInstancePricingCard.tsx",
+  "apps/web/src/components/vault/VaultInstanceVisiblePricingCard.tsx",
+  "apps/web/src/app/card/[gv_id]/market/page.tsx",
+].map((relativePath) => readFileSync(path.join(ROOT, relativePath), "utf8"));
 const FLUTTER_PRICE = readFileSync(
   path.join(ROOT, "lib", "widgets", "card_surface_price.dart"),
   "utf8",
@@ -652,6 +658,12 @@ test("web price capture distinguishes primary evidence from supplemental repeats
   assert.match(VISIBLE_PRICE, /data-pricing-proof-role=\{proofRole\}/);
   assert.match(VISIBLE_PRICE, /proofRole = "primary"/);
   assert.match(COMPARE_WORKSPACE, /proofRole="supplemental"/);
+  for (const emitter of DIRECT_WEB_PRICE_EMITTERS) {
+    const proofCount = emitter.match(/data-pricing-proof="tcgplayer-market"/g)?.length ?? 0;
+    const primaryCount = emitter.match(/data-pricing-proof-role="primary"/g)?.length ?? 0;
+    assert.ok(proofCount > 0);
+    assert.equal(primaryCount, proofCount);
+  }
 });
 
 test("newly wired web surfaces require auth before fetching governed pricing", () => {

--- a/tests/contracts/tcgplayer_market_product_surface_proof_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_product_surface_proof_v1.test.mjs
@@ -71,6 +71,18 @@ const VISIBLE_PRICE = readFileSync(
   ),
   "utf8",
 );
+const COMPARE_WORKSPACE = readFileSync(
+  path.join(
+    ROOT,
+    "apps",
+    "web",
+    "src",
+    "components",
+    "compare",
+    "CompareWorkspace.tsx",
+  ),
+  "utf8",
+);
 const FLUTTER_PRICE = readFileSync(
   path.join(ROOT, "lib", "widgets", "card_surface_price.dart"),
   "utf8",
@@ -626,6 +638,20 @@ test("the executable registry binds all 17 surfaces to existing owners and proof
   assert.deepEqual(vaultItem?.auth_boundary_files, [
     "apps/web/src/app/vault/gvvi/[gvvi_id]/page.tsx",
   ]);
+});
+
+test("web price capture distinguishes primary evidence from supplemental repeats", () => {
+  const webPriceSurfaces = TCGPLAYER_MARKET_PRODUCT_SURFACE_REGISTRY_V1.filter(
+    (surface) =>
+      surface.client === "web" && surface.proof_kind === "price_record",
+  );
+  assert.ok(webPriceSurfaces.length > 0);
+  for (const surface of webPriceSurfaces) {
+    assert.match(surface.capture_selector, /data-pricing-proof-role="primary"/);
+  }
+  assert.match(VISIBLE_PRICE, /data-pricing-proof-role=\{proofRole\}/);
+  assert.match(VISIBLE_PRICE, /proofRole = "primary"/);
+  assert.match(COMPARE_WORKSPACE, /proofRole="supplemental"/);
 });
 
 test("newly wired web surfaces require auth before fetching governed pricing", () => {

--- a/tests/contracts/tcgplayer_market_vault_production_readback_v1.test.mjs
+++ b/tests/contracts/tcgplayer_market_vault_production_readback_v1.test.mjs
@@ -27,12 +27,21 @@ function evidence() {
       relation_kind: "v",
       relation_options: [
         "security_barrier=true",
-        "security_invoker=false",
+        "security_invoker=true",
       ],
       owner_table_rls_enabled: true,
-      definition_owner_scoped: true,
-      definition_excludes_archived: true,
-      definition_excludes_slabs: true,
+      definition_owner_scoped: false,
+      definition_excludes_archived: false,
+      definition_excludes_slabs: false,
+      definition_uses_backing_function: true,
+      backing_function_name:
+        "vault_mobile_pricing_target_rows_for_current_user_v2",
+      backing_function_security_definer: true,
+      backing_function_stable: true,
+      backing_function_fixed_search_path: true,
+      backing_function_owner_scoped: true,
+      backing_function_excludes_archived: true,
+      backing_function_excludes_slabs: true,
     },
     access: {
       anonymous_select_granted: false,
@@ -43,6 +52,9 @@ function evidence() {
       anonymous_runtime_denied: true,
       anonymous_runtime_code: "42501",
       authenticated_without_uid_count: 0,
+      backing_function_anonymous_execute_granted: false,
+      backing_function_authenticated_execute_granted: true,
+      backing_function_service_execute_granted: true,
     },
     owner_scope: {
       sample_owner_available: true,
@@ -81,9 +93,52 @@ test("clean production readback passes exact-copy pricing and access proof", () 
   );
   assert.equal(result.status, "passed");
   assert.deepEqual(result.findings, []);
+  assert.equal(
+    result.schema.authority_mode,
+    "security_invoker_function",
+  );
   assert.equal(result.owner_scope.authenticated_target_count, 3);
   assert.equal(result.exact_pricing.priced_copy_count, 2);
   assert.equal(result.exact_pricing.reconciled_total_usd, 24.68);
+});
+
+test("legacy direct owner-scoped authority remains valid", () => {
+  const input = evidence();
+  input.schema.relation_options = [
+    "security_barrier=true",
+    "security_invoker=false",
+  ];
+  input.schema.definition_owner_scoped = true;
+  input.schema.definition_excludes_archived = true;
+  input.schema.definition_excludes_slabs = true;
+  input.schema.definition_uses_backing_function = false;
+  input.schema.backing_function_name = null;
+  input.schema.backing_function_security_definer = false;
+  input.schema.backing_function_stable = false;
+  input.schema.backing_function_fixed_search_path = false;
+  input.schema.backing_function_owner_scoped = false;
+  input.schema.backing_function_excludes_archived = false;
+  input.schema.backing_function_excludes_slabs = false;
+  input.access.backing_function_authenticated_execute_granted = false;
+  input.access.backing_function_service_execute_granted = false;
+  const result =
+    evaluateTcgplayerMarketVaultProductionReadbackV1(input);
+  assert.equal(result.status, "passed");
+  assert.equal(
+    result.schema.authority_mode,
+    "direct_security_definer_view",
+  );
+});
+
+test("hardened authority fails closed when backing function grants widen", () => {
+  const input = evidence();
+  input.access.backing_function_anonymous_execute_granted = true;
+  const result =
+    evaluateTcgplayerMarketVaultProductionReadbackV1(input);
+  assert.equal(result.status, "failed");
+  assert.ok(
+    result.findings.includes("vault_pricing_target_authority_invalid"),
+  );
 });
 
 test("missing schema and widened grants fail closed", () => {


### PR DESCRIPTION
## Summary
- align the Vault production verifier with the hardened security-invoker/backing-function authority already deployed
- distinguish primary rendered market-price proof from supplemental Compare repetitions
- keep all 17 pricing surface captures bound to one governed read model

## Production evidence
- live 99-row canary healthy with 0 stale prices and 0 broken provenance traces
- authenticated governed RPC reads 99/99; anonymous remains denied with SQLSTATE 42501
- schema, grants, RLS, and backing-function authority verified read-only
- exact-Vault positive sample remains unavailable during the canary because no active canary printing overlaps an eligible raw Vault copy

## Verification
- 168/168 pricing contracts pass
- web typecheck, lint, and production build pass
- targeted Flutter pricing tests pass
- targeted Flutter analysis passes
- git diff check passes

The full eligible activation remains fail-closed until the active 72-hour canary reaches its required end on 2026-08-16T09:56:42.279Z.